### PR TITLE
61.8: Phase 61 closeout evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Canonical cross-phase boundary reference:
 - [Phase 59.4 AI disabled and degraded mode contract](docs/phase-59-4-ai-disabled-degraded-mode-contract.md) defines disabled and degraded AI posture, blocked AI generation, non-blocking workflow surfaces, operator explanations, and advisory-only authority.
 - [Phase 59.8 closeout evaluation](docs/phase-59-closeout-evaluation.md) records the AI governance foundation outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 60/66 handoff.
 - [Phase 60.9 closeout evaluation](docs/phase-60-closeout-evaluation.md) records the AI Daily Operations outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 61/62/66 handoff.
+- [Phase 61.8 closeout evaluation](docs/phase-61-closeout-evaluation.md) records the Minimum SIEM Replacement Breadth outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 62/66 handoff.
 - [Phase 58.5 upgrade and rollback plan contract](docs/phase-58-5-upgrade-rollback-plan-contract.md) defines reviewed upgrade-plan and rollback-plan evidence fields, failure states, and authority boundaries without implementing live upgrade or rollback execution.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
@@ -160,6 +161,8 @@ The Phase 59.8 closeout evaluation is defined by the [Phase 59.8 closeout evalua
 The Phase 59.4 AI disabled and degraded mode contract is defined by the [Phase 59.4 AI disabled and degraded mode contract](docs/phase-59-4-ai-disabled-degraded-mode-contract.md).
 
 The Phase 60.9 closeout evaluation is defined by the [Phase 60.9 closeout evaluation](docs/phase-60-closeout-evaluation.md).
+
+The Phase 61.8 closeout evaluation is defined by the [Phase 61.8 closeout evaluation](docs/phase-61-closeout-evaluation.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/phase-61-closeout-evaluation.md
+++ b/docs/phase-61-closeout-evaluation.md
@@ -1,0 +1,142 @@
+# Phase 61 Closeout Evaluation
+
+- **Status**: Accepted as Minimum SIEM Replacement Breadth before Phase 62 SOAR breadth, Phase 66 RC proof, Beta, RC, GA, and commercial replacement-readiness claims.
+- **Date**: 2026-05-16
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1288, #1289, #1290, #1291, #1292, #1293, #1294, #1295, #1296
+
+## Verdict
+
+Phase 61 is accepted as the Minimum SIEM Replacement Breadth slice for reviewed source catalog, detector lifecycle, detector activation review, false-positive review, suppression proposal, source-health dashboard, and AegisOps record search/filter workflows.
+
+The accepted breadth is enough to evaluate multiple source families and detector review posture inside the AegisOps operator experience. It is not a raw SIEM search replacement, raw Wazuh console replacement, custom rule authoring workbench, multi-site source management surface, Phase 62 automation breadth, Phase 66 RC proof, Beta, RC, GA, or commercial replacement readiness.
+
+AegisOps control-plane records remain authoritative for alert, case, evidence, detector lifecycle, false-positive review, suppression proposal, source-health record, search-result navigation, approval, action request, execution receipt, reconciliation, audit event, limitation, release, gate, and closeout truth.
+
+Wazuh state, source-native alert state, parser output, detector display state, source-health display state, operator UI state, browser state, AI output, optional evidence, verifier output, issue-lint output, and record-search result ordering remain subordinate context and cannot close, reconcile, approve, activate, disable, suppress, release, gate, or claim readiness without reviewed AegisOps workflow records.
+
+Phase 61 must reject missing child evidence, missing verifier output, raw Wazuh or source-native status as AegisOps truth, detector lifecycle skips, silent suppression, uncited or ownerless suppression, false-positive silent deletion, raw SIEM replacement claims, custom rule authoring expansion, network-heavy strategy shift, production secrets, workstation-local paths, and Phase 62/66/Beta/RC/GA/commercial-readiness claims.
+
+This closeout does not claim Phase 62 SOAR breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a commercial replacement for every SIEM/SOAR capability.
+
+## Child Issue Outcomes
+
+| Issue | Scope | Outcome |
+| --- | --- | --- |
+| #1288 | Epic: Phase 61 Minimum SIEM Replacement Breadth | Open until #1296 lands; accepted when this closeout, focused verifiers, focused backend/UI tests, authority-boundary checks, publishable path hygiene, and issue-lint pass. |
+| #1289 | Phase 61.1 source catalog contract | Closed. `docs/phase-61-minimum-source-catalog-contract.md`, source-family onboarding packages, validation notes, and focused verifier prove the reviewed minimum source catalog without broad marketplace or source-native authority expansion. |
+| #1290 | Phase 61.2 detector lifecycle record contract | Closed. `docs/phase-61-2-detector-lifecycle-record-contract.md`, backend record models, validation logic, migration, and tests prove reviewed detector lifecycle records with fail-closed source-catalog binding and no lifecycle skip. |
+| #1291 | Phase 61.3 detector activation review UI | Closed. `apps/operator-ui/src/app/operatorConsolePages/detectorActivationReviewPages.tsx` and `apps/operator-ui/src/app/OperatorRoutes.detectorActivationReview.testSuite.tsx` render reviewed detector posture without source-native active-state authority or mutating activate/disable controls. |
+| #1292 | Phase 61.4 false-positive review records | Closed. `FalsePositiveReviewRecord` model, validation, migration, validation note, and focused verifier prove reviewed false-positive records without silent deletion, source-signal hiding, or case closure authority. |
+| #1293 | Phase 61.5 suppression proposal workflow | Closed. `SuppressionProposalRecord` model, validation, migration, validation note, and focused verifier prove proposal-only suppression records with owner, citations, finite expiry, and no active suppression authority. |
+| #1294 | Phase 61.6 source-health dashboard | Closed. `SourceHealthRecord` model, source-health validation, migration, operator dashboard page, UI tests, and focused verifier prove reviewed source-health visibility while rejecting stale cache, source-native authority, and display-state authority. |
+| #1295 | Phase 61.7 AegisOps record search/filter MVP | Closed. `control-plane/aegisops/control_plane/inspection/record_search.py`, backend tests, operator search page, UI tests, validation note, and focused verifier prove read-only navigation over reviewed records without raw SIEM query or workflow truth authority. |
+| #1296 | Phase 61.8 Phase 61 closeout evaluation | Open until this document and focused closeout verifier land. |
+
+## Changed Files
+
+Phase 61 materially added or tightened these repo-owned surfaces:
+
+- `docs/phase-61-minimum-source-catalog-contract.md`
+- `docs/phase-61-1-source-catalog-contract-validation.md`
+- `docs/phase-61-2-detector-lifecycle-record-contract.md`
+- `docs/phase-61-2-detector-lifecycle-record-contract-validation.md`
+- `docs/phase-61-4-false-positive-review-records-validation.md`
+- `docs/phase-61-5-suppression-proposal-workflow-validation.md`
+- `docs/phase-61-7-record-search-filter-validation.md`
+- `docs/source-families/github-audit/onboarding-package.md`
+- `docs/source-families/entra-id/onboarding-package.md`
+- `docs/source-families/microsoft-365-audit/onboarding-package.md`
+- `docs/source-families/windows-security-and-endpoint/onboarding-package.md`
+- `control-plane/aegisops/control_plane/models.py`
+- `control-plane/aegisops/control_plane/record_validation.py`
+- `control-plane/aegisops/control_plane/inspection/record_search.py`
+- `control-plane/tests/test_phase61_detector_lifecycle_record_contract.py`
+- `control-plane/tests/test_phase61_7_record_search_filter.py`
+- `apps/operator-ui/src/app/operatorConsolePages/detectorActivationReviewPages.tsx`
+- `apps/operator-ui/src/app/operatorConsolePages/sourceHealthDashboardPages.tsx`
+- `apps/operator-ui/src/app/operatorConsolePages/recordSearchPages.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.detectorActivationReview.testSuite.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.sourceHealthDashboard.testSuite.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.recordSearch.testSuite.tsx`
+- `apps/operator-ui/src/operatorDataProvider/listSemantics.ts`
+- `postgres/control-plane/migrations/0014_phase_61_source_health_records.sql`
+- `scripts/verify-phase-61-1-source-catalog-contract.sh`
+- `scripts/verify-phase-61-2-detector-lifecycle-record-contract.sh`
+- `scripts/verify-phase-61-4-false-positive-review-records.sh`
+- `scripts/verify-phase-61-5-suppression-proposal-workflow.sh`
+- `scripts/verify-phase-61-6-source-health-dashboard.sh`
+- `scripts/verify-phase-61-7-record-search-filter.sh`
+- `scripts/verify-phase-61-8-closeout-evaluation.sh`
+- `scripts/test-verify-phase-61-8-closeout-evaluation.sh`
+
+## Behavior Before And After
+
+| Surface | Before Phase 61 | Accepted Phase 61 behavior |
+| --- | --- | --- |
+| Source catalog | Reviewed Wazuh profile and source-family material existed, but the minimum SIEM breadth catalog was not accepted as one Phase 61 baseline. | Reviewed source catalog covers Wazuh, GitHub audit, Entra ID, Microsoft 365 audit, and Windows endpoint detection-ready posture with source-native authority explicitly denied. |
+| Detector lifecycle | Detector activation evidence existed, but detector lifecycle records were not a reviewed AegisOps record family for Phase 61 breadth. | Detector lifecycle records support candidate, staging, active, disabled, rollback, and review-overdue states with owner, rollback owner, disable owner, audit references, and fail-closed source-catalog binding. |
+| Detector activation review UI | Operators lacked a bounded Phase 61 detector review page tied to lifecycle records. | Operator UI renders detector review posture as read-only context and refuses missing owners, malformed lifecycle state, stale display state, and source-native active-state shortcuts. |
+| False-positive review | False-positive context was not a reviewed Phase 61 record family. | False-positive review records preserve linked evidence, owner, disposition, dispute state, recurrence posture, and source signal handling without deleting source signals or closing cases. |
+| Suppression proposal | Suppression requests were not captured as proposal-only reviewed records. | Suppression proposal records require owner, citations, finite expiry, review cadence, bounded scope, and expected impact while keeping every suppression state proposal-only. |
+| Source-health dashboard | Source-health context was available in earlier projections but not as a Phase 61 reviewed dashboard surface. | Source-health records and dashboard rows show reviewed health posture while rejecting stale cache, raw-source authority, display-state authority, unreviewed catalog linkage, and lifecycle mismatch. |
+| Record search/filter | Operators lacked a bounded reviewed-record search/filter MVP for the new Phase 61 record families. | Search/filter returns navigation-only results over reviewed records and refuses raw-source queries, unsupported families, stale-cache results, and authority-leaking records. |
+
+## Verifier Evidence
+
+Focused Phase 61 and closeout verifiers that must pass:
+
+- `bash scripts/verify-phase-61-1-source-catalog-contract.sh`
+- `bash scripts/verify-phase-61-2-detector-lifecycle-record-contract.sh`
+- `bash scripts/verify-phase-61-4-false-positive-review-records.sh`
+- `bash scripts/verify-phase-61-5-suppression-proposal-workflow.sh`
+- `bash scripts/verify-phase-61-6-source-health-dashboard.sh`
+- `bash scripts/verify-phase-61-7-record-search-filter.sh`
+- `bash scripts/verify-phase-61-8-closeout-evaluation.sh`
+- `bash scripts/test-verify-phase-61-8-closeout-evaluation.sh`
+- `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+- `python3 -m unittest control-plane.tests.test_phase61_detector_lifecycle_record_contract`
+- `uv run python control-plane/tests/test_phase61_7_record_search_filter.py`
+- `npm --prefix apps/operator-ui test -- OperatorRoutes.test.tsx`
+- `npm run test --workspace @aegisops/operator-ui -- OperatorRoutes.test.tsx`
+- `npm run typecheck --workspace @aegisops/operator-ui`
+
+Issue-lint evidence:
+
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1288 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1289 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1290 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1291 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1292 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1293 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1294 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1295 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1296 --config <supervisor-config-path>`
+
+Focused negative behaviors covered:
+
+- Source catalog validation rejects missing owner, missing source-health boundary, source-native truth promotion, broad marketplace expansion, raw SIEM replacement claims, and unsupported family drift.
+- Detector lifecycle validation rejects unsupported source families, source-catalog mismatches, candidate-to-active skips, missing state-specific reason fields, source-native active-state shortcuts, and missing owners.
+- Detector activation review UI rejects missing owner, malformed lifecycle state, stale display state, source-native active-state authority, and write-capable activation, disable, or rollback controls.
+- False-positive review validation rejects silent source-signal deletion, source-history mutation, case closure from labels alone, missing review linkage, missing owner, and source-native false-positive truth.
+- Suppression proposal validation rejects active suppression authority, missing citations, missing owner, unbounded scope, missing finite expiry, source-history mutation, silent signal hiding, and case closure shortcuts.
+- Source-health validation and UI tests reject stale-cache source health, raw-source authority, display-state authority, unreviewed state, unreviewed catalog linkage, lifecycle mismatch, and dashboard-driven workflow truth.
+- Record search/filter tests reject malformed queries, raw-source queries, unsupported search families, stale-cache search results, authority-leaking results, and workflow mutation through search.
+- Path hygiene rejects workstation-local absolute paths in publishable docs, scripts, tests, prompts, and validation output.
+
+## Accepted Limitations
+
+- Phase 61 does not implement broad raw SIEM search replacement, raw Wazuh console replacement, or custom rule authoring.
+- Phase 61 does not implement multi-site source management, source marketplace breadth, or network-heavy strategy expansion.
+- Phase 61 does not implement autonomous approval, autonomous execution, autonomous reconciliation, autonomous case closure, autonomous detector activation, autonomous detector disablement, active suppression, source-truth creation, or policy bypass.
+- Phase 61 does not implement Phase 62 SOAR breadth, Phase 66 RC proof, Beta readiness, RC readiness, GA readiness, self-service commercial readiness, or commercial replacement readiness.
+- Phase 61 source-health, detector, false-positive, suppression, and search surfaces are reviewed AegisOps context only; they do not replace authoritative case, approval, execution, reconciliation, release, gate, or closeout records.
+
+## Phase 62 And Phase 66 Handoff
+
+Phase 62 can consume Phase 61 reviewed source catalog, detector lifecycle, false-positive review, suppression proposal, source-health dashboard, and record search/filter evidence as SIEM-breadth input only. Phase 62 must still implement SOAR breadth, action-family expansion, automation evidence, execution-quality gates, and reconciliation proof under its own issue wave.
+
+Phase 66 can consume Phase 61 as one RC evidence input for minimum SIEM replacement breadth. Phase 66 must still prove RC gates, first-user RC readiness, issue-lint and verifier completeness, rollout operational hygiene, support and restore evidence, SOAR breadth evidence, limitation ownership, and production rollout readiness outside this closeout.
+
+Phase 61 closeout is release and planning evidence only. It does not add source-native authority, write authority, active suppression, raw query replacement, rule-workbench expansion, SOAR automation breadth, RC proof, or readiness and replacement claims.

--- a/scripts/test-verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-61-8-closeout-evaluation.sh
@@ -178,7 +178,11 @@ assert_fails_with \
 
 colon_prefixed_absolute_path_repo="${workdir}/colon-prefixed-absolute-path"
 copy_valid_repo "${colon_prefixed_absolute_path_repo}"
-printf 'Run:/%s/example/Dev/codex-supervisor/dist/index.js.\n' "Users" \
+printf '%s\n' \
+  "Run:/${users_segment}/example/Dev/codex-supervisor/dist/index.js." \
+  "Path:/${home_segment}/alice/file." \
+  "Path:C:\\${users_segment}\\alice\\file." \
+  "Path:C:/${users_segment}/alice/file." \
   >>"${colon_prefixed_absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
 assert_fails_with \
   "${colon_prefixed_absolute_path_repo}" \

--- a/scripts/test-verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-61-8-closeout-evaluation.sh
@@ -66,8 +66,10 @@ url_path_repo="${workdir}/url-path"
 copy_valid_repo "${url_path_repo}"
 users_segment="Users"
 home_segment="home"
+root_segment="root"
 printf '%s\n' \
   "Reference URL: https://example.com/${home_segment}/docs/phase-61-closeout" \
+  "Reference URL: https://example.com/${root_segment}/docs/phase-61-closeout" \
   "Reference URL: https://example.com/C:/${users_segment}/docs/phase-61-closeout" \
   "Reference URL: https://example.com/search?artifact=/${users_segment}/example/Dev/codex-supervisor/dist/index.js" \
   >>"${url_path_repo}/docs/phase-61-closeout-evaluation.md"
@@ -155,6 +157,20 @@ assert_fails_with \
   "${raw_siem_overclaim_repo}" \
   "Forbidden Phase 61 closeout evaluation claim: Raw SIEM search replacement is complete"
 
+production_secret_overclaim_repo="${workdir}/production-secret-overclaim"
+copy_valid_repo "${production_secret_overclaim_repo}"
+printf '%s\n' "Production secrets are valid evidence for Phase 61." >>"${production_secret_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${production_secret_overclaim_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: production secrets are valid"
+
+phase61_production_secret_overclaim_repo="${workdir}/phase61-production-secret-overclaim"
+copy_valid_repo "${phase61_production_secret_overclaim_repo}"
+printf '%s\n' "Phase 61 accepts production secrets." >>"${phase61_production_secret_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${phase61_production_secret_overclaim_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: Phase 61 accepts production secrets"
+
 source_truth_repo="${workdir}/source-truth"
 copy_valid_repo "${source_truth_repo}"
 printf '%s\n' "Source-native status is AegisOps truth" >>"${source_truth_repo}/docs/phase-61-closeout-evaluation.md"
@@ -176,11 +192,19 @@ assert_fails_with \
   "${absolute_path_repo}" \
   "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
 
+root_absolute_path_repo="${workdir}/root-absolute-path"
+copy_valid_repo "${root_absolute_path_repo}"
+printf 'Run /%s/example/Dev/codex-supervisor/dist/index.js.\n' "${root_segment}" >>"${root_absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${root_absolute_path_repo}" \
+  "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
+
 colon_prefixed_absolute_path_repo="${workdir}/colon-prefixed-absolute-path"
 copy_valid_repo "${colon_prefixed_absolute_path_repo}"
 printf '%s\n' \
   "Run:/${users_segment}/example/Dev/codex-supervisor/dist/index.js." \
   "Path:/${home_segment}/alice/file." \
+  "Path:/${root_segment}/file." \
   "Path:C:\\${users_segment}\\alice\\file." \
   "Path:C:/${users_segment}/alice/file." \
   >>"${colon_prefixed_absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
@@ -196,6 +220,23 @@ assert_fails_with \
   "${file_url_absolute_path_repo}" \
   "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
 
+json_escaped_unix_absolute_path_repo="${workdir}/json-escaped-unix-absolute-path"
+copy_valid_repo "${json_escaped_unix_absolute_path_repo}"
+json_slash="\\/"
+printf 'Run "%s%s%s%s%s".\n' "${json_slash}" "Users" "${json_slash}" "example" "${json_slash}private.txt" \
+  >>"${json_escaped_unix_absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${json_escaped_unix_absolute_path_repo}" \
+  "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
+
+json_escaped_root_absolute_path_repo="${workdir}/json-escaped-root-absolute-path"
+copy_valid_repo "${json_escaped_root_absolute_path_repo}"
+printf 'Run "%s%s%sprivate.txt".\n' "${json_slash}" "${root_segment}" "${json_slash}" \
+  >>"${json_escaped_root_absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${json_escaped_root_absolute_path_repo}" \
+  "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
+
 absolute_path_windows_backslash_repo="${workdir}/absolute-path-windows-backslash"
 copy_valid_repo "${absolute_path_windows_backslash_repo}"
 windows_drive="C:"
@@ -204,6 +245,15 @@ windows_path="${windows_drive}${windows_sep}Users${windows_sep}example${windows_
 printf '%s\n' "Run ${windows_path}." >>"${absolute_path_windows_backslash_repo}/docs/phase-61-closeout-evaluation.md"
 assert_fails_with \
   "${absolute_path_windows_backslash_repo}" \
+  "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
+
+json_escaped_windows_backslash_repo="${workdir}/json-escaped-windows-backslash"
+copy_valid_repo "${json_escaped_windows_backslash_repo}"
+json_windows_sep="\\\\"
+printf '%s\n' "Run ${windows_drive}${json_windows_sep}${users_segment}${json_windows_sep}example${json_windows_sep}private.txt." \
+  >>"${json_escaped_windows_backslash_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${json_escaped_windows_backslash_repo}" \
   "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
 
 echo "Phase 61 closeout evaluation verifier tests passed."

--- a/scripts/test-verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-61-8-closeout-evaluation.sh
@@ -176,6 +176,14 @@ assert_fails_with \
   "${absolute_path_repo}" \
   "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
 
+colon_prefixed_absolute_path_repo="${workdir}/colon-prefixed-absolute-path"
+copy_valid_repo "${colon_prefixed_absolute_path_repo}"
+printf 'Run:/%s/example/Dev/codex-supervisor/dist/index.js.\n' "Users" \
+  >>"${colon_prefixed_absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${colon_prefixed_absolute_path_repo}" \
+  "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
+
 file_url_absolute_path_repo="${workdir}/file-url-absolute-path"
 copy_valid_repo "${file_url_absolute_path_repo}"
 printf 'Run file:///%s/example/Dev/codex-supervisor/dist/index.js.\n' "Users" \

--- a/scripts/test-verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-61-8-closeout-evaluation.sh
@@ -69,8 +69,15 @@ home_segment="home"
 printf '%s\n' \
   "Reference URL: https://example.com/${home_segment}/docs/phase-61-closeout" \
   "Reference URL: https://example.com/C:/${users_segment}/docs/phase-61-closeout" \
+  "Reference URL: https://example.com/search?artifact=/${users_segment}/example/Dev/codex-supervisor/dist/index.js" \
   >>"${url_path_repo}/docs/phase-61-closeout-evaluation.md"
 assert_passes "${url_path_repo}"
+
+relative_home_repo="${workdir}/relative-home"
+copy_valid_repo "${relative_home_repo}"
+printf '%s\n' "Relative fixture path: ./${home_segment}/example/Dev/codex-supervisor/dist/index.js" \
+  >>"${relative_home_repo}/docs/phase-61-closeout-evaluation.md"
+assert_passes "${relative_home_repo}"
 
 missing_doc_repo="${workdir}/missing-doc"
 mkdir -p "${missing_doc_repo}/docs"
@@ -167,6 +174,14 @@ copy_valid_repo "${absolute_path_repo}"
 printf 'Run /%s/example/Dev/codex-supervisor/dist/index.js.\n' "Users" >>"${absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
 assert_fails_with \
   "${absolute_path_repo}" \
+  "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
+
+file_url_absolute_path_repo="${workdir}/file-url-absolute-path"
+copy_valid_repo "${file_url_absolute_path_repo}"
+printf 'Run file:///%s/example/Dev/codex-supervisor/dist/index.js.\n' "Users" \
+  >>"${file_url_absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${file_url_absolute_path_repo}" \
   "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
 
 absolute_path_windows_backslash_repo="${workdir}/absolute-path-windows-backslash"

--- a/scripts/test-verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-61-8-closeout-evaluation.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-61-8-closeout-evaluation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fiq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+copy_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cp "${repo_root}/docs/phase-61-closeout-evaluation.md" "${target}/docs/phase-61-closeout-evaluation.md"
+  cp "${repo_root}/README.md" "${target}/README.md"
+}
+
+remove_doc_text() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-61-closeout-evaluation.md"
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+url_path_repo="${workdir}/url-path"
+copy_valid_repo "${url_path_repo}"
+users_segment="Users"
+home_segment="home"
+printf '%s\n' \
+  "Reference URL: https://example.com/${home_segment}/docs/phase-61-closeout" \
+  "Reference URL: https://example.com/C:/${users_segment}/docs/phase-61-closeout" \
+  >>"${url_path_repo}/docs/phase-61-closeout-evaluation.md"
+assert_passes "${url_path_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+mkdir -p "${missing_doc_repo}/docs"
+cp "${repo_root}/README.md" "${missing_doc_repo}/README.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 61 closeout evaluation: docs/phase-61-closeout-evaluation.md"
+
+missing_readme_canonical_bullet_repo="${workdir}/missing-readme-canonical-bullet"
+copy_valid_repo "${missing_readme_canonical_bullet_repo}"
+perl -0pi -e 's/- \[Phase 61\.8 closeout evaluation\]\(docs\/phase-61-closeout-evaluation\.md\)[^\n]*\n/- Phase 61.8 closeout evaluation\\n/' \
+  "${missing_readme_canonical_bullet_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_canonical_bullet_repo}" \
+  "Missing README canonical cross-phase boundary bullet: - [Phase 61.8 closeout evaluation](docs/phase-61-closeout-evaluation.md)"
+
+missing_readme_product_positioning_repo="${workdir}/missing-readme-product-positioning"
+copy_valid_repo "${missing_readme_product_positioning_repo}"
+perl -0pi -e 's/The Phase 61\.8 closeout evaluation is defined by the \[Phase 61\.8 closeout evaluation\]\(docs\/phase-61-closeout-evaluation\.md\)\./The Phase 61.8 closeout evaluation is defined by the Phase 61.8 closeout evaluation./' \
+  "${missing_readme_product_positioning_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_product_positioning_repo}" \
+  "Missing README Product positioning reference: The Phase 61.8 closeout evaluation is defined by the [Phase 61.8 closeout evaluation](docs/phase-61-closeout-evaluation.md)."
+
+missing_authority_repo="${workdir}/missing-authority"
+copy_valid_repo "${missing_authority_repo}"
+remove_doc_text "${missing_authority_repo}" \
+  "AegisOps control-plane records remain authoritative for alert, case, evidence, detector lifecycle, false-positive review, suppression proposal, source-health record, search-result navigation, approval, action request, execution receipt, reconciliation, audit event, limitation, release, gate, and closeout truth."
+assert_fails_with \
+  "${missing_authority_repo}" \
+  "Missing required Phase 61 closeout term in docs/phase-61-closeout-evaluation.md: AegisOps control-plane records remain authoritative"
+
+missing_child_repo="${workdir}/missing-child"
+copy_valid_repo "${missing_child_repo}"
+remove_doc_text "${missing_child_repo}" \
+  "| #1296 | Phase 61.8 Phase 61 closeout evaluation | Open until this document and focused closeout verifier land. |"
+assert_fails_with \
+  "${missing_child_repo}" \
+  "Missing required Phase 61 closeout term in docs/phase-61-closeout-evaluation.md: | #1296 | Phase 61.8 Phase 61 closeout evaluation | Open until this document and focused closeout verifier land. |"
+
+missing_issue_lint_repo="${workdir}/missing-issue-lint"
+copy_valid_repo "${missing_issue_lint_repo}"
+perl -0pi -e 's/- `node <codex-supervisor-root>\/dist\/index\.js issue-lint 1296 --config <supervisor-config-path>`.*\n//m' \
+  "${missing_issue_lint_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_issue_lint_repo}" \
+  'Missing required Phase 61 closeout term in docs/phase-61-closeout-evaluation.md: `node <codex-supervisor-root>/dist/index.js issue-lint 1296 --config <supervisor-config-path>`'
+
+missing_path_hygiene_repo="${workdir}/missing-path-hygiene"
+copy_valid_repo "${missing_path_hygiene_repo}"
+remove_doc_text "${missing_path_hygiene_repo}" \
+  "Path hygiene rejects workstation-local absolute paths in publishable docs, scripts, tests, prompts, and validation output."
+assert_fails_with \
+  "${missing_path_hygiene_repo}" \
+  "Missing required Phase 61 closeout term in docs/phase-61-closeout-evaluation.md: Path hygiene rejects workstation-local absolute paths in publishable docs, scripts, tests, prompts, and validation output."
+
+phase62_overclaim_repo="${workdir}/phase62-overclaim"
+copy_valid_repo "${phase62_overclaim_repo}"
+printf '%s\n' "Phase 62 SOAR breadth is complete" >>"${phase62_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${phase62_overclaim_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: Phase 62 SOAR breadth is complete"
+
+commercial_overclaim_repo="${workdir}/commercial-overclaim"
+copy_valid_repo "${commercial_overclaim_repo}"
+printf '%s\n' "AegisOps is a commercial replacement for every SIEM/SOAR capability" >>"${commercial_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${commercial_overclaim_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: AegisOps is a commercial replacement for every SIEM/SOAR capability"
+
+raw_siem_overclaim_repo="${workdir}/raw-siem-overclaim"
+copy_valid_repo "${raw_siem_overclaim_repo}"
+printf '%s\n' "Raw SIEM search replacement is complete" >>"${raw_siem_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${raw_siem_overclaim_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: Raw SIEM search replacement is complete"
+
+source_truth_repo="${workdir}/source-truth"
+copy_valid_repo "${source_truth_repo}"
+printf '%s\n' "Source-native status is AegisOps truth" >>"${source_truth_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${source_truth_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: Source-native status is AegisOps truth"
+
+silent_suppression_repo="${workdir}/silent-suppression"
+copy_valid_repo "${silent_suppression_repo}"
+printf '%s\n' "Silent suppression is allowed" >>"${silent_suppression_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${silent_suppression_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: Silent suppression is allowed"
+
+absolute_path_repo="${workdir}/absolute-path"
+copy_valid_repo "${absolute_path_repo}"
+printf 'Run /%s/example/Dev/codex-supervisor/dist/index.js.\n' "Users" >>"${absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_repo}" \
+  "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
+
+absolute_path_windows_backslash_repo="${workdir}/absolute-path-windows-backslash"
+copy_valid_repo "${absolute_path_windows_backslash_repo}"
+windows_drive="C:"
+windows_sep="\\"
+windows_path="${windows_drive}${windows_sep}Users${windows_sep}example${windows_sep}Dev${windows_sep}codex-supervisor${windows_sep}dist${windows_sep}index.js"
+printf '%s\n' "Run ${windows_path}." >>"${absolute_path_windows_backslash_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_windows_backslash_repo}" \
+  "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
+
+echo "Phase 61 closeout evaluation verifier tests passed."

--- a/scripts/test-verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-61-8-closeout-evaluation.sh
@@ -178,6 +178,34 @@ assert_fails_with \
   "${phase61_production_secret_overclaim_repo}" \
   "Forbidden Phase 61 closeout evaluation claim: Phase 61 accepts production secrets"
 
+production_secret_without_overclaim_repo="${workdir}/production-secret-without-overclaim"
+copy_valid_repo "${production_secret_without_overclaim_repo}"
+printf '%s\n' "Production secrets can be trusted without review." >>"${production_secret_without_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${production_secret_without_overclaim_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: production secrets accepted as valid evidence"
+
+ga_overclaim_repo="${workdir}/ga-overclaim"
+copy_valid_repo "${ga_overclaim_repo}"
+printf '%s\n' "AegisOps is generally available (GA)." >>"${ga_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${ga_overclaim_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: release-readiness overclaim"
+
+rc_overclaim_repo="${workdir}/rc-overclaim"
+copy_valid_repo "${rc_overclaim_repo}"
+printf '%s\n' "AegisOps is release candidate (RC)." >>"${rc_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${rc_overclaim_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: release-readiness overclaim"
+
+phase66_overclaim_repo="${workdir}/phase66-overclaim"
+copy_valid_repo "${phase66_overclaim_repo}"
+printf '%s\n' "Phase 66 RC proof is fully complete." >>"${phase66_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${phase66_overclaim_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: release-readiness overclaim"
+
 source_truth_repo="${workdir}/source-truth"
 copy_valid_repo "${source_truth_repo}"
 printf '%s\n' "Source-native status is AegisOps truth" >>"${source_truth_repo}/docs/phase-61-closeout-evaluation.md"
@@ -206,6 +234,17 @@ assert_fails_with \
   "${root_absolute_path_repo}" \
   "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
 
+bare_absolute_path_repo="${workdir}/bare-absolute-path"
+copy_valid_repo "${bare_absolute_path_repo}"
+printf '%s\n' \
+  "Run /${home_segment}/" \
+  "Run /${root_segment}/" \
+  "Run C:/${users_segment}/" \
+  >>"${bare_absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${bare_absolute_path_repo}" \
+  "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
+
 colon_prefixed_absolute_path_repo="${workdir}/colon-prefixed-absolute-path"
 copy_valid_repo "${colon_prefixed_absolute_path_repo}"
 printf '%s\n' \
@@ -225,6 +264,16 @@ printf 'Run file:///%s/example/Dev/codex-supervisor/dist/index.js.\n' "Users" \
   >>"${file_url_absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
 assert_fails_with \
   "${file_url_absolute_path_repo}" \
+  "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
+
+localhost_file_url_absolute_path_repo="${workdir}/localhost-file-url-absolute-path"
+copy_valid_repo "${localhost_file_url_absolute_path_repo}"
+printf '%s\n' \
+  "Run file://localhost/${users_segment}/example/private.txt." \
+  "Run file:/C:/${users_segment}/example/private.txt." \
+  >>"${localhost_file_url_absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${localhost_file_url_absolute_path_repo}" \
   "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
 
 json_escaped_unix_absolute_path_repo="${workdir}/json-escaped-unix-absolute-path"

--- a/scripts/test-verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-61-8-closeout-evaluation.sh
@@ -159,9 +159,16 @@ assert_fails_with \
 
 production_secret_overclaim_repo="${workdir}/production-secret-overclaim"
 copy_valid_repo "${production_secret_overclaim_repo}"
-printf '%s\n' "Production secrets are valid evidence for Phase 61." >>"${production_secret_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
+printf '%s\n' "Production secrets are allowed." >>"${production_secret_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
 assert_fails_with \
   "${production_secret_overclaim_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: production secrets are allowed"
+
+production_secret_valid_overclaim_repo="${workdir}/production-secret-valid-overclaim"
+copy_valid_repo "${production_secret_valid_overclaim_repo}"
+printf '%s\n' "Production secrets are valid evidence for Phase 61." >>"${production_secret_valid_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${production_secret_valid_overclaim_repo}" \
   "Forbidden Phase 61 closeout evaluation claim: production secrets are valid"
 
 phase61_production_secret_overclaim_repo="${workdir}/phase61-production-secret-overclaim"

--- a/scripts/test-verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-61-8-closeout-evaluation.sh
@@ -185,6 +185,18 @@ assert_fails_with \
   "${production_secret_without_overclaim_repo}" \
   "Forbidden Phase 61 closeout evaluation claim: production secrets accepted as valid evidence"
 
+production_secret_used_overclaim_repo="${workdir}/production-secret-used-overclaim"
+copy_valid_repo "${production_secret_used_overclaim_repo}"
+printf '%s\n' "Production secrets may be used for validation." >>"${production_secret_used_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${production_secret_used_overclaim_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: production secrets accepted as valid evidence"
+
+production_secret_negative_context_repo="${workdir}/production-secret-negative-context"
+copy_valid_repo "${production_secret_negative_context_repo}"
+printf '%s\n' "Production secrets are not yet allowed." >>"${production_secret_negative_context_repo}/docs/phase-61-closeout-evaluation.md"
+assert_passes "${production_secret_negative_context_repo}"
+
 ga_overclaim_repo="${workdir}/ga-overclaim"
 copy_valid_repo "${ga_overclaim_repo}"
 printf '%s\n' "AegisOps is generally available (GA)." >>"${ga_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
@@ -204,6 +216,13 @@ copy_valid_repo "${phase66_overclaim_repo}"
 printf '%s\n' "Phase 66 RC proof is fully complete." >>"${phase66_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
 assert_fails_with \
   "${phase66_overclaim_repo}" \
+  "Forbidden Phase 61 closeout evaluation claim: release-readiness overclaim"
+
+ga_reached_overclaim_repo="${workdir}/ga-reached-overclaim"
+copy_valid_repo "${ga_reached_overclaim_repo}"
+printf '%s\n' "AegisOps reached GA." >>"${ga_reached_overclaim_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${ga_reached_overclaim_repo}" \
   "Forbidden Phase 61 closeout evaluation claim: release-readiness overclaim"
 
 source_truth_repo="${workdir}/source-truth"
@@ -256,6 +275,14 @@ printf '%s\n' \
   >>"${colon_prefixed_absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
 assert_fails_with \
   "${colon_prefixed_absolute_path_repo}" \
+  "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
+
+assignment_prefixed_absolute_path_repo="${workdir}/assignment-prefixed-absolute-path"
+copy_valid_repo "${assignment_prefixed_absolute_path_repo}"
+printf '%s\n' "Run=/${users_segment}/example/Dev/codex-supervisor/dist/index.js." \
+  >>"${assignment_prefixed_absolute_path_repo}/docs/phase-61-closeout-evaluation.md"
+assert_fails_with \
+  "${assignment_prefixed_absolute_path_repo}" \
   "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected"
 
 file_url_absolute_path_repo="${workdir}/file-url-absolute-path"

--- a/scripts/verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/verify-phase-61-8-closeout-evaluation.sh
@@ -154,10 +154,14 @@ forbidden_claims=(
   "phase 61 validates production secrets"
 )
 
-for forbidden in "${forbidden_claims[@]}"; do
-  if tr '[:upper:]' '[:lower:]' < "${absolute_doc_path}" | \
+forbidden_claim_text() {
+  tr '[:upper:]' '[:lower:]' < "${absolute_doc_path}" | \
     grep -Fxv -- "${allowed_non_claim_line_lower}" | \
-    grep -Fq -- "${forbidden}"; then
+    grep -Fxv -- "${required_rejection_line_lower}"
+}
+
+for forbidden in "${forbidden_claims[@]}"; do
+  if forbidden_claim_text | grep -Fq -e "${forbidden}"; then
     echo "Forbidden Phase 61 closeout evaluation claim: ${forbidden}" >&2
     exit 1
   fi

--- a/scripts/verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/verify-phase-61-8-closeout-evaluation.sh
@@ -145,8 +145,10 @@ forbidden_claims=(
   "ownerless suppression is allowed"
   "uncited suppression is allowed"
   "production secrets are accepted"
+  "production secrets are allowed"
   "production secrets are valid"
   "phase 61 accepts production secrets"
+  "phase 61 allows production secrets"
   "phase 61 validates production secrets"
 )
 

--- a/scripts/verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/verify-phase-61-8-closeout-evaluation.sh
@@ -102,8 +102,10 @@ windows_backslash_home_pattern='[a-z]:\\+users\\+'
 windows_slash_home_pattern='[a-z]:/'"users"'/'
 unix_local_path_pattern="(${macos_home_pattern}|${linux_home_pattern}|${root_home_pattern})"
 local_path_pattern="(${unix_local_path_pattern}|${windows_backslash_home_pattern}|${windows_slash_home_pattern})"
-absolute_path_pattern="(${absolute_path_boundary}${local_path_pattern}|file:///?${local_path_pattern})[^[:space:]]+"
-colon_prefixed_absolute_path_pattern="${absolute_path_boundary}[^[:space:]/:]+:${local_path_pattern}[^[:space:]]+"
+local_path_with_tail="${local_path_pattern}[^[:space:]]*"
+file_uri_local_path_pattern="file:(//localhost)?/*${local_path_with_tail}"
+absolute_path_pattern="(${absolute_path_boundary}${local_path_with_tail}|${file_uri_local_path_pattern})"
+colon_prefixed_absolute_path_pattern="${absolute_path_boundary}[^[:space:]/:]+:${local_path_with_tail}"
 if path_hygiene_text "${absolute_doc_path}" | grep -Eq -- "${absolute_path_pattern}" || \
    path_hygiene_text "${readme_path}" | grep -Eq -- "${absolute_path_pattern}" || \
    path_hygiene_text "${absolute_doc_path}" | grep -Eq -- "${colon_prefixed_absolute_path_pattern}" || \
@@ -161,13 +163,43 @@ for forbidden in "${forbidden_claims[@]}"; do
   fi
 done
 
+if awk -v allowed_non_claim_line="${allowed_non_claim_line_lower}" \
+  -v required_rejection_line="${required_rejection_line_lower}" '
+  {
+    line = tolower($0)
+    if (line == allowed_non_claim_line || line == required_rejection_line) {
+      next
+    }
+    negative_context = line ~ /(must reject|must fail|fail closed|fails validation|invalid|must not|cannot|not satisfy|rejected|not valid|does not|not yet|pre-ga|excluded|redacted|forbidden)/
+    if (negative_context) {
+      next
+    }
+    if (line ~ /(^|[^[:alnum:]_])aegisops[[:space:]]+is[[:space:]]+(beta|rc|ga|release candidate|generally available|self-service commercially ready|commercially ready)([^[:alnum:]_]|$)/) {
+      found = 1
+    }
+    if (line ~ /(^|[^[:alnum:]_])aegisops[[:space:]]+is[[:space:]]+generally[[:space:]]+available[[:space:]]*(\(|$)/) {
+      found = 1
+    }
+    if (line ~ /(^|[^[:alnum:]_])phase 6[26][[:space:]]+(soar breadth|rc proof)([^.]*[[:space:]])?(is[[:space:]]+)?(fully[[:space:]]+)?(complete|ready|verified|accepted|done)([^[:alnum:]_]|$)/) {
+      found = 1
+    }
+    if (line ~ /(^|[^[:alnum:]_])phase 61([^.]*[[:space:]])?(proves|ships|includes|validates)[[:space:]]+(rc readiness|ga readiness|commercial replacement readiness)([^[:alnum:]_]|$)/) {
+      found = 1
+    }
+  }
+  END { exit(found ? 0 : 1) }
+' "${absolute_doc_path}"; then
+  echo "Forbidden Phase 61 closeout evaluation claim: release-readiness overclaim" >&2
+  exit 1
+fi
+
 if awk -v required_rejection_line="${required_rejection_line_lower}" '
   {
     line = tolower($0)
     if (line == required_rejection_line) {
       next
     }
-    negative_context = line ~ /(must reject|must fail|fail closed|fails validation|invalid|must not|cannot|not satisfy|rejected|not valid|does not|without|excluded|redacted|forbidden)/
+    negative_context = line ~ /(must reject|must fail|fail closed|fails validation|invalid|must not|cannot|not satisfy|rejected|not valid|does not|excluded|redacted|forbidden)/
     if (negative_context) {
       next
     }

--- a/scripts/verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/verify-phase-61-8-closeout-evaluation.sh
@@ -94,8 +94,11 @@ linux_home_pattern="/""home/"
 windows_backslash_home_pattern='[a-z]:\\+users\\+'
 windows_slash_home_pattern='[a-z]:/'"users"'/'
 absolute_path_pattern="(${absolute_path_boundary}(${macos_home_pattern}|${linux_home_pattern}|${windows_backslash_home_pattern}|${windows_slash_home_pattern})|file:///?(${macos_home_pattern}|${linux_home_pattern}|${windows_backslash_home_pattern}|${windows_slash_home_pattern}))[^[:space:]]+"
+colon_prefixed_absolute_path_pattern="${absolute_path_boundary}[^[:space:]/:]+:(${macos_home_pattern}|${linux_home_pattern}|${windows_backslash_home_pattern}|${windows_slash_home_pattern})[^[:space:]]+"
 if tr '[:upper:]' '[:lower:]' < "${absolute_doc_path}" | grep -Eq -- "${absolute_path_pattern}" || \
-   tr '[:upper:]' '[:lower:]' < "${readme_path}" | grep -Eq -- "${absolute_path_pattern}"; then
+   tr '[:upper:]' '[:lower:]' < "${readme_path}" | grep -Eq -- "${absolute_path_pattern}" || \
+   tr '[:upper:]' '[:lower:]' < "${absolute_doc_path}" | grep -Eq -- "${colon_prefixed_absolute_path_pattern}" || \
+   tr '[:upper:]' '[:lower:]' < "${readme_path}" | grep -Eq -- "${colon_prefixed_absolute_path_pattern}"; then
   echo "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected" >&2
   exit 1
 fi

--- a/scripts/verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/verify-phase-61-8-closeout-evaluation.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+doc_path="docs/phase-61-closeout-evaluation.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+readme_path="${repo_root}/README.md"
+
+require_phrase() {
+  local file="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" "${file}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -s "${absolute_doc_path}" ]]; then
+  echo "Missing Phase 61 closeout evaluation: ${doc_path}" >&2
+  exit 1
+fi
+
+if [[ ! -s "${readme_path}" ]]; then
+  echo "Missing README for Phase 61 closeout link check: README.md" >&2
+  exit 1
+fi
+
+require_phrase "${readme_path}" "- [Phase 61.8 closeout evaluation](docs/phase-61-closeout-evaluation.md)" "README canonical cross-phase boundary bullet"
+require_phrase "${readme_path}" "The Phase 61.8 closeout evaluation is defined by the [Phase 61.8 closeout evaluation](docs/phase-61-closeout-evaluation.md)." "README Product positioning reference"
+
+required_phrases=()
+while IFS= read -r phrase; do
+  required_phrases+=("${phrase}")
+done <<'EOF_PHRASE'
+# Phase 61 Closeout Evaluation
+**Status**: Accepted as Minimum SIEM Replacement Breadth before Phase 62 SOAR breadth, Phase 66 RC proof, Beta, RC, GA, and commercial replacement-readiness claims.
+**Related Issues**: #1288, #1289, #1290, #1291, #1292, #1293, #1294, #1295, #1296
+Phase 61 is accepted as the Minimum SIEM Replacement Breadth slice for reviewed source catalog, detector lifecycle, detector activation review, false-positive review, suppression proposal, source-health dashboard, and AegisOps record search/filter workflows.
+AegisOps control-plane records remain authoritative for alert, case, evidence, detector lifecycle, false-positive review, suppression proposal, source-health record, search-result navigation, approval, action request, execution receipt, reconciliation, audit event, limitation, release, gate, and closeout truth.
+Wazuh state, source-native alert state, parser output, detector display state, source-health display state, operator UI state, browser state, AI output, optional evidence, verifier output, issue-lint output, and record-search result ordering remain subordinate context and cannot close, reconcile, approve, activate, disable, suppress, release, gate, or claim readiness without reviewed AegisOps workflow records.
+Phase 61 must reject missing child evidence, missing verifier output, raw Wazuh or source-native status as AegisOps truth, detector lifecycle skips, silent suppression, uncited or ownerless suppression, false-positive silent deletion, raw SIEM replacement claims, custom rule authoring expansion, network-heavy strategy shift, production secrets, workstation-local paths, and Phase 62/66/Beta/RC/GA/commercial-readiness claims.
+This closeout does not claim Phase 62 SOAR breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a commercial replacement for every SIEM/SOAR capability.
+| #1288 | Epic: Phase 61 Minimum SIEM Replacement Breadth | Open until #1296 lands; accepted when this closeout, focused verifiers, focused backend/UI tests, authority-boundary checks, publishable path hygiene, and issue-lint pass. |
+| #1296 | Phase 61.8 Phase 61 closeout evaluation | Open until this document and focused closeout verifier land. |
+`apps/operator-ui/src/app/OperatorRoutes.detectorActivationReview.testSuite.tsx`
+`apps/operator-ui/src/app/OperatorRoutes.sourceHealthDashboard.testSuite.tsx`
+`apps/operator-ui/src/app/OperatorRoutes.recordSearch.testSuite.tsx`
+`control-plane/tests/test_phase61_detector_lifecycle_record_contract.py`
+`control-plane/tests/test_phase61_7_record_search_filter.py`
+`bash scripts/verify-phase-61-1-source-catalog-contract.sh`
+`bash scripts/verify-phase-61-2-detector-lifecycle-record-contract.sh`
+`bash scripts/verify-phase-61-4-false-positive-review-records.sh`
+`bash scripts/verify-phase-61-5-suppression-proposal-workflow.sh`
+`bash scripts/verify-phase-61-6-source-health-dashboard.sh`
+`bash scripts/verify-phase-61-7-record-search-filter.sh`
+`bash scripts/verify-phase-61-8-closeout-evaluation.sh`
+`bash scripts/test-verify-phase-61-8-closeout-evaluation.sh`
+`bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`
+`bash scripts/verify-publishable-path-hygiene.sh`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1288 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1289 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1290 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1291 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1292 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1293 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1294 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1295 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1296 --config <supervisor-config-path>`
+Source catalog validation rejects missing owner, missing source-health boundary, source-native truth promotion, broad marketplace expansion, raw SIEM replacement claims, and unsupported family drift.
+Detector lifecycle validation rejects unsupported source families, source-catalog mismatches, candidate-to-active skips, missing state-specific reason fields, source-native active-state shortcuts, and missing owners.
+False-positive review validation rejects silent source-signal deletion, source-history mutation, case closure from labels alone, missing review linkage, missing owner, and source-native false-positive truth.
+Suppression proposal validation rejects active suppression authority, missing citations, missing owner, unbounded scope, missing finite expiry, source-history mutation, silent signal hiding, and case closure shortcuts.
+Source-health validation and UI tests reject stale-cache source health, raw-source authority, display-state authority, unreviewed state, unreviewed catalog linkage, lifecycle mismatch, and dashboard-driven workflow truth.
+Record search/filter tests reject malformed queries, raw-source queries, unsupported search families, stale-cache search results, authority-leaking results, and workflow mutation through search.
+Path hygiene rejects workstation-local absolute paths in publishable docs, scripts, tests, prompts, and validation output.
+Phase 61 does not implement Phase 62 SOAR breadth, Phase 66 RC proof, Beta readiness, RC readiness, GA readiness, self-service commercial readiness, or commercial replacement readiness.
+Phase 62 can consume Phase 61 reviewed source catalog, detector lifecycle, false-positive review, suppression proposal, source-health dashboard, and record search/filter evidence as SIEM-breadth input only.
+Phase 66 can consume Phase 61 as one RC evidence input for minimum SIEM replacement breadth.
+Phase 61 closeout is release and planning evidence only.
+EOF_PHRASE
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${absolute_doc_path}" "${phrase}" "required Phase 61 closeout term in ${doc_path}"
+done
+
+absolute_path_boundary='(^|[[:space:](){}<>;,!?.`"'\''=])'
+macos_home_pattern="/""users/"
+linux_home_pattern="/""home/"
+windows_backslash_home_pattern='[a-z]:\\+users\\+'
+windows_slash_home_pattern='[a-z]:/'"users"'/'
+absolute_path_pattern="${absolute_path_boundary}(${macos_home_pattern}|${linux_home_pattern}|${windows_backslash_home_pattern}|${windows_slash_home_pattern})[^ ]+"
+if tr '[:upper:]' '[:lower:]' < "${absolute_doc_path}" | grep -Eq -- "${absolute_path_pattern}" || \
+   tr '[:upper:]' '[:lower:]' < "${readme_path}" | grep -Eq -- "${absolute_path_pattern}"; then
+  echo "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+allowed_non_claim_line="This closeout does not claim Phase 62 SOAR breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a commercial replacement for every SIEM/SOAR capability."
+allowed_non_claim_line_lower="$(printf '%s' "${allowed_non_claim_line}" | tr '[:upper:]' '[:lower:]')"
+
+forbidden_claims=(
+  "phase 62 soar breadth is complete"
+  "phase 66 rc proof is complete"
+  "aegisops is beta"
+  "aegisops is rc"
+  "aegisops is ga"
+  "aegisops is self-service commercially ready"
+  "aegisops is a commercial replacement for every siem/soar capability"
+  "phase 61 proves rc readiness"
+  "phase 61 proves ga readiness"
+  "phase 61 proves commercial replacement readiness"
+  "raw siem search replacement is complete"
+  "raw wazuh console replacement is complete"
+  "custom rule authoring workbench is complete"
+  "multi-site source management is complete"
+  "wazuh status closes aegisops cases"
+  "source-native alert state closes aegisops records"
+  "source-native status is aegisops truth"
+  "detector display state activates detectors"
+  "source-health display state is workflow truth"
+  "source-health dashboard closes cases"
+  "record search result ordering is workflow truth"
+  "false-positive review silently deletes source signals"
+  "suppression proposal actively suppresses source signals"
+  "silent suppression is allowed"
+  "ownerless suppression is allowed"
+  "uncited suppression is allowed"
+)
+
+for forbidden in "${forbidden_claims[@]}"; do
+  if tr '[:upper:]' '[:lower:]' < "${absolute_doc_path}" | \
+    grep -Fxv -- "${allowed_non_claim_line_lower}" | \
+    grep -Fq -- "${forbidden}"; then
+    echo "Forbidden Phase 61 closeout evaluation claim: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 61 closeout evaluation records minimum SIEM breadth outcomes, bounded authority posture, verifier evidence, accepted limitations, and Phase 62/66 handoff."

--- a/scripts/verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/verify-phase-61-8-closeout-evaluation.sh
@@ -88,12 +88,12 @@ for phrase in "${required_phrases[@]}"; do
   require_phrase "${absolute_doc_path}" "${phrase}" "required Phase 61 closeout term in ${doc_path}"
 done
 
-absolute_path_boundary='(^|[[:space:](){}<>;,!?.`"'\''=])'
+absolute_path_boundary='(^|[[:space:](){}<>;,!?`"'\''])'
 macos_home_pattern="/""users/"
 linux_home_pattern="/""home/"
 windows_backslash_home_pattern='[a-z]:\\+users\\+'
 windows_slash_home_pattern='[a-z]:/'"users"'/'
