### PR TITLE
61.7: Add AegisOps record search/filter MVP

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.recordSearch.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.recordSearch.testSuite.tsx
@@ -138,5 +138,32 @@ export function registerOperatorRoutesRecordSearchTests() {
       });
       expect(screen.queryByRole("link", { name: "case:case-001" })).toBeNull();
     });
+
+    it("applies the 25-result client pagination cap", async () => {
+      const records = Array.from({ length: 30 }, (_, index) => {
+        const recordId = `case-${String(index).padStart(3, "0")}`;
+        return {
+          ...recordSearchResults[0],
+          id: `case:${recordId}`,
+          record_id: recordId,
+          route: `/operator/cases/${recordId}`,
+        };
+      });
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-record-search": {
+            records,
+            total_records: records.length,
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/search", dependencies);
+
+      expect(
+        await screen.findByRole("link", { name: "case:case-024" }),
+      ).toHaveAttribute("href", "/operator/cases/case-024");
+      expect(screen.queryByRole("link", { name: "case:case-025" })).toBeNull();
+    });
   });
 }

--- a/apps/operator-ui/src/app/OperatorRoutes.recordSearch.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.recordSearch.testSuite.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createDefaultDependencies } from "./OperatorRoutes";
+import {
+  createAuthorizedFetch,
+  renderOperatorRoute,
+} from "./OperatorRoutes.testSupport";
+
+const recordSearchResults = [
+  {
+    id: "case:case-001",
+    record_family: "case",
+    record_id: "case-001",
+    source_family: "github_audit",
+    lifecycle_state: "open",
+    route: "/operator/cases/case-001",
+    route_kind: "reviewed_surface",
+    authority: "navigation_only",
+    raw_source_authority: false,
+    matched_query: "github",
+    summary: "Reviewed GitHub audit case.",
+  },
+  {
+    id: "source_health:source-health-github-audit-001",
+    record_family: "source_health",
+    record_id: "source-health-github-audit-001",
+    source_family: "github_audit",
+    lifecycle_state: "reviewed",
+    route: "/operator/source-health",
+    route_kind: "reviewed_surface",
+    authority: "navigation_only",
+    raw_source_authority: false,
+    matched_query: "github",
+    summary: "Reviewed GitHub audit source is available.",
+  },
+] as const;
+
+export function registerOperatorRoutesRecordSearchTests() {
+  describe("record search route", () => {
+    it("searches reviewed records and routes only to reviewed surfaces", async () => {
+      const fetchFn = createAuthorizedFetch({
+        "/inspect-record-search": {
+          records: recordSearchResults,
+          total_records: recordSearchResults.length,
+        },
+      });
+      const dependencies = createDefaultDependencies({ fetchFn });
+
+      renderOperatorRoute("/operator/search", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Record Search" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(await screen.findByRole("link", { name: "case:case-001" })).toHaveAttribute(
+        "href",
+        "/operator/cases/case-001",
+      );
+      expect(screen.getAllByText("navigation_only").length).toBeGreaterThan(0);
+      expect(screen.queryByRole("button", { name: /close case/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /reconcile/i })).toBeNull();
+
+      const searchCall = fetchFn.mock.calls.find(([url]) =>
+        String(url).startsWith("/inspect-record-search"),
+      );
+      expect(searchCall).toBeDefined();
+      const parsedUrl = new URL(String(searchCall![0]), "http://operator-ui.local");
+      expect(parsedUrl.searchParams.get("q")).toBe("github");
+
+      fireEvent.change(screen.getByLabelText("Search reviewed records"), {
+        target: { value: "source-health" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+      await waitFor(() => {
+        const latestSearchCall = fetchFn.mock.calls
+          .map(([url]) => String(url))
+          .filter((url) => url.startsWith("/inspect-record-search"))
+          .at(-1);
+        expect(latestSearchCall).toContain("q=source-health");
+      });
+    });
+
+    it("fails closed for stale-cache or authority-leaking search results", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-record-search": {
+            records: [
+              {
+                ...recordSearchResults[0],
+                authority: "workflow_truth",
+                raw_source_authority: true,
+              },
+            ],
+            total_records: 1,
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/search", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Reviewed operator data could not be verified. The browser stayed fail-closed instead of rendering an untrusted record.",
+          ),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText("workflow_truth")).not.toBeInTheDocument();
+    });
+  });
+}

--- a/apps/operator-ui/src/app/OperatorRoutes.recordSearch.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.recordSearch.testSuite.tsx
@@ -110,5 +110,33 @@ export function registerOperatorRoutesRecordSearchTests() {
       });
       expect(screen.queryByText("workflow_truth")).not.toBeInTheDocument();
     });
+
+    it("fails closed for non-reviewed search result routes", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-record-search": {
+            records: [
+              {
+                ...recordSearchResults[0],
+                route: "https://source.example.invalid/raw/case-001",
+                route_kind: "reviewed_surface",
+              },
+            ],
+            total_records: 1,
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/search", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Reviewed operator data could not be verified. The browser stayed fail-closed instead of rendering an untrusted record.",
+          ),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByRole("link", { name: "case:case-001" })).toBeNull();
+    });
   });
 }

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -8,6 +8,7 @@ import { registerOperatorRoutesCaseworkTests } from "./OperatorRoutes.casework.t
 import { registerOperatorRoutesControlPlaneTests } from "./OperatorRoutes.controlPlane.testSuite";
 import { registerOperatorRoutesDetectorActivationReviewTests } from "./OperatorRoutes.detectorActivationReview.testSuite";
 import { registerOperatorRoutesFirstLoginChecklistTests } from "./OperatorRoutes.firstLoginChecklist.testSuite";
+import { registerOperatorRoutesRecordSearchTests } from "./OperatorRoutes.recordSearch.testSuite";
 import { registerOperatorRoutesSourceHealthDashboardTests } from "./OperatorRoutes.sourceHealthDashboard.testSuite";
 import { registerOperatorRoutesTodayTests } from "./OperatorRoutes.today.testSuite";
 