-absolute_path_pattern="${absolute_path_boundary}(${macos_home_pattern}|${linux_home_pattern}|${windows_backslash_home_pattern}|${windows_slash_home_pattern})[^ ]+"
+absolute_path_pattern="(${absolute_path_boundary}(${macos_home_pattern}|${linux_home_pattern}|${windows_backslash_home_pattern}|${windows_slash_home_pattern})|file:///?(${macos_home_pattern}|${linux_home_pattern}|${windows_backslash_home_pattern}|${windows_slash_home_pattern}))[^[:space:]]+"
 if tr '[:upper:]' '[:lower:]' < "${absolute_doc_path}" | grep -Eq -- "${absolute_path_pattern}" || \
    tr '[:upper:]' '[:lower:]' < "${readme_path}" | grep -Eq -- "${absolute_path_pattern}"; then
   echo "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected" >&2

--- a/scripts/verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/verify-phase-61-8-closeout-evaluation.sh
@@ -88,23 +88,34 @@ for phrase in "${required_phrases[@]}"; do
   require_phrase "${absolute_doc_path}" "${phrase}" "required Phase 61 closeout term in ${doc_path}"
 done
 
+path_hygiene_text() {
+  local file="$1"
+
+  tr '[:upper:]' '[:lower:]' < "${file}" | sed 's#\\/#/#g'
+}
+
 absolute_path_boundary='(^|[[:space:](){}<>;,!?`"'\''])'
 macos_home_pattern="/""users/"
 linux_home_pattern="/""home/"
+root_home_pattern="/""root/"
 windows_backslash_home_pattern='[a-z]:\\+users\\+'
 windows_slash_home_pattern='[a-z]:/'"users"'/'
-absolute_path_pattern="(${absolute_path_boundary}(${macos_home_pattern}|${linux_home_pattern}|${windows_backslash_home_pattern}|${windows_slash_home_pattern})|file:///?(${macos_home_pattern}|${linux_home_pattern}|${windows_backslash_home_pattern}|${windows_slash_home_pattern}))[^[:space:]]+"
-colon_prefixed_absolute_path_pattern="${absolute_path_boundary}[^[:space:]/:]+:(${macos_home_pattern}|${linux_home_pattern}|${windows_backslash_home_pattern}|${windows_slash_home_pattern})[^[:space:]]+"
-if tr '[:upper:]' '[:lower:]' < "${absolute_doc_path}" | grep -Eq -- "${absolute_path_pattern}" || \
-   tr '[:upper:]' '[:lower:]' < "${readme_path}" | grep -Eq -- "${absolute_path_pattern}" || \
-   tr '[:upper:]' '[:lower:]' < "${absolute_doc_path}" | grep -Eq -- "${colon_prefixed_absolute_path_pattern}" || \
-   tr '[:upper:]' '[:lower:]' < "${readme_path}" | grep -Eq -- "${colon_prefixed_absolute_path_pattern}"; then
+unix_local_path_pattern="(${macos_home_pattern}|${linux_home_pattern}|${root_home_pattern})"
+local_path_pattern="(${unix_local_path_pattern}|${windows_backslash_home_pattern}|${windows_slash_home_pattern})"
+absolute_path_pattern="(${absolute_path_boundary}${local_path_pattern}|file:///?${local_path_pattern})[^[:space:]]+"
+colon_prefixed_absolute_path_pattern="${absolute_path_boundary}[^[:space:]/:]+:${local_path_pattern}[^[:space:]]+"
+if path_hygiene_text "${absolute_doc_path}" | grep -Eq -- "${absolute_path_pattern}" || \
+   path_hygiene_text "${readme_path}" | grep -Eq -- "${absolute_path_pattern}" || \
+   path_hygiene_text "${absolute_doc_path}" | grep -Eq -- "${colon_prefixed_absolute_path_pattern}" || \
+   path_hygiene_text "${readme_path}" | grep -Eq -- "${colon_prefixed_absolute_path_pattern}"; then
   echo "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected" >&2
   exit 1
 fi
 
 allowed_non_claim_line="This closeout does not claim Phase 62 SOAR breadth is complete, Phase 66 RC proof is complete, AegisOps is Beta, RC, GA, self-service commercially ready, or a commercial replacement for every SIEM/SOAR capability."
 allowed_non_claim_line_lower="$(printf '%s' "${allowed_non_claim_line}" | tr '[:upper:]' '[:lower:]')"