@@ -22,6 +23,7 @@ describe("OperatorRoutes", () => {
   registerOperatorRoutesAssistantTests();
   registerOperatorRoutesControlPlaneTests();
   registerOperatorRoutesDetectorActivationReviewTests();
+  registerOperatorRoutesRecordSearchTests();
   registerOperatorRoutesSourceHealthDashboardTests();
   registerOperatorRoutesFirstLoginChecklistTests();
   registerOperatorRoutesTodayTests();

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -19,6 +19,7 @@ import HandshakeOutlinedIcon from "@mui/icons-material/HandshakeOutlined";
 import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
 import PlaylistAddCheckOutlinedIcon from "@mui/icons-material/PlaylistAddCheckOutlined";
 import RuleFolderOutlinedIcon from "@mui/icons-material/RuleFolderOutlined";
+import SearchOutlinedIcon from "@mui/icons-material/SearchOutlined";
 import SecurityOutlinedIcon from "@mui/icons-material/SecurityOutlined";
 import SensorsOutlinedIcon from "@mui/icons-material/SensorsOutlined";
 import TodayOutlinedIcon from "@mui/icons-material/TodayOutlined";
@@ -97,6 +98,8 @@ const ProvenancePage =
   lazyOperatorConsolePage("ProvenancePage") as unknown as typeof import("./operatorConsolePages").ProvenancePage;
 const ProvenanceIndexPage =
   lazyOperatorConsolePage("ProvenanceIndexPage") as unknown as typeof import("./operatorConsolePages").ProvenanceIndexPage;
+const RecordSearchPage =
+  lazyOperatorConsolePage("RecordSearchPage") as unknown as typeof import("./operatorConsolePages").RecordSearchPage;
 const QueuePage =
   lazyOperatorConsolePage("QueuePage") as unknown as typeof import("./operatorConsolePages").QueuePage;
 const ReadinessPage =
@@ -197,6 +200,11 @@ function OperatorMenu({
         leftIcon={<InsightsOutlinedIcon />}
         primaryText="Cases"
         to={buildOperatorShellPath(basePath, "cases")}
+      />
+      <Menu.Item
+        leftIcon={<SearchOutlinedIcon />}
+        primaryText="Search"
+        to={buildOperatorShellPath(basePath, "search")}
       />
       {showActionReview ? (
         <Menu.Item
@@ -552,6 +560,7 @@ function OperatorShellContent({
             path="alerts/:alertId"
           />
           <Route element={<CaseIndexPage />} path="cases" />
+          <Route element={<RecordSearchPage />} path="search" />
           <Route
             element={<CaseDetailPage operatorIdentity={operatorIdentity} />}
             path="cases/:caseId"

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -10,6 +10,7 @@ export {
   CaseIndexPage,
   ProvenanceIndexPage,
 } from "./operatorConsolePages/drilldownIndexPages";
+export { RecordSearchPage } from "./operatorConsolePages/recordSearchPages";
 export { DetectorActivationReviewPage } from "./operatorConsolePages/detectorActivationReviewPages";
 export { SourceHealthDashboardPage } from "./operatorConsolePages/sourceHealthDashboardPages";
 export { ActionReviewPage } from "./operatorConsolePages/actionReviewPages";

--- a/apps/operator-ui/src/app/operatorConsolePages/recordSearchPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/recordSearchPages.tsx
@@ -1,0 +1,172 @@
+import SearchIcon from "@mui/icons-material/Search";
+import {
+  Alert,
+  Button,
+  MenuItem,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+} from "@mui/material";
+import { FormEvent, useMemo, useState } from "react";
+import {
+  asString,
+  AuditedRouteLink,
+  EmptyState,
+  ErrorState,
+  formatValue,
+  LoadingState,
+  PageFrame,
+  QueryStateNotice,
+  type UnknownRecord,
+  useOperatorList,
+} from "./shared";
+
+const RECORD_SEARCH_SORT = {
+  field: "record_family",
+  order: "ASC",
+} as const;
+
+const SOURCE_FAMILY_OPTIONS = [
+  ["", "All reviewed sources"],
+  ["wazuh_detection", "Wazuh detection"],
+  ["github_audit", "GitHub audit"],
+  ["microsoft_365_audit", "Microsoft 365 audit"],
+  ["entra_id", "Entra ID"],
+  ["windows_security_endpoint", "Windows endpoint"],
+] as const;
+
+function RecordSearchTable({ records }: { records: UnknownRecord[] }) {
+  if (records.length === 0) {
+    return <EmptyState message="No reviewed AegisOps records matched the current search." />;
+  }
+
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>Record</TableCell>
+          <TableCell>Source</TableCell>
+          <TableCell>Lifecycle</TableCell>
+          <TableCell>Authority</TableCell>
+          <TableCell>Summary</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {records.map((record) => {
+          const recordFamily = asString(record.record_family);
+          const recordId = asString(record.record_id);
+          const route = asString(record.route);
+          const label = `${recordFamily ?? "record"}:${recordId ?? String(record.id)}`;
+
+          return (
+            <TableRow key={String(record.id)} hover>
+              <TableCell>
+                {route ? (
+                  <AuditedRouteLink label="Open reviewed record" to={route}>
+                    {label}
+                  </AuditedRouteLink>
+                ) : (
+                  label
+                )}
+              </TableCell>
+              <TableCell>{formatValue(record.source_family)}</TableCell>
+              <TableCell>{formatValue(record.lifecycle_state)}</TableCell>
+              <TableCell>{formatValue(record.authority)}</TableCell>
+              <TableCell>{formatValue(record.summary)}</TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+export function RecordSearchPage() {
+  const [draftQuery, setDraftQuery] = useState("github");
+  const [draftSourceFamily, setDraftSourceFamily] = useState("");
+  const [criteria, setCriteria] = useState({
+    q: "github",
+    source_family: "",
+  });
+  const filter = useMemo(
+    () => ({
+      q: criteria.q,
+      source_family: criteria.source_family,
+    }),
+    [criteria],
+  );
+  const results = useOperatorList(
+    "recordSearch",
+    filter,
+    RECORD_SEARCH_SORT,
+    25,
+  );
+
+  function submitSearch(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setCriteria({
+      q: draftQuery,
+      source_family: draftSourceFamily,
+    });
+  }
+
+  if (results.loading && results.data === null) {
+    return <LoadingState label="Loading reviewed record search" />;
+  }
+
+  return (
+    <PageFrame
+      subtitle="Search is a read-only navigation aid over reviewed AegisOps records. Results cannot close cases, approve detectors, suppress signals, reconcile outcomes, or promote raw source data into workflow truth."
+      title="Record Search"
+    >
+      {results.error && results.data === null ? (
+        <ErrorState error={results.error} />
+      ) : (
+        <Stack spacing={2}>
+          <Stack
+            component="form"
+            direction={{ xs: "column", md: "row" }}
+            onSubmit={submitSearch}
+            spacing={2}
+          >
+            <TextField
+              label="Search reviewed records"
+              onChange={(event) => setDraftQuery(event.target.value)}
+              size="small"
+              value={draftQuery}
+            />
+            <TextField
+              label="Source family"
+              onChange={(event) => setDraftSourceFamily(event.target.value)}
+              select
+              size="small"
+              value={draftSourceFamily}
+              sx={{ minWidth: 220 }}
+            >
+              {SOURCE_FAMILY_OPTIONS.map(([value, label]) => (
+                <MenuItem key={value || "all"} value={value}>
+                  {label}
+                </MenuItem>
+              ))}
+            </TextField>
+            <Button startIcon={<SearchIcon />} type="submit" variant="contained">
+              Search
+            </Button>
+          </Stack>
+          <QueryStateNotice
+            error={results.error}
+            refreshing={results.refreshing}
+          />
+          <Alert severity="info" variant="outlined">
+            Results route back to reviewed record surfaces and stay subordinate to backend lifecycle records.
+          </Alert>
+          <RecordSearchTable records={results.data ?? []} />
+        </Stack>
+      )}
+    </PageFrame>
+  );
+}

--- a/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
+++ b/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
@@ -341,6 +341,20 @@ function applyClientSideListSemantics(
   };
 }
 
+function clientSideListSemanticsParams(
+  resource: StandardOperatorResourceName,
+  params: GetListParams,
+): GetListParams {
+  if (resource !== "recordSearch" || params.filter === undefined) {
+    return params;
+  }
+  const { q: _backendSearchQuery, ...filter } = params.filter;
+  return {
+    ...params,
+    filter,
+  };
+}
+
 function buildListUrl(
   resource: StandardOperatorResourceName,
   params: GetListParams,
@@ -593,7 +607,10 @@ export async function getListForStandardResource({
   }
 
   if (binding.listSemantics === "client") {
-    return applyClientSideListSemantics(records, params);
+    return applyClientSideListSemantics(
+      records,
+      clientSideListSemanticsParams(resource, params),
+    );
   }
 
   return {

--- a/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
+++ b/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
@@ -58,6 +58,16 @@ const SOURCE_HEALTH_REVIEWED_STATES = new Set([
   "withdrawn",
 ]);
 
+const RECORD_SEARCH_FAMILIES = new Set([
+  "alert",
+  "case",
+  "evidence",
+  "detector_lifecycle",
+  "false_positive_review",
+  "suppression_proposal",
+  "source_health",
+]);
+
 const REVIEWED_SOURCE_CATALOG_ENTRIES_BY_FAMILY = new Map<string, Set<string>>([
   [
     "wazuh_detection",
@@ -476,6 +486,35 @@ function validateSourceHealthDashboardRecord(record: Record<string, unknown>) {
   }
 }
 
+function validateRecordSearchResult(record: Record<string, unknown>) {
+  const recordFamily = asString(record.record_family);
+  if (recordFamily === null || !RECORD_SEARCH_FAMILIES.has(recordFamily)) {
+    throw new OperatorDataProviderContractError(
+      "Resource recordSearch result has unsupported record_family.",
+    );
+  }
+  if (asString(record.record_id) === null) {
+    throw new OperatorDataProviderContractError(
+      "Resource recordSearch result is missing reviewed record_id.",
+    );
+  }
+  if (asString(record.route) === null || asString(record.route_kind) !== "reviewed_surface") {
+    throw new OperatorDataProviderContractError(
+      "Resource recordSearch result must route to a reviewed surface.",
+    );
+  }
+  if (record.authority !== "navigation_only" || record.raw_source_authority !== false) {
+    throw new OperatorDataProviderContractError(
+      "Resource recordSearch rejects search results as workflow truth.",
+    );
+  }
+  if (record.stale_cache === true || record.cache_sourced === true) {
+    throw new OperatorDataProviderContractError(
+      "Resource recordSearch rejects stale-cache results.",
+    );
+  }
+}
+
 export async function getListForStandardResource({
   binding,
   fetchFn,
@@ -509,6 +548,9 @@ export async function getListForStandardResource({
     }
     if (resource === "sourceHealthDashboard") {
       records.forEach(validateSourceHealthDashboardRecord);
+    }
+    if (resource === "recordSearch") {
+      records.forEach(validateRecordSearchResult);
     }
     totalRecords =
       typeof response.total_records === "number"

--- a/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
+++ b/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
@@ -67,6 +67,29 @@ const RECORD_SEARCH_FAMILIES = new Set([
   "suppression_proposal",
   "source_health",
 ]);
+const RECORD_SEARCH_REVIEWED_ROUTE_PATTERNS_BY_FAMILY = new Map<string, RegExp[]>([
+  ["alert", [/^\/operator\/alerts\/[^/?#]+$/]],
+  ["case", [/^\/operator\/cases\/[^/?#]+$/]],
+  ["evidence", [/^\/operator\/alerts\/[^/?#]+$/, /^\/operator\/cases\/[^/?#]+$/]],
+  ["detector_lifecycle", [/^\/operator\/detectors$/]],
+  [
+    "false_positive_review",
+    [
+      /^\/operator\/alerts\/[^/?#]+$/,
+      /^\/operator\/cases\/[^/?#]+$/,
+      /^\/operator\/detectors$/,
+    ],
+  ],
+  [
+    "suppression_proposal",
+    [
+      /^\/operator\/alerts\/[^/?#]+$/,
+      /^\/operator\/cases\/[^/?#]+$/,
+      /^\/operator\/detectors$/,
+    ],
+  ],
+  ["source_health", [/^\/operator\/source-health$/]],
+]);
 
 const REVIEWED_SOURCE_CATALOG_ENTRIES_BY_FAMILY = new Map<string, Set<string>>([
   [
@@ -498,7 +521,12 @@ function validateRecordSearchResult(record: Record<string, unknown>) {
       "Resource recordSearch result is missing reviewed record_id.",
     );
   }
-  if (asString(record.route) === null || asString(record.route_kind) !== "reviewed_surface") {
+  const route = asString(record.route);
+  if (
+    route === null ||
+    asString(record.route_kind) !== "reviewed_surface" ||
+    !isReviewedRecordSearchRoute(recordFamily, route)
+  ) {
     throw new OperatorDataProviderContractError(
       "Resource recordSearch result must route to a reviewed surface.",
     );
@@ -513,6 +541,12 @@ function validateRecordSearchResult(record: Record<string, unknown>) {
       "Resource recordSearch rejects stale-cache results.",
     );
   }
+}
+
+function isReviewedRecordSearchRoute(recordFamily: string, route: string): boolean {
+  const allowedPatterns =
+    RECORD_SEARCH_REVIEWED_ROUTE_PATTERNS_BY_FAMILY.get(recordFamily);
+  return allowedPatterns?.some((pattern) => pattern.test(route)) ?? false;
 }
 
 export async function getListForStandardResource({

--- a/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
+++ b/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
@@ -35,6 +35,10 @@ export const RESOURCE_BINDINGS: Record<
     listSemantics: "client",
     recordFamily: "detector_lifecycle",
   },
+  recordSearch: {
+    idField: "id",
+    listPath: "/inspect-record-search",
+  },
   sourceHealthDashboard: {
     idField: "source_health_id",
     listPath: "/inspect-records",

--- a/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
+++ b/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
@@ -38,6 +38,7 @@ export const RESOURCE_BINDINGS: Record<
   recordSearch: {
     idField: "id",
     listPath: "/inspect-record-search",
+    listSemantics: "client",
   },
   sourceHealthDashboard: {
     idField: "source_health_id",

--- a/apps/operator-ui/src/operatorDataProvider/types.ts
+++ b/apps/operator-ui/src/operatorDataProvider/types.ts
@@ -7,6 +7,7 @@ export type OperatorResourceName =
   | "cases"
   | "firstLoginChecklist"
   | "detectorActivationReview"
+  | "recordSearch"
   | "sourceHealthDashboard"
   | "runtimeReadiness"
   | "reconciliations"

--- a/control-plane/aegisops/control_plane/api/http_protected_surface.py
+++ b/control-plane/aegisops/control_plane/api/http_protected_surface.py
@@ -18,6 +18,7 @@ PROTECTED_READ_ROLES_BY_PATH: dict[str, tuple[str, ...]] = {
     "/diagnostics/readiness": READ_ONLY_PROTECTED_ROLES,
     "/admin/bootstrap-status": PLATFORM_ADMIN_ROLES,
     "/inspect-records": READ_ONLY_PROTECTED_ROLES,
+    "/inspect-record-search": READ_ONLY_PROTECTED_ROLES,
     "/inspect-reconciliation-status": READ_ONLY_PROTECTED_ROLES,
     "/inspect-analyst-queue": READ_ONLY_PROTECTED_ROLES,
     "/inspect-ai-trace-review-queue": READ_ONLY_PROTECTED_ROLES,

--- a/control-plane/aegisops/control_plane/api/http_surface.py
+++ b/control-plane/aegisops/control_plane/api/http_surface.py
@@ -173,6 +173,42 @@ def _handle_inspect_records(
     _write_json(handler, HTTPStatus.OK, payload)
 
 
+def _handle_inspect_record_search(
+    handler: BaseHTTPRequestHandler,
+    context: HttpSurfaceContext,
+    principal: object,
+) -> None:
+    query = _query_value(handler, "q")
+    raw_family = _query_value(handler, "family")
+    record_families = (
+        tuple(
+            family.strip()
+            for family in raw_family.split(",")
+            if family.strip()
+        )
+        if raw_family
+        else None
+    )
+    try:
+        payload = context.service.inspect_record_search(
+            query=query,
+            record_families=record_families,
+            source_family=_query_value(handler, "source_family"),
+            lifecycle_state=_query_value(handler, "lifecycle_state"),
+        ).to_dict()
+    except ValueError as exc:
+        _write_json(
+            handler,
+            HTTPStatus.BAD_REQUEST,
+            {
+                "error": "invalid_request",
+                "message": str(exc),
+            },
+        )
+        return
+    _write_json(handler, HTTPStatus.OK, payload)
+
+
 def _handle_inspect_reconciliation_status(
     handler: BaseHTTPRequestHandler,
     context: HttpSurfaceContext,
@@ -422,6 +458,7 @@ HTTP_GET_ROUTES: dict[str, GetRouteHandler] = {
     "/diagnostics/readiness": _handle_runtime_read,
     "/admin/bootstrap-status": _handle_runtime_read,
     "/inspect-records": _handle_inspect_records,
+    "/inspect-record-search": _handle_inspect_record_search,
     "/inspect-reconciliation-status": _handle_inspect_reconciliation_status,
     "/inspect-analyst-queue": _handle_inspect_analyst_queue,
     "/inspect-ai-trace-review-queue": _handle_inspect_ai_trace_review_queue,

--- a/control-plane/aegisops/control_plane/inspection/__init__.py
+++ b/control-plane/aegisops/control_plane/inspection/__init__.py
@@ -1,0 +1,1 @@
+"""Read-only operator inspection services."""

--- a/control-plane/aegisops/control_plane/inspection/record_search.py
+++ b/control-plane/aegisops/control_plane/inspection/record_search.py
@@ -92,11 +92,11 @@ class RecordSearchInspectionService:
     ) -> RecordInspectionSnapshot:
         search_query = self._normalize_record_search_query(query)
         selected_families = self._normalize_record_search_families(record_families)
-        normalized_source_family = self._service._normalize_optional_string(
+        normalized_source_family = self._normalize_record_search_filter(
             source_family,
             "source_family",
         )
-        normalized_lifecycle_state = self._service._normalize_optional_string(
+        normalized_lifecycle_state = self._normalize_record_search_filter(
             lifecycle_state,
             "lifecycle_state",
         )
@@ -205,6 +205,9 @@ class RecordSearchInspectionService:
             return None
 
         record_id = record.record_id
+        route = self._record_search_route(record)
+        if route is None:
+            return None
         return {
             "record_family": family,
             "record_id": record_id,
@@ -212,7 +215,7 @@ class RecordSearchInspectionService:
             "source_family": record_source_family,
             "lifecycle_state": record_lifecycle_state,
             "matched_query": query,
-            "route": self._record_search_route(family, record_id),
+            "route": route,
             "route_kind": "reviewed_surface",
             "authority": "navigation_only",
             "raw_source_authority": False,
@@ -233,11 +236,17 @@ class RecordSearchInspectionService:
         if isinstance(record, EvidenceRecord):
             if record.case_id is not None:
                 case = self._service._store.get(CaseRecord, record.case_id)
-                if isinstance(case, CaseRecord) and self._service._case_is_in_reviewed_operator_slice(case):
+                if (
+                    isinstance(case, CaseRecord)
+                    and self._service._case_is_in_reviewed_operator_slice(case)
+                ):
                     return self._service._reviewed_operator_source_family(case.reviewed_context)
             if record.alert_id is not None:
                 alert = self._service._store.get(AlertRecord, record.alert_id)
-                if isinstance(alert, AlertRecord) and self._service._alert_is_in_reviewed_operator_slice(alert):
+                if (
+                    isinstance(alert, AlertRecord)
+                    and self._service._alert_is_in_reviewed_operator_slice(alert)
+                ):
                     return self._service._reviewed_operator_source_family(alert.reviewed_context)
             return None
 
@@ -250,7 +259,7 @@ class RecordSearchInspectionService:
                 SourceHealthRecord,
             ),
         ):
-            return record.source_family
+            return record.source_family.strip()
 
         return None
 
@@ -262,19 +271,61 @@ class RecordSearchInspectionService:
         haystack = json.dumps(_json_ready(payload), sort_keys=True).lower()
         return query.lower() in haystack
 
-    @staticmethod
-    def _record_search_route(record_family: str, record_id: str) -> str:
-        if record_family == "alert":
-            return f"/operator/alerts/{record_id}"
-        if record_family == "case":
-            return f"/operator/cases/{record_id}"
-        if record_family == "evidence":
-            return f"/operator/provenance/evidence/{record_id}"
-        if record_family == "detector_lifecycle":
+    def _record_search_route(self, record: ControlPlaneRecord) -> str | None:
+        if isinstance(record, AlertRecord):
+            return f"/operator/alerts/{record.record_id}"
+        if isinstance(record, CaseRecord):
+            return f"/operator/cases/{record.record_id}"
+        if isinstance(record, EvidenceRecord):
+            return self._reviewed_anchor_route(
+                case_id=record.case_id,
+                alert_id=record.alert_id,
+            )
+        if isinstance(record, DetectorLifecycleRecord):
             return "/operator/detectors"
-        if record_family == "source_health":
+        if isinstance(record, (FalsePositiveReviewRecord, SuppressionProposalRecord)):
+            return (
+                self._reviewed_anchor_route(
+                    case_id=record.case_id,
+                    alert_id=record.alert_id,
+                )
+                or "/operator/detectors"
+            )
+        if isinstance(record, SourceHealthRecord):
             return "/operator/source-health"
-        return f"/operator/provenance/{record_family}/{record_id}"
+        return None
+
+    def _reviewed_anchor_route(
+        self,
+        *,
+        case_id: str | None,
+        alert_id: str | None,
+    ) -> str | None:
+        if case_id is not None:
+            case = self._service._store.get(CaseRecord, case_id)
+            if (
+                isinstance(case, CaseRecord)
+                and self._service._case_is_in_reviewed_operator_slice(case)
+            ):
+                return f"/operator/cases/{case.case_id}"
+        if alert_id is not None:
+            alert = self._service._store.get(AlertRecord, alert_id)
+            if (
+                isinstance(alert, AlertRecord)
+                and self._service._alert_is_in_reviewed_operator_slice(alert)
+            ):
+                return f"/operator/alerts/{alert.alert_id}"
+        return None
+
+    def _normalize_record_search_filter(
+        self,
+        value: str | None,
+        field_name: str,
+    ) -> str | None:
+        normalized = self._service._normalize_optional_string(value, field_name)
+        if normalized is None:
+            return None
+        return normalized.strip()
 
     @staticmethod
     def _record_search_summary(

--- a/control-plane/aegisops/control_plane/inspection/record_search.py
+++ b/control-plane/aegisops/control_plane/inspection/record_search.py
@@ -9,6 +9,7 @@ from ..models import (
     DetectorLifecycleRecord,
     EvidenceRecord,
     FalsePositiveReviewRecord,
+    ReconciliationRecord,
     SourceHealthRecord,
     SuppressionProposalRecord,
 )
@@ -152,6 +153,21 @@ class RecordSearchServiceDependencies(Protocol):
         ...
 
     def _alert_is_in_reviewed_operator_slice(self, alert: AlertRecord) -> bool:
+        ...
+
+    def _latest_detection_reconciliation_for_alert(
+        self,
+        alert_id: str,
+    ) -> ReconciliationRecord | None:
+        ...
+
+    def _reconciliation_is_wazuh_origin(
+        self,
+        reconciliation: ReconciliationRecord,
+    ) -> bool:
+        ...
+
+    def _linked_id_exists(self, values: object, expected_id: str) -> bool:
         ...
 
 
@@ -309,12 +325,12 @@ class RecordSearchInspectionService:
         if isinstance(record, AlertRecord):
             if not self._service._alert_is_in_reviewed_operator_slice(record):
                 return None
-            return self._service._reviewed_operator_source_family(record.reviewed_context)
+            return self._record_search_alert_source_family(record)
 
         if isinstance(record, CaseRecord):
             if not self._service._case_is_in_reviewed_operator_slice(record):
                 return None
-            return self._service._reviewed_operator_source_family(record.reviewed_context)
+            return self._record_search_case_source_family(record)
 
         if isinstance(record, EvidenceRecord):
             if record.case_id is not None:
@@ -323,14 +339,16 @@ class RecordSearchInspectionService:
                     isinstance(case, CaseRecord)
                     and self._service._case_is_in_reviewed_operator_slice(case)
                 ):
-                    return self._service._reviewed_operator_source_family(case.reviewed_context)
+                    source_family = self._record_search_case_source_family(case)
+                    if source_family is not None:
+                        return source_family
             if record.alert_id is not None:
                 alert = self._service._store.get(AlertRecord, record.alert_id)
                 if (
                     isinstance(alert, AlertRecord)
                     and self._service._alert_is_in_reviewed_operator_slice(alert)
                 ):
-                    return self._service._reviewed_operator_source_family(alert.reviewed_context)
+                    return self._record_search_alert_source_family(alert)
             return None
 
         if isinstance(
@@ -345,6 +363,77 @@ class RecordSearchInspectionService:
             return record.source_family.strip()
 
         return None
+
+    def _record_search_case_source_family(self, case: CaseRecord) -> str | None:
+        source_family = self._service._reviewed_operator_source_family(
+            case.reviewed_context
+        )
+        if source_family is not None:
+            return source_family
+
+        if case.alert_id is not None:
+            alert = self._service._store.get(AlertRecord, case.alert_id)
+            if isinstance(alert, AlertRecord):
+                source_family = self._service._reviewed_operator_source_family(
+                    alert.reviewed_context
+                )
+                if source_family is not None:
+                    return source_family
+            reconciliation = self._record_search_reviewed_reconciliation_for_alert(
+                case.alert_id,
+                case_id=case.case_id,
+            )
+            if reconciliation is not None:
+                return self._reviewed_reconciliation_source_family(reconciliation)
+
+        return None
+
+    def _record_search_alert_source_family(self, alert: AlertRecord) -> str | None:
+        source_family = self._service._reviewed_operator_source_family(
+            alert.reviewed_context
+        )
+        if source_family is not None:
+            return source_family
+
+        reconciliation = self._record_search_reviewed_reconciliation_for_alert(
+            alert.alert_id
+        )
+        if reconciliation is None:
+            return None
+        return self._reviewed_reconciliation_source_family(reconciliation)
+
+    def _record_search_reviewed_reconciliation_for_alert(
+        self,
+        alert_id: str,
+        *,
+        case_id: str | None = None,
+    ) -> ReconciliationRecord | None:
+        reconciliation = self._service._latest_detection_reconciliation_for_alert(
+            alert_id
+        )
+        if reconciliation is None or not self._service._reconciliation_is_wazuh_origin(
+            reconciliation
+        ):
+            return None
+        if not self._service._linked_id_exists(
+            reconciliation.subject_linkage.get("alert_ids"),
+            alert_id,
+        ):
+            return None
+        if case_id is not None and not self._service._linked_id_exists(
+            reconciliation.subject_linkage.get("case_ids"),
+            case_id,
+        ):
+            return None
+        return reconciliation
+
+    def _reviewed_reconciliation_source_family(
+        self,
+        reconciliation: ReconciliationRecord,
+    ) -> str | None:
+        return self._service._reviewed_operator_source_family(
+            reconciliation.subject_linkage.get("reviewed_source_profile")
+        )
 
     @staticmethod
     def _record_search_payload_matches(

--- a/control-plane/aegisops/control_plane/inspection/record_search.py
+++ b/control-plane/aegisops/control_plane/inspection/record_search.py
@@ -183,9 +183,9 @@ class RecordSearchInspectionService:
             return None
 
         record_lifecycle_state = payload.get("lifecycle_state")
-        if (
-            lifecycle_state is not None
-            and str(record_lifecycle_state).strip() != lifecycle_state
+        if not self._record_search_lifecycle_state_matches(
+            record_lifecycle_state,
+            lifecycle_state,
         ):
             return None
 
@@ -326,6 +326,15 @@ class RecordSearchInspectionService:
         if normalized is None:
             return None
         return normalized.strip()
+
+    @staticmethod
+    def _record_search_lifecycle_state_matches(
+        record_lifecycle_state: object,
+        lifecycle_state: str | None,
+    ) -> bool:
+        if lifecycle_state is None:
+            return True
+        return str(record_lifecycle_state).strip() == lifecycle_state
 
     @staticmethod
     def _record_search_summary(

--- a/control-plane/aegisops/control_plane/inspection/record_search.py
+++ b/control-plane/aegisops/control_plane/inspection/record_search.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Iterable, Mapping, Protocol, Type
-import json
 
 from ..models import (
     AlertRecord,
@@ -39,6 +38,90 @@ RECORD_SEARCH_BLOCKED_TERMS = (
     "approve detector",
     "suppress signal",
 )
+RECORD_SEARCH_COMMON_REVIEWED_FIELDS = (
+    "record_family",
+    "record_id",
+    "source_family",
+    "lifecycle_state",
+)
+RECORD_SEARCH_REVIEWED_FIELDS_BY_FAMILY = {
+    "alert": (
+        "alert_id",
+        "analytic_signal_id",
+        "case_id",
+        "finding_id",
+        "reviewed_context",
+    ),
+    "case": (
+        "case_id",
+        "alert_id",
+        "finding_id",
+        "evidence_ids",
+        "reviewed_context",
+    ),
+    "evidence": (
+        "evidence_id",
+        "alert_id",
+        "case_id",
+    ),
+    "detector_lifecycle": (
+        "detector_lifecycle_id",
+        "owner",
+        "source_catalog_entry",
+        "detector_identifier",
+        "expected_signal_posture",
+        "review_cadence",
+        "rollback_owner",
+        "disable_owner",
+        "lifecycle_audit_references",
+        "disabled_reason",
+        "rollback_reason",
+        "review_overdue_reason",
+    ),
+    "false_positive_review": (
+        "false_positive_review_id",
+        "detector_lifecycle_id",
+        "source_catalog_entry",
+        "alert_id",
+        "case_id",
+        "evidence_ids",
+        "owner",
+        "disposition",
+        "disposition_rationale",
+        "dispute_state",
+        "recurrence_posture",
+        "review_evidence_references",
+        "source_signal_handling",
+    ),
+    "suppression_proposal": (
+        "suppression_proposal_id",
+        "detector_lifecycle_id",
+        "source_catalog_entry",
+        "alert_id",
+        "case_id",
+        "evidence_ids",
+        "owner",
+        "rationale",
+        "citation_references",
+        "expires_at",
+        "review_cadence",
+        "expected_signal_impact",
+        "scope",
+        "source_signal_handling",
+    ),
+    "source_health": (
+        "source_health_id",
+        "source_catalog_entry",
+        "health_state",
+        "reviewed_state",
+        "reviewed_at",
+        "observed_at",
+        "detector_drift",
+        "credential_posture",
+        "evidence_references",
+        "operator_visible_reason",
+    ),
+}
 
 
 class RecordSearchStore(Protocol):
@@ -268,8 +351,57 @@ class RecordSearchInspectionService:
         payload: Mapping[str, object],
         query: str,
     ) -> bool:
-        haystack = json.dumps(_json_ready(payload), sort_keys=True).lower()
+        haystack = " ".join(
+            value.lower()
+            for value in RecordSearchInspectionService._record_search_payload_values(
+                payload
+            )
+        )
         return query.lower() in haystack
+
+    @staticmethod
+    def _record_search_payload_values(
+        payload: Mapping[str, object],
+    ) -> tuple[str, ...]:
+        family = payload.get("record_family")
+        selected_fields = (
+            *RECORD_SEARCH_COMMON_REVIEWED_FIELDS,
+            *RECORD_SEARCH_REVIEWED_FIELDS_BY_FAMILY.get(str(family), ()),
+        )
+        values: list[str] = []
+        for field_name in selected_fields:
+            if field_name in payload:
+                values.extend(
+                    RecordSearchInspectionService._record_search_value_text(
+                        _json_ready(payload[field_name])
+                    )
+                )
+        return tuple(values)
+
+    @staticmethod
+    def _record_search_value_text(value: object) -> tuple[str, ...]:
+        if value is None:
+            return ()
+        if isinstance(value, Mapping):
+            text: list[str] = []
+            for nested_value in value.values():
+                text.extend(
+                    RecordSearchInspectionService._record_search_value_text(
+                        nested_value
+                    )
+                )
+            return tuple(text)
+        if isinstance(value, (list, tuple)):
+            text: list[str] = []
+            for item in value:
+                text.extend(
+                    RecordSearchInspectionService._record_search_value_text(item)
+                )
+            return tuple(text)
+        rendered = str(value).strip()
+        if not rendered:
+            return ()
+        return (rendered,)
 
     def _record_search_route(self, record: ControlPlaneRecord) -> str | None:
         if isinstance(record, AlertRecord):

--- a/control-plane/aegisops/control_plane/inspection/record_search.py
+++ b/control-plane/aegisops/control_plane/inspection/record_search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Iterable, Mapping, Protocol, Type
 import json
 
-from .models import (
+from ..models import (
     AlertRecord,
     CaseRecord,
     ControlPlaneRecord,
@@ -13,7 +13,7 @@ from .models import (
     SourceHealthRecord,
     SuppressionProposalRecord,
 )
-from .runtime.service_snapshots import RecordInspectionSnapshot, _json_ready
+from ..runtime.service_snapshots import RecordInspectionSnapshot, _json_ready
 
 
 RECORD_SEARCH_RECORD_TYPES: tuple[Type[ControlPlaneRecord], ...] = (

--- a/control-plane/aegisops/control_plane/record_search.py
+++ b/control-plane/aegisops/control_plane/record_search.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Protocol, Type
+import json
+
+from .models import (
+    AlertRecord,
+    CaseRecord,
+    ControlPlaneRecord,
+    DetectorLifecycleRecord,
+    EvidenceRecord,
+    FalsePositiveReviewRecord,
+    SourceHealthRecord,
+    SuppressionProposalRecord,
+)
+from .runtime.service_snapshots import RecordInspectionSnapshot, _json_ready
+
+
+RECORD_SEARCH_RECORD_TYPES: tuple[Type[ControlPlaneRecord], ...] = (
+    AlertRecord,
+    CaseRecord,
+    EvidenceRecord,
+    DetectorLifecycleRecord,
+    FalsePositiveReviewRecord,
+    SuppressionProposalRecord,
+    SourceHealthRecord,
+)
+RECORD_SEARCH_RECORD_TYPES_BY_FAMILY: dict[str, Type[ControlPlaneRecord]] = {
+    record_type.record_family: record_type for record_type in RECORD_SEARCH_RECORD_TYPES
+}
+RECORD_SEARCH_BLOCKED_TERMS = (
+    "raw:",
+    "raw wazuh",
+    "raw source",
+    "source-native",
+    "source native",
+    "close case",
+    "reconcile",
+    "approve detector",
+    "suppress signal",
+)
+
+
+class RecordSearchStore(Protocol):
+    def get(self, record_type: Type[ControlPlaneRecord], record_id: str) -> object | None:
+        ...
+
+    def list(self, record_type: Type[ControlPlaneRecord]) -> tuple[object, ...]:
+        ...
+
+
+class RecordSearchServiceDependencies(Protocol):
+    _store: RecordSearchStore
+
+    def _normalize_optional_string(
+        self,
+        value: object,
+        field_name: str,
+    ) -> str | None:
+        ...
+
+    def _reviewed_operator_source_family(
+        self,
+        reviewed_context: object,
+    ) -> str | None:
+        ...
+
+    def _case_is_in_reviewed_operator_slice(self, case: CaseRecord) -> bool:
+        ...
+
+    def _alert_is_in_reviewed_operator_slice(self, alert: AlertRecord) -> bool:
+        ...
+
+
+class RecordSearchInspectionService:
+    def __init__(
+        self,
+        service: RecordSearchServiceDependencies,
+        *,
+        record_to_dict,
+    ) -> None:
+        self._service = service
+        self._record_to_dict = record_to_dict
+
+    def inspect_record_search(
+        self,
+        *,
+        query: str,
+        record_families: Iterable[str] | None = None,
+        source_family: str | None = None,
+        lifecycle_state: str | None = None,
+    ) -> RecordInspectionSnapshot:
+        search_query = self._normalize_record_search_query(query)
+        selected_families = self._normalize_record_search_families(record_families)
+        normalized_source_family = self._service._normalize_optional_string(
+            source_family,
+            "source_family",
+        )
+        normalized_lifecycle_state = self._service._normalize_optional_string(
+            lifecycle_state,
+            "lifecycle_state",
+        )
+
+        records: list[dict[str, object]] = []
+        for family in selected_families:
+            record_type = RECORD_SEARCH_RECORD_TYPES_BY_FAMILY[family]
+            for record in self._service._store.list(record_type):
+                if not isinstance(record, ControlPlaneRecord):
+                    continue
+                result = self._record_search_result(
+                    record,
+                    query=search_query,
+                    source_family=normalized_source_family,
+                    lifecycle_state=normalized_lifecycle_state,
+                )
+                if result is not None:
+                    records.append(result)
+
+        records = sorted(
+            records,
+            key=lambda result: (
+                str(result["record_family"]),
+                str(result["record_id"]),
+            ),
+        )
+        return RecordInspectionSnapshot(
+            read_only=True,
+            record_family="record_search",
+            total_records=len(records),
+            records=tuple(records),
+        )
+
+    @staticmethod
+    def _normalize_record_search_query(query: str) -> str:
+        if not isinstance(query, str):
+            raise ValueError("unsupported record search query")
+        normalized_query = query.strip()
+        if not normalized_query:
+            raise ValueError("unsupported record search query")
+
+        lowered_query = normalized_query.lower()
+        if any(term in lowered_query for term in RECORD_SEARCH_BLOCKED_TERMS):
+            raise ValueError("unsupported record search query")
+        return normalized_query
+
+    @staticmethod
+    def _normalize_record_search_families(
+        record_families: Iterable[str] | None,
+    ) -> tuple[str, ...]:
+        if record_families is None:
+            return tuple(RECORD_SEARCH_RECORD_TYPES_BY_FAMILY)
+
+        families: list[str] = []
+        for family in record_families:
+            normalized_family = str(family).strip()
+            if normalized_family not in RECORD_SEARCH_RECORD_TYPES_BY_FAMILY:
+                known_families = ", ".join(sorted(RECORD_SEARCH_RECORD_TYPES_BY_FAMILY))
+                raise ValueError(
+                    f"Unsupported search record family {normalized_family!r}; "
+                    f"expected one of: {known_families}"
+                )
+            if normalized_family not in families:
+                families.append(normalized_family)
+        if not families:
+            raise ValueError("unsupported record search query")
+        return tuple(families)
+
+    def _record_search_result(
+        self,
+        record: ControlPlaneRecord,
+        *,
+        query: str,
+        source_family: str | None,
+        lifecycle_state: str | None,
+    ) -> dict[str, object] | None:
+        payload = self._record_to_dict(record)
+        family = record.record_family
+        record_source_family = self._record_search_source_family(record)
+
+        if record_source_family is None:
+            return None
+        if source_family is not None and record_source_family != source_family:
+            return None
+
+        record_lifecycle_state = payload.get("lifecycle_state")
+        if (
+            lifecycle_state is not None
+            and str(record_lifecycle_state).strip() != lifecycle_state
+        ):
+            return None
+
+        if isinstance(record, SourceHealthRecord):
+            if record.cache_sourced:
+                raise ValueError("stale-cache record search result refused")
+            if record.source_native_authority or record.display_state_authority:
+                raise ValueError("raw-source authority record search result refused")
+
+        search_payload = {
+            **payload,
+            "record_family": family,
+            "record_id": record.record_id,
+            "source_family": record_source_family,
+        }
+        if not self._record_search_payload_matches(search_payload, query):
+            return None
+
+        record_id = record.record_id
+        return {
+            "record_family": family,
+            "record_id": record_id,
+            "id": f"{family}:{record_id}",
+            "source_family": record_source_family,
+            "lifecycle_state": record_lifecycle_state,
+            "matched_query": query,
+            "route": self._record_search_route(family, record_id),
+            "route_kind": "reviewed_surface",
+            "authority": "navigation_only",
+            "raw_source_authority": False,
+            "summary": self._record_search_summary(payload, family, record_id),
+        }
+
+    def _record_search_source_family(self, record: ControlPlaneRecord) -> str | None:
+        if isinstance(record, AlertRecord):
+            if not self._service._alert_is_in_reviewed_operator_slice(record):
+                return None
+            return self._service._reviewed_operator_source_family(record.reviewed_context)
+
+        if isinstance(record, CaseRecord):
+            if not self._service._case_is_in_reviewed_operator_slice(record):
+                return None
+            return self._service._reviewed_operator_source_family(record.reviewed_context)
+
+        if isinstance(record, EvidenceRecord):
+            if record.case_id is not None:
+                case = self._service._store.get(CaseRecord, record.case_id)
+                if isinstance(case, CaseRecord) and self._service._case_is_in_reviewed_operator_slice(case):
+                    return self._service._reviewed_operator_source_family(case.reviewed_context)
+            if record.alert_id is not None:
+                alert = self._service._store.get(AlertRecord, record.alert_id)
+                if isinstance(alert, AlertRecord) and self._service._alert_is_in_reviewed_operator_slice(alert):
+                    return self._service._reviewed_operator_source_family(alert.reviewed_context)
+            return None
+
+        if isinstance(
+            record,
+            (
+                DetectorLifecycleRecord,
+                FalsePositiveReviewRecord,
+                SuppressionProposalRecord,
+                SourceHealthRecord,
+            ),
+        ):
+            return record.source_family
+
+        return None
+
+    @staticmethod
+    def _record_search_payload_matches(
+        payload: Mapping[str, object],
+        query: str,
+    ) -> bool:
+        haystack = json.dumps(_json_ready(payload), sort_keys=True).lower()
+        return query.lower() in haystack
+
+    @staticmethod
+    def _record_search_route(record_family: str, record_id: str) -> str:
+        if record_family == "alert":
+            return f"/operator/alerts/{record_id}"
+        if record_family == "case":
+            return f"/operator/cases/{record_id}"
+        if record_family == "evidence":
+            return f"/operator/provenance/evidence/{record_id}"
+        if record_family == "detector_lifecycle":
+            return "/operator/detectors"
+        if record_family == "source_health":
+            return "/operator/source-health"
+        return f"/operator/provenance/{record_family}/{record_id}"
+
+    @staticmethod
+    def _record_search_summary(
+        payload: Mapping[str, object],
+        record_family: str,
+        record_id: str,
+    ) -> str:
+        for field_name in (
+            "operator_visible_reason",
+            "disposition_rationale",
+            "rationale",
+            "expected_signal_posture",
+            "lifecycle_state",
+        ):
+            value = payload.get(field_name)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return f"Reviewed {record_family} record {record_id}"

--- a/control-plane/aegisops/control_plane/record_validation.py
+++ b/control-plane/aegisops/control_plane/record_validation.py
@@ -869,7 +869,8 @@ def _validate_source_health_record(record: SourceHealthRecord) -> None:
         )
     if record.cache_sourced:
         raise ValueError(
-            f"source_health record {record.record_id!r} must not be cache sourced"
+            f"source_health record {record.record_id!r} must not be stale-cache "
+            "or cache sourced"
         )
 
 

--- a/control-plane/aegisops/control_plane/record_validation.py
+++ b/control-plane/aegisops/control_plane/record_validation.py
@@ -869,8 +869,8 @@ def _validate_source_health_record(record: SourceHealthRecord) -> None:
         )
     if record.cache_sourced:
         raise ValueError(
-            f"source_health record {record.record_id!r} must not be stale-cache "
-            "or cache sourced"
+            f"source_health record {record.record_id!r} must not be cache sourced; "
+            "stale-cache source health is refused"
         )
 
 

--- a/control-plane/aegisops/control_plane/service.py
+++ b/control-plane/aegisops/control_plane/service.py
@@ -45,7 +45,6 @@ from .runtime.readiness_contracts import (
 )
 from .runtime.runtime_boundary import RuntimeBoundaryService
 from .reviewed_slice_policy import REVIEWED_LIVE_SLICE_LABEL, ReviewedSlicePolicy
-from .record_search import RecordSearchInspectionService
 from .ingestion.case_workflow import CaseWorkflowFacade
 from .ingestion.detection_lifecycle_helpers import LATEST_LIFECYCLE_TRANSITION_UNSET
 from .evidence.external_evidence_facade import ExternalEvidenceFacade
@@ -78,6 +77,9 @@ from .structured_events import sanitize_structured_event_fields
 
 
 RecordT = TypeVar("RecordT", bound=ControlPlaneRecord)
+RECORD_SEARCH_INSPECTION_FAMILY = "record_search"
+RECORD_SEARCH_INSPECTION_AUTHORITY = "navigation_only"
+RECORD_SEARCH_INSPECTION_SURFACE = "read_only"
 
 _CASE_CLOSED_TRIAGE_DISPOSITIONS = frozenset(
     {
@@ -470,7 +472,6 @@ class AegisOpsControlPlaneService(CaseWorkflowFacade, ExternalEvidenceFacade):
             service=self,
             composition=composition,
         )
-        self.inspect_record_search = RecordSearchInspectionService(self, record_to_dict=_record_to_dict).inspect_record_search
 
     def describe_runtime(self) -> RuntimeSnapshot:
         return self._runtime_restore_readiness_diagnostics_service.describe_runtime()

--- a/control-plane/aegisops/control_plane/service.py
+++ b/control-plane/aegisops/control_plane/service.py
@@ -44,10 +44,8 @@ from .runtime.readiness_contracts import (
     resolve_current_readiness_runtime_status,
 )
 from .runtime.runtime_boundary import RuntimeBoundaryService
-from .reviewed_slice_policy import (
-    REVIEWED_LIVE_SLICE_LABEL,
-    ReviewedSlicePolicy,
-)
+from .reviewed_slice_policy import REVIEWED_LIVE_SLICE_LABEL, ReviewedSlicePolicy
+from .record_search import RecordSearchInspectionService
 from .ingestion.case_workflow import CaseWorkflowFacade
 from .ingestion.detection_lifecycle_helpers import LATEST_LIFECYCLE_TRANSITION_UNSET
 from .evidence.external_evidence_facade import ExternalEvidenceFacade
@@ -316,29 +314,6 @@ AUTHORITATIVE_RECORD_CHAIN_FAMILIES: tuple[str, ...] = tuple(
 AUTHORITATIVE_RECORD_CHAIN_BACKUP_SCHEMA_VERSION = (
     "phase23.authoritative-record-chain.v5"
 )
-RECORD_SEARCH_RECORD_TYPES: tuple[Type[ControlPlaneRecord], ...] = (
-    AlertRecord,
-    CaseRecord,
-    EvidenceRecord,
-    DetectorLifecycleRecord,
-    FalsePositiveReviewRecord,
-    SuppressionProposalRecord,
-    SourceHealthRecord,
-)
-RECORD_SEARCH_RECORD_TYPES_BY_FAMILY: dict[str, Type[ControlPlaneRecord]] = {
-    record_type.record_family: record_type for record_type in RECORD_SEARCH_RECORD_TYPES
-}
-RECORD_SEARCH_BLOCKED_TERMS = (
-    "raw:",
-    "raw wazuh",
-    "raw source",
-    "source-native",
-    "source native",
-    "close case",
-    "reconcile",
-    "approve detector",
-    "suppress signal",
-)
 _AUTHORITATIVE_PRIMARY_ID_FIELD_BY_FAMILY: dict[str, str] = {
     "analytic_signal": "analytic_signal_id",
     "alert": "alert_id",
@@ -495,6 +470,7 @@ class AegisOpsControlPlaneService(CaseWorkflowFacade, ExternalEvidenceFacade):
             service=self,
             composition=composition,
         )
+        self.inspect_record_search = RecordSearchInspectionService(self, record_to_dict=_record_to_dict).inspect_record_search
 
     def describe_runtime(self) -> RuntimeSnapshot:
         return self._runtime_restore_readiness_diagnostics_service.describe_runtime()
@@ -788,216 +764,6 @@ class AegisOpsControlPlaneService(CaseWorkflowFacade, ExternalEvidenceFacade):
             total_records=len(records),
             records=records,
         )
-
-    def inspect_record_search(
-        self,
-        *,
-        query: str,
-        record_families: Iterable[str] | None = None,
-        source_family: str | None = None,
-        lifecycle_state: str | None = None,
-    ) -> RecordInspectionSnapshot:
-        search_query = self._normalize_record_search_query(query)
-        selected_families = self._normalize_record_search_families(record_families)
-        normalized_source_family = self._normalize_optional_string(
-            source_family,
-            "source_family",
-        )
-        normalized_lifecycle_state = self._normalize_optional_string(
-            lifecycle_state,
-            "lifecycle_state",
-        )
-
-        records: list[dict[str, object]] = []
-        for family in selected_families:
-            record_type = RECORD_SEARCH_RECORD_TYPES_BY_FAMILY[family]
-            for record in self._store.list(record_type):
-                result = self._record_search_result(
-                    record,
-                    query=search_query,
-                    source_family=normalized_source_family,
-                    lifecycle_state=normalized_lifecycle_state,
-                )
-                if result is not None:
-                    records.append(result)
-
-        records = sorted(
-            records,
-            key=lambda result: (
-                str(result["record_family"]),
-                str(result["record_id"]),
-            ),
-        )
-        return RecordInspectionSnapshot(
-            read_only=True,
-            record_family="record_search",
-            total_records=len(records),
-            records=tuple(records),
-        )
-
-    @staticmethod
-    def _normalize_record_search_query(query: str) -> str:
-        if not isinstance(query, str):
-            raise ValueError("unsupported record search query")
-        normalized_query = query.strip()
-        if not normalized_query:
-            raise ValueError("unsupported record search query")
-
-        lowered_query = normalized_query.lower()
-        if any(term in lowered_query for term in RECORD_SEARCH_BLOCKED_TERMS):
-            raise ValueError("unsupported record search query")
-        return normalized_query
-
-    @staticmethod
-    def _normalize_record_search_families(
-        record_families: Iterable[str] | None,
-    ) -> tuple[str, ...]:
-        if record_families is None:
-            return tuple(RECORD_SEARCH_RECORD_TYPES_BY_FAMILY)
-
-        families: list[str] = []
-        for family in record_families:
-            normalized_family = str(family).strip()
-            if normalized_family not in RECORD_SEARCH_RECORD_TYPES_BY_FAMILY:
-                known_families = ", ".join(sorted(RECORD_SEARCH_RECORD_TYPES_BY_FAMILY))
-                raise ValueError(
-                    f"Unsupported search record family {normalized_family!r}; "
-                    f"expected one of: {known_families}"
-                )
-            if normalized_family not in families:
-                families.append(normalized_family)
-        if not families:
-            raise ValueError("unsupported record search query")
-        return tuple(families)
-
-    def _record_search_result(
-        self,
-        record: ControlPlaneRecord,
-        *,
-        query: str,
-        source_family: str | None,
-        lifecycle_state: str | None,
-    ) -> dict[str, object] | None:
-        payload = _record_to_dict(record)
-        family = record.record_family
-        record_source_family = self._record_search_source_family(record)
-
-        if record_source_family is None:
-            return None
-        if source_family is not None and record_source_family != source_family:
-            return None
-
-        record_lifecycle_state = payload.get("lifecycle_state")
-        if (
-            lifecycle_state is not None
-            and str(record_lifecycle_state).strip() != lifecycle_state
-        ):
-            return None
-
-        if isinstance(record, SourceHealthRecord):
-            if record.cache_sourced:
-                raise ValueError("stale-cache record search result refused")
-            if record.source_native_authority or record.display_state_authority:
-                raise ValueError("raw-source authority record search result refused")
-
-        search_payload = {
-            **payload,
-            "record_family": family,
-            "record_id": record.record_id,
-            "source_family": record_source_family,
-        }
-        if not self._record_search_payload_matches(search_payload, query):
-            return None
-
-        record_id = record.record_id
-        return {
-            "record_family": family,
-            "record_id": record_id,
-            "id": f"{family}:{record_id}",
-            "source_family": record_source_family,
-            "lifecycle_state": record_lifecycle_state,
-            "matched_query": query,
-            "route": self._record_search_route(family, record_id),
-            "route_kind": "reviewed_surface",
-            "authority": "navigation_only",
-            "raw_source_authority": False,
-            "summary": self._record_search_summary(payload, family, record_id),
-        }
-
-    def _record_search_source_family(self, record: ControlPlaneRecord) -> str | None:
-        if isinstance(record, AlertRecord):
-            if not self._alert_is_in_reviewed_operator_slice(record):
-                return None
-            return self._reviewed_operator_source_family(record.reviewed_context)
-
-        if isinstance(record, CaseRecord):
-            if not self._case_is_in_reviewed_operator_slice(record):
-                return None
-            return self._reviewed_operator_source_family(record.reviewed_context)
-
-        if isinstance(record, EvidenceRecord):
-            if record.case_id is not None:
-                case = self._store.get(CaseRecord, record.case_id)
-                if case is not None and self._case_is_in_reviewed_operator_slice(case):
-                    return self._reviewed_operator_source_family(case.reviewed_context)
-            if record.alert_id is not None:
-                alert = self._store.get(AlertRecord, record.alert_id)
-                if alert is not None and self._alert_is_in_reviewed_operator_slice(alert):
-                    return self._reviewed_operator_source_family(alert.reviewed_context)
-            return None
-
-        if isinstance(
-            record,
-            (
-                DetectorLifecycleRecord,
-                FalsePositiveReviewRecord,
-                SuppressionProposalRecord,
-                SourceHealthRecord,
-            ),
-        ):
-            return record.source_family
-
-        return None
-
-    @staticmethod
-    def _record_search_payload_matches(
-        payload: Mapping[str, object],
-        query: str,
-    ) -> bool:
-        haystack = json.dumps(_json_ready(payload), sort_keys=True).lower()
-        return query.lower() in haystack
-
-    @staticmethod
-    def _record_search_route(record_family: str, record_id: str) -> str:
-        if record_family == "alert":
-            return f"/operator/alerts/{record_id}"
-        if record_family == "case":
-            return f"/operator/cases/{record_id}"
-        if record_family == "evidence":
-            return f"/operator/provenance/evidence/{record_id}"
-        if record_family == "detector_lifecycle":
-            return "/operator/detectors"
-        if record_family == "source_health":
-            return "/operator/source-health"
-        return f"/operator/provenance/{record_family}/{record_id}"
-
-    @staticmethod
-    def _record_search_summary(
-        payload: Mapping[str, object],
-        record_family: str,
-        record_id: str,
-    ) -> str:
-        for field_name in (
-            "operator_visible_reason",
-            "disposition_rationale",
-            "rationale",
-            "expected_signal_posture",
-            "lifecycle_state",
-        ):
-            value = payload.get(field_name)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-        return f"Reviewed {record_family} record {record_id}"
 
     def inspect_reconciliation_status(self) -> ReconciliationStatusSnapshot:
         records = self._store.list(ReconciliationRecord)

--- a/control-plane/aegisops/control_plane/service.py
+++ b/control-plane/aegisops/control_plane/service.py
@@ -316,6 +316,29 @@ AUTHORITATIVE_RECORD_CHAIN_FAMILIES: tuple[str, ...] = tuple(
 AUTHORITATIVE_RECORD_CHAIN_BACKUP_SCHEMA_VERSION = (
     "phase23.authoritative-record-chain.v5"
 )
+RECORD_SEARCH_RECORD_TYPES: tuple[Type[ControlPlaneRecord], ...] = (
+    AlertRecord,
+    CaseRecord,
+    EvidenceRecord,
+    DetectorLifecycleRecord,
+    FalsePositiveReviewRecord,
+    SuppressionProposalRecord,
+    SourceHealthRecord,
+)
+RECORD_SEARCH_RECORD_TYPES_BY_FAMILY: dict[str, Type[ControlPlaneRecord]] = {
+    record_type.record_family: record_type for record_type in RECORD_SEARCH_RECORD_TYPES
+}
+RECORD_SEARCH_BLOCKED_TERMS = (
+    "raw:",
+    "raw wazuh",
+    "raw source",
+    "source-native",
+    "source native",
+    "close case",
+    "reconcile",
+    "approve detector",
+    "suppress signal",
+)
 _AUTHORITATIVE_PRIMARY_ID_FIELD_BY_FAMILY: dict[str, str] = {
     "analytic_signal": "analytic_signal_id",
     "alert": "alert_id",
@@ -765,6 +788,216 @@ class AegisOpsControlPlaneService(CaseWorkflowFacade, ExternalEvidenceFacade):
             total_records=len(records),
             records=records,
         )
+
+    def inspect_record_search(
+        self,
+        *,
+        query: str,
+        record_families: Iterable[str] | None = None,
+        source_family: str | None = None,
+        lifecycle_state: str | None = None,
+    ) -> RecordInspectionSnapshot:
+        search_query = self._normalize_record_search_query(query)
+        selected_families = self._normalize_record_search_families(record_families)
+        normalized_source_family = self._normalize_optional_string(
+            source_family,
+            "source_family",
+        )
+        normalized_lifecycle_state = self._normalize_optional_string(
+            lifecycle_state,
+            "lifecycle_state",
+        )
+
+        records: list[dict[str, object]] = []
+        for family in selected_families:
+            record_type = RECORD_SEARCH_RECORD_TYPES_BY_FAMILY[family]
+            for record in self._store.list(record_type):
+                result = self._record_search_result(
+                    record,
+                    query=search_query,
+                    source_family=normalized_source_family,
+                    lifecycle_state=normalized_lifecycle_state,
+                )
+                if result is not None:
+                    records.append(result)
+
+        records = sorted(
+            records,
+            key=lambda result: (
+                str(result["record_family"]),
+                str(result["record_id"]),
+            ),
+        )
+        return RecordInspectionSnapshot(
+            read_only=True,
+            record_family="record_search",
+            total_records=len(records),
+            records=tuple(records),
+        )
+
+    @staticmethod
+    def _normalize_record_search_query(query: str) -> str:
+        if not isinstance(query, str):
+            raise ValueError("unsupported record search query")
+        normalized_query = query.strip()
+        if not normalized_query:
+            raise ValueError("unsupported record search query")
+
+        lowered_query = normalized_query.lower()
+        if any(term in lowered_query for term in RECORD_SEARCH_BLOCKED_TERMS):
+            raise ValueError("unsupported record search query")
+        return normalized_query
+
+    @staticmethod
+    def _normalize_record_search_families(
+        record_families: Iterable[str] | None,
+    ) -> tuple[str, ...]:
+        if record_families is None:
+            return tuple(RECORD_SEARCH_RECORD_TYPES_BY_FAMILY)
+
+        families: list[str] = []
+        for family in record_families:
+            normalized_family = str(family).strip()
+            if normalized_family not in RECORD_SEARCH_RECORD_TYPES_BY_FAMILY:
+                known_families = ", ".join(sorted(RECORD_SEARCH_RECORD_TYPES_BY_FAMILY))
+                raise ValueError(
+                    f"Unsupported search record family {normalized_family!r}; "
+                    f"expected one of: {known_families}"
+                )
+            if normalized_family not in families:
+                families.append(normalized_family)
+        if not families:
+            raise ValueError("unsupported record search query")
+        return tuple(families)
+
+    def _record_search_result(
+        self,
+        record: ControlPlaneRecord,
+        *,
+        query: str,
+        source_family: str | None,
+        lifecycle_state: str | None,
+    ) -> dict[str, object] | None:
+        payload = _record_to_dict(record)
+        family = record.record_family
+        record_source_family = self._record_search_source_family(record)
+
+        if record_source_family is None:
+            return None
+        if source_family is not None and record_source_family != source_family:
+            return None
+
+        record_lifecycle_state = payload.get("lifecycle_state")
+        if (
+            lifecycle_state is not None
+            and str(record_lifecycle_state).strip() != lifecycle_state
+        ):
+            return None
+
+        if isinstance(record, SourceHealthRecord):
+            if record.cache_sourced:
+                raise ValueError("stale-cache record search result refused")
+            if record.source_native_authority or record.display_state_authority:
+                raise ValueError("raw-source authority record search result refused")
+
+        search_payload = {
+            **payload,
+            "record_family": family,
+            "record_id": record.record_id,
+            "source_family": record_source_family,
+        }
+        if not self._record_search_payload_matches(search_payload, query):
+            return None
+
+        record_id = record.record_id
+        return {
+            "record_family": family,
+            "record_id": record_id,
+            "id": f"{family}:{record_id}",
+            "source_family": record_source_family,
+            "lifecycle_state": record_lifecycle_state,
+            "matched_query": query,
+            "route": self._record_search_route(family, record_id),
+            "route_kind": "reviewed_surface",
+            "authority": "navigation_only",
+            "raw_source_authority": False,
+            "summary": self._record_search_summary(payload, family, record_id),
+        }
+
+    def _record_search_source_family(self, record: ControlPlaneRecord) -> str | None:
+        if isinstance(record, AlertRecord):
+            if not self._alert_is_in_reviewed_operator_slice(record):
+                return None
+            return self._reviewed_operator_source_family(record.reviewed_context)
+
+        if isinstance(record, CaseRecord):
+            if not self._case_is_in_reviewed_operator_slice(record):
+                return None
+            return self._reviewed_operator_source_family(record.reviewed_context)
+
+        if isinstance(record, EvidenceRecord):
+            if record.case_id is not None:
+                case = self._store.get(CaseRecord, record.case_id)
+                if case is not None and self._case_is_in_reviewed_operator_slice(case):
+                    return self._reviewed_operator_source_family(case.reviewed_context)
+            if record.alert_id is not None:
+                alert = self._store.get(AlertRecord, record.alert_id)
+                if alert is not None and self._alert_is_in_reviewed_operator_slice(alert):
+                    return self._reviewed_operator_source_family(alert.reviewed_context)
+            return None
+
+        if isinstance(
+            record,
+            (
+                DetectorLifecycleRecord,
+                FalsePositiveReviewRecord,
+                SuppressionProposalRecord,
+                SourceHealthRecord,
+            ),
+        ):
+            return record.source_family
+
+        return None
+
+    @staticmethod
+    def _record_search_payload_matches(
+        payload: Mapping[str, object],
+        query: str,
+    ) -> bool:
+        haystack = json.dumps(_json_ready(payload), sort_keys=True).lower()
+        return query.lower() in haystack
+
+    @staticmethod
+    def _record_search_route(record_family: str, record_id: str) -> str:
+        if record_family == "alert":
+            return f"/operator/alerts/{record_id}"
+        if record_family == "case":
+            return f"/operator/cases/{record_id}"
+        if record_family == "evidence":
+            return f"/operator/provenance/evidence/{record_id}"
+        if record_family == "detector_lifecycle":
+            return "/operator/detectors"
+        if record_family == "source_health":
+            return "/operator/source-health"
+        return f"/operator/provenance/{record_family}/{record_id}"
+
+    @staticmethod
+    def _record_search_summary(
+        payload: Mapping[str, object],
+        record_family: str,
+        record_id: str,
+    ) -> str:
+        for field_name in (
+            "operator_visible_reason",
+            "disposition_rationale",
+            "rationale",
+            "expected_signal_posture",
+            "lifecycle_state",
+        ):
+            value = payload.get(field_name)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return f"Reviewed {record_family} record {record_id}"
 
     def inspect_reconciliation_status(self) -> ReconciliationStatusSnapshot:
         records = self._store.list(ReconciliationRecord)

--- a/control-plane/aegisops/control_plane/service_composition.py
+++ b/control-plane/aegisops/control_plane/service_composition.py
@@ -31,6 +31,7 @@ from .ingestion.evidence_linkage import EvidenceLinkageService
 from .actions.execution_coordinator import ExecutionCoordinator
 from .evidence.external_evidence_boundary import ExternalEvidenceBoundary
 from .assistant.live_assistant_workflow import LiveAssistantWorkflowCoordinator
+from .inspection.record_search import RecordSearchInspectionService
 from .models import ControlPlaneRecord, ReconciliationRecord
 from .operator_inspection import OperatorInspectionReadSurface
 from .persistence_lifecycle import PersistenceLifecycleService
@@ -106,6 +107,7 @@ class ControlPlaneServiceComposition:
     live_assistant_workflow_coordinator: LiveAssistantWorkflowCoordinator
     action_review_inspection_boundary: ActionReviewInspectionBoundary
     operator_inspection_read_surface: OperatorInspectionReadSurface
+    record_search_inspection_service: RecordSearchInspectionService
     action_review_write_surface: ActionReviewWriteSurface
     evidence_linkage_service: EvidenceLinkageService
     case_workflow_service: CaseWorkflowService
@@ -213,6 +215,10 @@ def build_control_plane_service_composition(
         coordination_reference_payload=dependencies.coordination_reference_payload,
         coordination_reference_signature=dependencies.coordination_reference_signature,
         dedupe_strings=dependencies.dedupe_strings,
+    )
+    record_search_inspection_service = RecordSearchInspectionService(
+        service,
+        record_to_dict=dependencies.record_to_dict,
     )
     action_review_write_surface = ActionReviewWriteSurface(
         service,
@@ -353,6 +359,7 @@ def build_control_plane_service_composition(
         live_assistant_workflow_coordinator=live_assistant_workflow_coordinator,
         action_review_inspection_boundary=action_review_inspection_boundary,
         operator_inspection_read_surface=operator_inspection_read_surface,
+        record_search_inspection_service=record_search_inspection_service,
         action_review_write_surface=action_review_write_surface,
         evidence_linkage_service=evidence_linkage_service,
         case_workflow_service=case_workflow_service,
@@ -398,6 +405,9 @@ def install_control_plane_service_composition(
         ),
         "_operator_inspection_read_surface": (
             composition.operator_inspection_read_surface
+        ),
+        "inspect_record_search": (
+            composition.record_search_inspection_service.inspect_record_search
         ),
         "_action_review_write_surface": composition.action_review_write_surface,
         "_evidence_linkage_service": composition.evidence_linkage_service,

--- a/control-plane/tests/test_phase61_7_record_search_filter.py
+++ b/control-plane/tests/test_phase61_7_record_search_filter.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+import pathlib
+import sys
+
+
+CONTROL_PLANE_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+TESTS_ROOT = pathlib.Path(__file__).resolve().parent
+if str(TESTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(TESTS_ROOT))
+
+from aegisops.control_plane.models import (
+    EvidenceRecord,
+    SourceHealthRecord,
+)
+from support.service_persistence import ServicePersistenceTestBase
+
+
+class Phase617RecordSearchFilterTests(ServicePersistenceTestBase):
+    def test_record_search_returns_reviewed_navigation_results_only(self) -> None:
+        store, service, case, evidence_id, _reviewed_at = self._build_phase19_in_scope_case()
+        service.persist_record(
+            SourceHealthRecord(
+                source_health_id="source-health-github-audit-001",
+                source_family="github_audit",
+                source_catalog_entry="docs/source-families/github-audit/onboarding-package.md",
+                health_state="available",
+                reviewed_state="reviewed",
+                reviewed_at=datetime(2026, 5, 15, 8, 0, tzinfo=timezone.utc),
+                observed_at=datetime(2026, 5, 15, 7, 55, tzinfo=timezone.utc),
+                detector_drift="none",
+                credential_posture="reviewed",
+                evidence_references=("evidence://source-health/github-audit",),
+                operator_visible_reason="Reviewed GitHub audit source is available.",
+                source_native_authority=False,
+                display_state_authority=False,
+                cache_sourced=False,
+            )
+        )
+
+        snapshot = service.inspect_record_search(
+            query="github",
+            record_families=("alert", "case", "evidence", "source_health"),
+            source_family="github_audit",
+        )
+        result_keys = {
+            (result["record_family"], result["record_id"])
+            for result in snapshot.to_dict()["records"]
+        }
+
+        self.assertIn(("case", case.case_id), result_keys)
+        self.assertIn(("evidence", evidence_id), result_keys)
+        self.assertIn(("source_health", "source-health-github-audit-001"), result_keys)
+        for result in snapshot.to_dict()["records"]:
+            self.assertEqual(result["authority"], "navigation_only")
+            self.assertEqual(result["route_kind"], "reviewed_surface")
+            self.assertFalse(result["raw_source_authority"])
+
+        stale_source_health = replace(
+            store.get(SourceHealthRecord, "source-health-github-audit-001"),
+            source_health_id="source-health-cache-001",
+            cache_sourced=True,
+        )
+        with self.assertRaisesRegex(ValueError, "stale-cache"):
+            service.persist_record(stale_source_health)
+
+    def test_record_search_rejects_malformed_or_raw_source_queries(self) -> None:
+        _store, service, _case, _evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+
+        invalid_queries = (
+            "",
+            "  ",
+            "raw:wazuh rule.id:5715",
+            "source-native status current",
+            "close case case-001",
+        )
+        for query in invalid_queries:
+            with self.subTest(query=query):
+                with self.assertRaisesRegex(ValueError, "unsupported record search query"):
+                    service.inspect_record_search(query=query)
+
+        with self.assertRaisesRegex(ValueError, "Unsupported search record family"):
+            service.inspect_record_search(
+                query="github",
+                record_families=("native_detection",),
+            )
+
+        raw_evidence = EvidenceRecord(
+            evidence_id="evidence-raw-unlinked-001",
+            source_record_id="native-raw-001",
+            alert_id="alert-unreviewed-raw-001",
+            case_id=None,
+            source_system="wazuh",
+            collector_identity="collector://wazuh/raw",
+            acquired_at=datetime(2026, 5, 15, 8, 0, tzinfo=timezone.utc),
+            derivation_relationship="native_detection_record",
+            lifecycle_state="collected",
+            provenance={"classification": "raw"},
+            content={"message": "github raw source hit"},
+        )
+        service.persist_record(raw_evidence)
+
+        snapshot = service.inspect_record_search(query="raw")
+        result_ids = {
+            result["record_id"]
+            for result in snapshot.to_dict()["records"]
+        }
+        self.assertNotIn(raw_evidence.evidence_id, result_ids)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/control-plane/tests/test_phase61_7_record_search_filter.py
+++ b/control-plane/tests/test_phase61_7_record_search_filter.py
@@ -14,20 +14,27 @@ if str(TESTS_ROOT) not in sys.path:
     sys.path.insert(0, str(TESTS_ROOT))
 
 from aegisops.control_plane.models import (
+    DetectorLifecycleRecord,
     EvidenceRecord,
+    FalsePositiveReviewRecord,
     SourceHealthRecord,
+    SuppressionProposalRecord,
 )
 from support.service_persistence import ServicePersistenceTestBase
+
+GITHUB_AUDIT_CATALOG_ENTRY = "docs/source-families/github-audit/onboarding-package.md"
 
 
 class Phase617RecordSearchFilterTests(ServicePersistenceTestBase):
     def test_record_search_returns_reviewed_navigation_results_only(self) -> None:
-        store, service, case, evidence_id, _reviewed_at = self._build_phase19_in_scope_case()
+        store, service, case, evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
         service.persist_record(
             SourceHealthRecord(
                 source_health_id="source-health-github-audit-001",
                 source_family="github_audit",
-                source_catalog_entry="docs/source-families/github-audit/onboarding-package.md",
+                source_catalog_entry=GITHUB_AUDIT_CATALOG_ENTRY,
                 health_state="available",
                 reviewed_state="reviewed",
                 reviewed_at=datetime(2026, 5, 15, 8, 0, tzinfo=timezone.utc),
@@ -41,24 +48,147 @@ class Phase617RecordSearchFilterTests(ServicePersistenceTestBase):
                 cache_sourced=False,
             )
         )
+        service.persist_record(
+            DetectorLifecycleRecord(
+                detector_lifecycle_id="detector-lifecycle-github-audit-001",
+                owner="detector-owner",
+                source_family="github_audit",
+                source_catalog_entry=GITHUB_AUDIT_CATALOG_ENTRY,
+                detector_identifier="github-audit-admin-membership-change",
+                expected_signal_posture="reviewed GitHub admin-membership signal",
+                review_cadence="daily",
+                rollback_owner="rollback-owner",
+                disable_owner="disable-owner",
+                lifecycle_audit_references=("audit-evidence://github-audit-detector",),
+                lifecycle_state="candidate",
+            )
+        )
+        service.persist_record(
+            FalsePositiveReviewRecord(
+                false_positive_review_id="fp-review-github-audit-001",
+                detector_lifecycle_id="detector-lifecycle-github-audit-001",
+                source_family="github_audit",
+                source_catalog_entry=GITHUB_AUDIT_CATALOG_ENTRY,
+                alert_id=case.alert_id,
+                case_id=case.case_id,
+                evidence_ids=(evidence_id,),
+                owner="fp-review-owner",
+                disposition="benign_activity",
+                disposition_rationale="Reviewed GitHub audit case matched approved admin access.",
+                dispute_state="undisputed",
+                recurrence_posture="single_reviewed_instance",
+                review_evidence_references=("evidence://case/github-audit-admin-ticket",),
+                source_signal_handling="preserve_source_signal",
+                lifecycle_state="reviewed",
+            )
+        )
+        service.persist_record(
+            SuppressionProposalRecord(
+                suppression_proposal_id="suppression-proposal-github-audit-001",
+                detector_lifecycle_id="detector-lifecycle-github-audit-001",
+                source_family="github_audit",
+                source_catalog_entry=GITHUB_AUDIT_CATALOG_ENTRY,
+                alert_id=case.alert_id,
+                case_id=case.case_id,
+                evidence_ids=(evidence_id,),
+                owner="suppression-owner",
+                rationale="Reviewed GitHub audit admin churn from approved rotation.",
+                citation_references=("evidence://case/github-audit-admin-ticket",),
+                expires_at=datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc),
+                review_cadence="weekly",
+                expected_signal_impact="Reduce duplicate reviewed admin-membership alerts.",
+                scope="detector_case_context",
+                source_signal_handling="preserve_source_signal",
+                lifecycle_state="proposed",
+            )
+        )
 
         snapshot = service.inspect_record_search(
             query="github",
-            record_families=("alert", "case", "evidence", "source_health"),
-            source_family="github_audit",
+            record_families=(
+                "alert",
+                "case",
+                "evidence",
+                "detector_lifecycle",
+                "false_positive_review",
+                "suppression_proposal",
+                "source_health",
+            ),
+            source_family=" github_audit ",
         )
+        results = snapshot.to_dict()["records"]
         result_keys = {
-            (result["record_family"], result["record_id"])
-            for result in snapshot.to_dict()["records"]
+            (result["record_family"], result["record_id"]) for result in results
+        }
+        routes_by_key = {
+            (result["record_family"], result["record_id"]): result["route"]
+            for result in results
         }
 
         self.assertIn(("case", case.case_id), result_keys)
         self.assertIn(("evidence", evidence_id), result_keys)
+        self.assertIn(
+            ("detector_lifecycle", "detector-lifecycle-github-audit-001"),
+            result_keys,
+        )
+        self.assertIn(
+            ("false_positive_review", "fp-review-github-audit-001"),
+            result_keys,
+        )
+        self.assertIn(
+            ("suppression_proposal", "suppression-proposal-github-audit-001"),
+            result_keys,
+        )
         self.assertIn(("source_health", "source-health-github-audit-001"), result_keys)
-        for result in snapshot.to_dict()["records"]:
+        self.assertEqual(
+            routes_by_key[("case", case.case_id)],
+            f"/operator/cases/{case.case_id}",
+        )
+        self.assertEqual(
+            routes_by_key[("evidence", evidence_id)],
+            f"/operator/cases/{case.case_id}",
+        )
+        self.assertEqual(
+            routes_by_key[
+                ("detector_lifecycle", "detector-lifecycle-github-audit-001")
+            ],
+            "/operator/detectors",
+        )
+        self.assertEqual(
+            routes_by_key[("false_positive_review", "fp-review-github-audit-001")],
+            f"/operator/cases/{case.case_id}",
+        )
+        self.assertEqual(
+            routes_by_key[
+                ("suppression_proposal", "suppression-proposal-github-audit-001")
+            ],
+            f"/operator/cases/{case.case_id}",
+        )
+        self.assertEqual(
+            routes_by_key[("source_health", "source-health-github-audit-001")],
+            "/operator/source-health",
+        )
+        for result in results:
             self.assertEqual(result["authority"], "navigation_only")
             self.assertEqual(result["route_kind"], "reviewed_surface")
             self.assertFalse(result["raw_source_authority"])
+            self.assertFalse(
+                str(result["route"]).startswith("/operator/provenance/")
+            )
+
+        source_health_snapshot = service.inspect_record_search(
+            query="github",
+            record_families=("source_health",),
+            source_family=" github_audit ",
+            lifecycle_state=" reviewed ",
+        )
+        self.assertEqual(
+            [
+                result["record_id"]
+                for result in source_health_snapshot.to_dict()["records"]
+            ],
+            ["source-health-github-audit-001"],
+        )
 
         stale_source_health = replace(
             store.get(SourceHealthRecord, "source-health-github-audit-001"),

--- a/control-plane/tests/test_phase61_7_record_search_filter.py
+++ b/control-plane/tests/test_phase61_7_record_search_filter.py
@@ -14,6 +14,7 @@ if str(TESTS_ROOT) not in sys.path:
     sys.path.insert(0, str(TESTS_ROOT))
 
 from aegisops.control_plane.models import (
+    AlertRecord,
     DetectorLifecycleRecord,
     EvidenceRecord,
     FalsePositiveReviewRecord,
@@ -197,6 +198,46 @@ class Phase617RecordSearchFilterTests(ServicePersistenceTestBase):
         )
         with self.assertRaisesRegex(ValueError, "stale-cache"):
             service.persist_record(stale_source_health)
+
+    def test_record_search_preserves_reviewed_slice_source_family_fallback(self) -> None:
+        store, service, case, evidence_id, _reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        alert = store.get(AlertRecord, case.alert_id)
+        if not isinstance(alert, AlertRecord):
+            raise AssertionError("expected reviewed alert fixture")
+
+        alert_context_without_source = dict(alert.reviewed_context)
+        alert_context_without_source.pop("source", None)
+        case_context_without_source = dict(case.reviewed_context)
+        case_context_without_source.pop("source", None)
+        service.persist_record(
+            replace(alert, reviewed_context=alert_context_without_source)
+        )
+        service.persist_record(replace(case, reviewed_context=case_context_without_source))
+
+        snapshot = service.inspect_record_search(
+            query="github",
+            record_families=("alert", "case", "evidence"),
+            source_family="github_audit",
+        )
+        results = {
+            (result["record_family"], result["record_id"]): result
+            for result in snapshot.to_dict()["records"]
+        }
+
+        self.assertEqual(
+            results[("alert", alert.alert_id)]["source_family"],
+            "github_audit",
+        )
+        self.assertEqual(
+            results[("case", case.case_id)]["source_family"],
+            "github_audit",
+        )
+        self.assertEqual(
+            results[("evidence", evidence_id)]["source_family"],
+            "github_audit",
+        )
 
     def test_record_search_rejects_malformed_or_raw_source_queries(self) -> None:
         _store, service, case, _evidence_id, _reviewed_at = (

--- a/control-plane/tests/test_phase61_7_record_search_filter.py
+++ b/control-plane/tests/test_phase61_7_record_search_filter.py
@@ -199,7 +199,7 @@ class Phase617RecordSearchFilterTests(ServicePersistenceTestBase):
             service.persist_record(stale_source_health)
 
     def test_record_search_rejects_malformed_or_raw_source_queries(self) -> None:
-        _store, service, _case, _evidence_id, _reviewed_at = (
+        _store, service, case, _evidence_id, _reviewed_at = (
             self._build_phase19_in_scope_case()
         )
 
@@ -220,6 +220,36 @@ class Phase617RecordSearchFilterTests(ServicePersistenceTestBase):
                 query="github",
                 record_families=("native_detection",),
             )
+
+        reviewed_raw_content_evidence = EvidenceRecord(
+            evidence_id="evidence-reviewed-raw-content-only-001",
+            source_record_id="native-reviewed-content-only-001",
+            alert_id=case.alert_id,
+            case_id=case.case_id,
+            source_system="wazuh",
+            collector_identity="collector://wazuh/reviewed-content-only",
+            acquired_at=datetime(2026, 5, 15, 8, 0, tzinfo=timezone.utc),
+            derivation_relationship="native_detection_record",
+            lifecycle_state="collected",
+            provenance={"raw_only_marker": "needle-provenance-only"},
+            content={"message": "needle-content-only"},
+        )
+        service.persist_record(reviewed_raw_content_evidence)
+
+        raw_content_snapshot = service.inspect_record_search(
+            query="needle-content-only",
+            record_families=("evidence",),
+        )
+        self.assertNotIn(
+            reviewed_raw_content_evidence.evidence_id,
+            {
+                result["record_id"]
+                for result in raw_content_snapshot.to_dict()["records"]
+            },
+        )
+
+        field_name_snapshot = service.inspect_record_search(query="record_id")
+        self.assertEqual(field_name_snapshot.to_dict()["records"], [])
 
         raw_evidence = EvidenceRecord(
             evidence_id="evidence-raw-unlinked-001",

--- a/docs/phase-61-7-record-search-filter-validation.md
+++ b/docs/phase-61-7-record-search-filter-validation.md
@@ -1,0 +1,30 @@
+# Phase 61.7 Record Search Filter Validation
+
+- Validation status: PASS
+- Scope: AegisOps record search/filter MVP over reviewed AegisOps records.
+
+## Behavior
+
+The record search endpoint and operator page provide a read-only navigation aid over reviewed AegisOps records:
+
+- alerts
+- cases
+- evidence linked to reviewed alerts or cases
+- detector lifecycle records
+- false-positive review records
+- suppression proposal records
+- source-health records
+
+Results return reviewed-surface routes and `navigation_only` authority. They do not close cases, reconcile outcomes, approve detector changes, suppress signals, or promote raw source data into AegisOps workflow truth.
+
+## Negative Coverage
+
+Focused tests cover malformed query refusal, raw-source query refusal, unsupported search families, reviewed-record filtering, stale-cache refusal, and browser fail-closed handling for authority-leaking search results.
+
+## Verification Commands
+
+Run `bash scripts/verify-phase-61-7-record-search-filter.sh`.
+
+## Limitations
+
+This MVP is bounded to simple reviewed-record search and source-family/lifecycle filters. It is not a raw Wazuh query replacement, raw SIEM search surface, custom query workbench, or workflow truth source.

--- a/scripts/verify-phase-61-7-record-search-filter.sh
+++ b/scripts/verify-phase-61-7-record-search-filter.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv run python control-plane/tests/test_phase61_7_record_search_filter.py
+npm run test --workspace @aegisops/operator-ui -- OperatorRoutes.test.tsx


### PR DESCRIPTION
## Summary
- Add protected reviewed-record search endpoint over AegisOps reviewed records with navigation-only result authority.
- Add operator UI record search route with source-family filtering and fail-closed result validation.
- Add Phase 61.7 focused backend/UI tests, validation note, and verifier script.

## Verification
- uv run python control-plane/tests/test_phase61_7_record_search_filter.py
- uv run python -m unittest control-plane.tests.test_phase61_7_record_search_filter
- npm run typecheck --workspace @aegisops/operator-ui
- npm run test --workspace @aegisops/operator-ui -- OperatorRoutes.test.tsx
- bash scripts/test-verify-publishable-path-hygiene.sh
- bash scripts/verify-phase-61-7-record-search-filter.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1288 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1295 --config <supervisor-config-path>

## Authority Boundary
Search results are read-only navigation aids over reviewed AegisOps records. They cannot close cases, reconcile outcomes, approve detector changes, suppress signals, or promote raw source data into workflow truth.

Closes #1295