+required_rejection_line="Phase 61 must reject missing child evidence, missing verifier output, raw Wazuh or source-native status as AegisOps truth, detector lifecycle skips, silent suppression, uncited or ownerless suppression, false-positive silent deletion, raw SIEM replacement claims, custom rule authoring expansion, network-heavy strategy shift, production secrets, workstation-local paths, and Phase 62/66/Beta/RC/GA/commercial-readiness claims."
+required_rejection_line_lower="$(printf '%s' "${required_rejection_line}" | tr '[:upper:]' '[:lower:]')"
 
 forbidden_claims=(
   "phase 62 soar breadth is complete"
@@ -133,6 +144,10 @@ forbidden_claims=(
   "silent suppression is allowed"
   "ownerless suppression is allowed"
   "uncited suppression is allowed"
+  "production secrets are accepted"
+  "production secrets are valid"
+  "phase 61 accepts production secrets"
+  "phase 61 validates production secrets"
 )
 
 for forbidden in "${forbidden_claims[@]}"; do
@@ -143,5 +158,28 @@ for forbidden in "${forbidden_claims[@]}"; do
     exit 1
   fi
 done
+
+if awk -v required_rejection_line="${required_rejection_line_lower}" '
+  {
+    line = tolower($0)
+    if (line == required_rejection_line) {
+      next
+    }
+    negative_context = line ~ /(must reject|must fail|fail closed|fails validation|invalid|must not|cannot|not satisfy|rejected|not valid|does not|without|excluded|redacted|forbidden)/
+    if (negative_context) {
+      next
+    }
+    if (line ~ /(^|[^[:alnum:]_])(production|prod|live)[- ]?secrets?[[:space:]]+(are|is|count as|counts as|may be|can be|remain|stays|accepted as|treated as|allowed as)[[:space:]]+([^.]*[^[:alnum:]_])?(valid|trusted|accepted|allowed|ready|verified|sufficient)([^[:alnum:]_]|$)/) {
+      found = 1
+    }
+    if (line ~ /(^|[^[:alnum:]_])phase 61[[:space:]]+(accepts|validates|proves|ships|includes|uses)[[:space:]]+([^.]*[[:space:]])?production[- ]?secrets?([^[:alnum:]_]|$)/) {
+      found = 1
+    }
+  }
+  END { exit(found ? 0 : 1) }
+' "${absolute_doc_path}"; then
+  echo "Forbidden Phase 61 closeout evaluation claim: production secrets accepted as valid evidence" >&2
+  exit 1
+fi
 
 echo "Phase 61 closeout evaluation records minimum SIEM breadth outcomes, bounded authority posture, verifier evidence, accepted limitations, and Phase 62/66 handoff."

--- a/scripts/verify-phase-61-8-closeout-evaluation.sh
+++ b/scripts/verify-phase-61-8-closeout-evaluation.sh
@@ -105,11 +105,12 @@ local_path_pattern="(${unix_local_path_pattern}|${windows_backslash_home_pattern
 local_path_with_tail="${local_path_pattern}[^[:space:]]*"
 file_uri_local_path_pattern="file:(//localhost)?/*${local_path_with_tail}"
 absolute_path_pattern="(${absolute_path_boundary}${local_path_with_tail}|${file_uri_local_path_pattern})"
-colon_prefixed_absolute_path_pattern="${absolute_path_boundary}[^[:space:]/:]+:${local_path_with_tail}"
+assignment_path_boundary='(^|[[:space:](){}<>;,!`"'\''])'
+assignment_prefixed_absolute_path_pattern="${assignment_path_boundary}[^[:space:]/:=?&]+[:=]${local_path_with_tail}"
 if path_hygiene_text "${absolute_doc_path}" | grep -Eq -- "${absolute_path_pattern}" || \
    path_hygiene_text "${readme_path}" | grep -Eq -- "${absolute_path_pattern}" || \
-   path_hygiene_text "${absolute_doc_path}" | grep -Eq -- "${colon_prefixed_absolute_path_pattern}" || \
-   path_hygiene_text "${readme_path}" | grep -Eq -- "${colon_prefixed_absolute_path_pattern}"; then
+   path_hygiene_text "${absolute_doc_path}" | grep -Eq -- "${assignment_prefixed_absolute_path_pattern}" || \
+   path_hygiene_text "${readme_path}" | grep -Eq -- "${assignment_prefixed_absolute_path_pattern}"; then
   echo "Forbidden Phase 61 closeout evaluation: workstation-local absolute path detected" >&2
   exit 1
 fi
@@ -184,6 +185,9 @@ if awk -v allowed_non_claim_line="${allowed_non_claim_line_lower}" \
     if (line ~ /(^|[^[:alnum:]_])aegisops[[:space:]]+is[[:space:]]+generally[[:space:]]+available[[:space:]]*(\(|$)/) {
       found = 1
     }
+    if (line ~ /(^|[^[:alnum:]_])aegisops[[:space:]]+(reached|reaches|achieved|achieves|entered|enters|shipped|ships)[[:space:]]+(beta|rc|ga|release candidate|general availability|generally available|self-service commercial readiness|self-service commercially ready|commercial readiness|commercially ready)([^[:alnum:]_]|$)/) {
+      found = 1
+    }
     if (line ~ /(^|[^[:alnum:]_])phase 6[26][[:space:]]+(soar breadth|rc proof)([^.]*[[:space:]])?(is[[:space:]]+)?(fully[[:space:]]+)?(complete|ready|verified|accepted|done)([^[:alnum:]_]|$)/) {
       found = 1
     }
@@ -203,11 +207,14 @@ if awk -v required_rejection_line="${required_rejection_line_lower}" '
     if (line == required_rejection_line) {
       next
     }
-    negative_context = line ~ /(must reject|must fail|fail closed|fails validation|invalid|must not|cannot|not satisfy|rejected|not valid|does not|excluded|redacted|forbidden)/
+    negative_context = line ~ /(must reject|must fail|fail closed|fails validation|invalid|must not|cannot|not satisfy|rejected|not valid|not yet|does not|excluded|redacted|forbidden)/
     if (negative_context) {
       next
     }
     if (line ~ /(^|[^[:alnum:]_])(production|prod|live)[- ]?secrets?[[:space:]]+(are|is|count as|counts as|may be|can be|remain|stays|accepted as|treated as|allowed as)[[:space:]]+([^.]*[^[:alnum:]_])?(valid|trusted|accepted|allowed|ready|verified|sufficient)([^[:alnum:]_]|$)/) {
+      found = 1
+    }
+    if (line ~ /(^|[^[:alnum:]_])(production|prod|live)[- ]?secrets?[[:space:]]+(are|is|may be|can be|could be|will be|should be|must be)[[:space:]]+used([[:space:]]+(for|as|in)[^.]*|[^[:alnum:]_]|$)/) {
       found = 1
     }
     if (line ~ /(^|[^[:alnum:]_])phase 61[[:space:]]+(accepts|validates|proves|ships|includes|uses)[[:space:]]+([^.]*[[:space:]])?production[- ]?secrets?([^[:alnum:]_]|$)/) {


### PR DESCRIPTION
## Summary
- Add the Phase 61 closeout evaluation for Minimum SIEM Replacement Breadth.
- Add the focused Phase 61.8 closeout verifier and verifier negative tests.
- Link the Phase 61.8 closeout from the README canonical boundary references.

## Verification
- `bash scripts/verify-phase-61-1-source-catalog-contract.sh`
- `bash scripts/verify-phase-61-2-detector-lifecycle-record-contract.sh`
- `bash scripts/verify-phase-61-4-false-positive-review-records.sh`
- `bash scripts/verify-phase-61-5-suppression-proposal-workflow.sh`
- `bash scripts/verify-phase-61-6-source-health-dashboard.sh`
- `bash scripts/verify-phase-61-7-record-search-filter.sh`
- `bash scripts/verify-phase-61-8-closeout-evaluation.sh`
- `bash scripts/test-verify-phase-61-8-closeout-evaluation.sh`
- `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `npm run typecheck --workspace @aegisops/operator-ui`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1288 --config <supervisor-config-path>` through `1296`

Closes #1296