### PR TITLE
Extract Phase 61 record validators

### DIFF
--- a/control-plane/aegisops/control_plane/phase61_record_validators.py
+++ b/control-plane/aegisops/control_plane/phase61_record_validators.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+from .models import (
+    ControlPlaneRecord,
+    DetectorLifecycleRecord,
+    FalsePositiveReviewRecord,
+    SourceHealthRecord,
+    SuppressionProposalRecord,
+)
+
+
+_DETECTOR_LIFECYCLE_STATES: frozenset[str] = frozenset(
+    {
+        "candidate",
+        "staging",
+        "active",
+        "disabled",
+        "rollback",
+        "review-overdue",
+    }
+)
+_DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY: dict[str, frozenset[str]] = {
+    "wazuh_detection": frozenset(
+        {"docs/phase-61-minimum-source-catalog-contract.md"}
+    ),
+    "github_audit": frozenset(
+        {
+            "docs/source-families/github-audit/onboarding-package.md",
+            "docs/source-families/github-audit/detector-activation-candidates/repository-admin-membership-change.md",
+        }
+    ),
+    "microsoft_365_audit": frozenset(
+        {"docs/source-families/microsoft-365-audit/onboarding-package.md"}
+    ),
+    "entra_id": frozenset(
+        {
+            "docs/source-families/entra-id/onboarding-package.md",
+            "docs/source-families/entra-id/detector-activation-candidates/privileged-role-assignment.md",
+        }
+    ),
+    "windows_security_endpoint": frozenset(
+        {"docs/source-families/windows-security-and-endpoint/onboarding-package.md"}
+    ),
+}
+_DETECTOR_STATE_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
+    "disabled": ("disabled_reason",),
+    "rollback": ("rollback_reason",),
+    "review-overdue": ("review_overdue_reason",),
+}
+_DETECTOR_REASON_FIELDS = frozenset(
+    {"disabled_reason", "rollback_reason", "review_overdue_reason"}
+)
+
+_FALSE_POSITIVE_REVIEW_DISPOSITIONS = frozenset(
+    {
+        "benign_activity",
+        "expected_activity",
+        "duplicate_signal",
+        "needs_detector_tuning",
+        "recurring_benign_activity",
+    }
+)
+_FALSE_POSITIVE_REVIEW_DISPUTE_STATES = frozenset(
+    {"undisputed", "disputed", "resolved"}
+)
+_FALSE_POSITIVE_REVIEW_RECURRENCE_POSTURES = frozenset(
+    {
+        "single_reviewed_instance",
+        "recurring_reviewed_pattern",
+        "recurrence_under_review",
+    }
+)
+_FALSE_POSITIVE_REVIEW_SOURCE_SIGNAL_HANDLING = frozenset(
+    {"preserve_source_signal", "preserve_and_escalate_for_tuning"}
+)
+_SUPPRESSION_PROPOSAL_SCOPES = frozenset(
+    {
+        "detector_case_context",
+        "detector_alert_context",
+        "detector_evidence_context",
+        "reviewed_recurring_pattern",
+    }
+)
+_SUPPRESSION_PROPOSAL_SOURCE_SIGNAL_HANDLING = frozenset(
+    {"preserve_source_signal", "preserve_and_escalate_for_review"}
+)
+_SOURCE_HEALTH_STATES = frozenset(
+    {
+        "available",
+        "degraded",
+        "unavailable",
+        "stale_source",
+        "missing_agent",
+        "parser_failure",
+        "volume_anomaly",
+        "credential_degraded",
+        "detector_drift",
+        "mismatched",
+    }
+)
+_SOURCE_HEALTH_DETECTOR_DRIFT_STATES = frozenset(
+    {"none", "review_required", "mismatched"}
+)
+_SOURCE_HEALTH_CREDENTIAL_POSTURES = frozenset(
+    {"reviewed", "degraded", "unavailable"}
+)
+
+
+def is_phase61_record_family(record: ControlPlaneRecord) -> bool:
+    return isinstance(
+        record,
+        (
+            DetectorLifecycleRecord,
+            FalsePositiveReviewRecord,
+            SuppressionProposalRecord,
+            SourceHealthRecord,
+        ),
+    )
+
+
+def validate_phase61_record(record: ControlPlaneRecord) -> bool:
+    if isinstance(record, DetectorLifecycleRecord):
+        _validate_detector_lifecycle_record(record)
+        return True
+    if isinstance(record, FalsePositiveReviewRecord):
+        _validate_false_positive_review_record(record)
+        return True
+    if isinstance(record, SuppressionProposalRecord):
+        _validate_suppression_proposal_record(record)
+        return True
+    if isinstance(record, SourceHealthRecord):
+        _validate_source_health_record(record)
+        return True
+    return False
+
+
+def _has_linkage_value(value: object) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip() != ""
+    if isinstance(value, (tuple, list, set, frozenset)):
+        return any(_has_linkage_value(item) for item in value)
+    return True
+
+
+def _require_any_linkage(
+    record: ControlPlaneRecord,
+    field_names: tuple[str, ...],
+) -> None:
+    if any(_has_linkage_value(getattr(record, field_name)) for field_name in field_names):
+        return
+    required_fields = ", ".join(field_names)
+    raise ValueError(
+        f"{record.record_family} record {record.record_id!r} requires at least one linkage field: "
+        f"{required_fields}"
+    )
+
+
+def _require_non_empty_tuple(
+    record: ControlPlaneRecord,
+    field_name: str,
+) -> None:
+    values = _require_tuple_or_list(record, field_name)
+    if len(values) >= 1:
+        return
+    raise ValueError(
+        f"{record.record_family} record {record.record_id!r} requires non-empty {field_name}"
+    )
+
+
+def _require_tuple_or_list(
+    record: ControlPlaneRecord,
+    field_name: str,
+) -> tuple[object, ...] | list[object]:
+    values = getattr(record, field_name)
+    if isinstance(values, (tuple, list)):
+        return values
+    raise ValueError(
+        f"{record.record_family} record {record.record_id!r} requires {field_name} "
+        "to be a tuple/list"
+    )
+
+
+def _require_non_blank_fields(
+    record: ControlPlaneRecord,
+    field_names: tuple[str, ...],
+) -> None:
+    for field_name in field_names:
+        if _has_linkage_value(getattr(record, field_name)):
+            continue
+        raise ValueError(
+            f"{record.record_family} record {record.record_id!r} requires non-blank {field_name}"
+        )
+
+
+def _validate_source_catalog_binding(
+    record: (
+        DetectorLifecycleRecord
+        | FalsePositiveReviewRecord
+        | SuppressionProposalRecord
+        | SourceHealthRecord
+    ),
+) -> tuple[str, str]:
+    source_family = record.source_family.strip()
+    if source_family not in _DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY:
+        raise ValueError(
+            f"{record.record_family} record {record.record_id!r} has unsupported "
+            f"source_family {record.source_family!r}; expected one of "
+            f"{sorted(_DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY)!r}"
+        )
+    source_catalog_entry = record.source_catalog_entry.strip()
+    if (
+        source_catalog_entry
+        not in _DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY[source_family]
+    ):
+        raise ValueError(
+            f"{record.record_family} record {record.record_id!r} has unsupported "
+            f"source_catalog_entry {record.source_catalog_entry!r} for "
+            f"source_family {source_family!r}; expected one of "
+            f"{sorted(_DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY[source_family])!r}"
+        )
+    return source_family, source_catalog_entry
+
+
+def _validate_non_blank_sequence_entries(
+    record: ControlPlaneRecord,
+    values: tuple[object, ...] | list[object],
+    field_name: str,
+) -> None:
+    for value in values:
+        if not isinstance(value, str) or not _has_linkage_value(value):
+            raise ValueError(
+                f"{record.record_family} record {record.record_id!r} requires "
+                f"non-blank {field_name} entries"
+            )
+
+
+def _validate_detector_lifecycle_record(record: DetectorLifecycleRecord) -> None:
+    _require_non_blank_fields(
+        record,
+        (
+            "owner",
+            "source_family",
+            "source_catalog_entry",
+            "detector_identifier",
+            "expected_signal_posture",
+            "review_cadence",
+            "rollback_owner",
+            "disable_owner",
+        ),
+    )
+    _require_non_empty_tuple(record, "lifecycle_audit_references")
+    _validate_non_blank_sequence_entries(
+        record,
+        record.lifecycle_audit_references,
+        "lifecycle_audit_references",
+    )
+    _validate_source_catalog_binding(record)
+
+    expected_reason_fields = frozenset(
+        _DETECTOR_STATE_REQUIRED_FIELDS.get(record.lifecycle_state, ())
+    )
+    for field_name in _DETECTOR_REASON_FIELDS:
+        reason_value = getattr(record, field_name)
+        if field_name in expected_reason_fields:
+            if not _has_linkage_value(reason_value):
+                raise ValueError(
+                    f"detector_lifecycle record {record.record_id!r} in state "
+                    f"{record.lifecycle_state!r} requires non-blank {field_name}"
+                )
+            continue
+        if _has_linkage_value(reason_value):
+            raise ValueError(
+                f"detector_lifecycle record {record.record_id!r} in state "
+                f"{record.lifecycle_state!r} must not set {field_name}; expected reason fields "
+                f"{sorted(expected_reason_fields)!r}"
+            )
+
+
+def _validate_false_positive_review_record(
+    record: FalsePositiveReviewRecord,
+) -> None:
+    _require_non_blank_fields(
+        record,
+        (
+            "detector_lifecycle_id",
+            "source_family",
+            "source_catalog_entry",
+            "owner",
+            "disposition",
+            "disposition_rationale",
+            "dispute_state",
+            "recurrence_posture",
+            "source_signal_handling",
+        ),
+    )
+    _require_non_empty_tuple(record, "review_evidence_references")
+    _require_tuple_or_list(record, "evidence_ids")
+    _require_any_linkage(record, ("alert_id", "case_id", "evidence_ids"))
+    if record.alert_id is None and record.case_id is None:
+        _require_non_empty_tuple(record, "evidence_ids")
+    _validate_non_blank_sequence_entries(record, record.evidence_ids, "evidence_ids")
+    _validate_non_blank_sequence_entries(
+        record,
+        record.review_evidence_references,
+        "review_evidence_references",
+    )
+    _validate_source_catalog_binding(record)
+    if record.disposition not in _FALSE_POSITIVE_REVIEW_DISPOSITIONS:
+        raise ValueError(
+            f"false_positive_review record {record.record_id!r} has invalid disposition "
+            f"{record.disposition!r}; expected one of "
+            f"{sorted(_FALSE_POSITIVE_REVIEW_DISPOSITIONS)!r}"
+        )
+    if record.dispute_state not in _FALSE_POSITIVE_REVIEW_DISPUTE_STATES:
+        raise ValueError(
+            f"false_positive_review record {record.record_id!r} has invalid dispute_state "
+            f"{record.dispute_state!r}; expected one of "
+            f"{sorted(_FALSE_POSITIVE_REVIEW_DISPUTE_STATES)!r}"
+        )
+    if record.recurrence_posture not in _FALSE_POSITIVE_REVIEW_RECURRENCE_POSTURES:
+        raise ValueError(
+            f"false_positive_review record {record.record_id!r} has invalid "
+            f"recurrence_posture {record.recurrence_posture!r}; expected one of "
+            f"{sorted(_FALSE_POSITIVE_REVIEW_RECURRENCE_POSTURES)!r}"
+        )
+    if (
+        record.source_signal_handling
+        not in _FALSE_POSITIVE_REVIEW_SOURCE_SIGNAL_HANDLING
+    ):
+        raise ValueError(
+            f"false_positive_review record {record.record_id!r} must preserve source "
+            "signals and may not delete, hide, or silently suppress source-native truth"
+        )
+    if record.dispute_state == "disputed" and record.lifecycle_state != "disputed":
+        raise ValueError(
+            f"false_positive_review record {record.record_id!r} disputed reviews must "
+            "use lifecycle_state 'disputed'"
+        )
+    if (
+        record.dispute_state != "disputed"
+        and record.lifecycle_state == "disputed"
+    ):
+        raise ValueError(
+            f"false_positive_review record {record.record_id!r} lifecycle_state "
+            "'disputed' requires dispute_state 'disputed'"
+        )
+    if (
+        record.disposition == "recurring_benign_activity"
+        and record.recurrence_posture != "recurring_reviewed_pattern"
+    ):
+        raise ValueError(
+            f"false_positive_review record {record.record_id!r} repeated false positives "
+            "require recurrence_posture 'recurring_reviewed_pattern'"
+        )
+
+
+def _validate_suppression_proposal_record(
+    record: SuppressionProposalRecord,
+) -> None:
+    _require_non_blank_fields(
+        record,
+        (
+            "detector_lifecycle_id",
+            "source_family",
+            "source_catalog_entry",
+            "owner",
+            "rationale",
+            "review_cadence",
+            "expected_signal_impact",
+            "scope",
+            "source_signal_handling",
+        ),
+    )
+    _require_non_empty_tuple(record, "citation_references")
+    _require_tuple_or_list(record, "evidence_ids")
+    _require_any_linkage(record, ("alert_id", "case_id", "evidence_ids"))
+    if record.alert_id is None and record.case_id is None:
+        _require_non_empty_tuple(record, "evidence_ids")
+    _validate_non_blank_sequence_entries(record, record.evidence_ids, "evidence_ids")
+    _validate_non_blank_sequence_entries(
+        record,
+        record.citation_references,
+        "citation_references",
+    )
+    if record.expires_at is None:
+        raise ValueError(
+            f"suppression_proposal record {record.record_id!r} must set a finite expires_at"
+        )
+    _validate_source_catalog_binding(record)
+    if record.scope not in _SUPPRESSION_PROPOSAL_SCOPES:
+        raise ValueError(
+            f"suppression_proposal record {record.record_id!r} has invalid scope "
+            f"{record.scope!r}; expected one of {sorted(_SUPPRESSION_PROPOSAL_SCOPES)!r}"
+        )
+    if record.source_signal_handling not in _SUPPRESSION_PROPOSAL_SOURCE_SIGNAL_HANDLING:
+        raise ValueError(
+            f"suppression_proposal record {record.record_id!r} must preserve source "
+            "signals and may not delete, hide, silently suppress, or apply source-native truth"
+        )
+
+
+def _validate_source_health_record(record: SourceHealthRecord) -> None:
+    _require_non_blank_fields(
+        record,
+        (
+            "source_family",
+            "source_catalog_entry",
+            "health_state",
+            "reviewed_state",
+            "detector_drift",
+            "credential_posture",
+            "operator_visible_reason",
+        ),
+    )
+    _require_non_empty_tuple(record, "evidence_references")
+    _validate_non_blank_sequence_entries(
+        record,
+        record.evidence_references,
+        "evidence_references",
+    )
+
+    _validate_source_catalog_binding(record)
+    if record.health_state not in _SOURCE_HEALTH_STATES:
+        raise ValueError(
+            f"source_health record {record.record_id!r} has invalid health_state "
+            f"{record.health_state!r}; expected one of "
+            f"{sorted(_SOURCE_HEALTH_STATES)!r}"
+        )
+    if record.reviewed_state != record.lifecycle_state:
+        raise ValueError(
+            f"source_health record {record.record_id!r} requires reviewed_state to match lifecycle_state"
+        )
+    if record.detector_drift not in _SOURCE_HEALTH_DETECTOR_DRIFT_STATES:
+        raise ValueError(
+            f"source_health record {record.record_id!r} has invalid detector_drift "
+            f"{record.detector_drift!r}; expected one of "
+            f"{sorted(_SOURCE_HEALTH_DETECTOR_DRIFT_STATES)!r}"
+        )
+    if record.credential_posture not in _SOURCE_HEALTH_CREDENTIAL_POSTURES:
+        raise ValueError(
+            f"source_health record {record.record_id!r} has invalid credential_posture "
+            f"{record.credential_posture!r}; expected one of "
+            f"{sorted(_SOURCE_HEALTH_CREDENTIAL_POSTURES)!r}"
+        )
+    if record.observed_at > record.reviewed_at:
+        raise ValueError(
+            f"source_health record {record.record_id!r} requires observed_at <= reviewed_at"
+        )
+    if record.source_native_authority or record.display_state_authority:
+        raise ValueError(
+            f"source_health record {record.record_id!r} must remain subordinate "
+            "operational context and cannot become workflow truth"
+        )
+    if record.cache_sourced:
+        raise ValueError(
+            f"source_health record {record.record_id!r} must not be cache sourced; "
+            "stale-cache source health is refused"
+        )
+
+
+__all__ = [
+    "_DETECTOR_LIFECYCLE_STATES",
+    "is_phase61_record_family",
+    "validate_phase61_record",
+]

--- a/control-plane/aegisops/control_plane/record_validation.py
+++ b/control-plane/aegisops/control_plane/record_validation.py
@@ -15,7 +15,6 @@ from .models import (
     ControlPlaneRecord,
     DetectorLifecycleRecord,
     EvidenceRecord,
-    FalsePositiveReviewRecord,
     HuntRecord,
     HuntRunRecord,
     LeadRecord,
@@ -24,7 +23,10 @@ from .models import (
     ReconciliationRecord,
     RecommendationRecord,
     SourceHealthRecord,
-    SuppressionProposalRecord,
+)
+from .phase61_record_validators import (
+    _DETECTOR_LIFECYCLE_STATES,
+    validate_phase61_record,
 )
 
 
@@ -32,18 +34,6 @@ _TICKET_REFERENCE_URL_PATTERN = re.compile(
     r"^https://[^/?#\s]+([/?#][^\s]*)?$",
     re.IGNORECASE,
 )
-
-_DETECTOR_LIFECYCLE_STATES: frozenset[str] = frozenset(
-    {
-        "candidate",
-        "staging",
-        "active",
-        "disabled",
-        "rollback",
-        "review-overdue",
-    }
-)
-
 
 _LIFECYCLE_STATES_BY_FAMILY: dict[str, frozenset[str]] = {
     "alert": frozenset(
@@ -212,91 +202,6 @@ _LIFECYCLE_STATES_BY_FAMILY: dict[str, frozenset[str]] = {
     ),
     "source_health": frozenset({"reviewed", "superseded", "withdrawn"}),
 }
-_DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY: dict[str, frozenset[str]] = {
-    "wazuh_detection": frozenset(
-        {"docs/phase-61-minimum-source-catalog-contract.md"}
-    ),
-    "github_audit": frozenset(
-        {
-            "docs/source-families/github-audit/onboarding-package.md",
-            "docs/source-families/github-audit/detector-activation-candidates/repository-admin-membership-change.md",
-        }
-    ),
-    "microsoft_365_audit": frozenset(
-        {"docs/source-families/microsoft-365-audit/onboarding-package.md"}
-    ),
-    "entra_id": frozenset(
-        {
-            "docs/source-families/entra-id/onboarding-package.md",
-            "docs/source-families/entra-id/detector-activation-candidates/privileged-role-assignment.md",
-        }
-    ),
-    "windows_security_endpoint": frozenset(
-        {"docs/source-families/windows-security-and-endpoint/onboarding-package.md"}
-    ),
-}
-_DETECTOR_STATE_REQUIRED_FIELDS: dict[str, tuple[str, ...]] = {
-    "disabled": ("disabled_reason",),
-    "rollback": ("rollback_reason",),
-    "review-overdue": ("review_overdue_reason",),
-}
-_DETECTOR_REASON_FIELDS = frozenset(
-    {"disabled_reason", "rollback_reason", "review_overdue_reason"}
-)
-
-_FALSE_POSITIVE_REVIEW_DISPOSITIONS = frozenset(
-    {
-        "benign_activity",
-        "expected_activity",
-        "duplicate_signal",
-        "needs_detector_tuning",
-        "recurring_benign_activity",
-    }
-)
-_FALSE_POSITIVE_REVIEW_DISPUTE_STATES = frozenset(
-    {"undisputed", "disputed", "resolved"}
-)
-_FALSE_POSITIVE_REVIEW_RECURRENCE_POSTURES = frozenset(
-    {
-        "single_reviewed_instance",
-        "recurring_reviewed_pattern",
-        "recurrence_under_review",
-    }
-)
-_FALSE_POSITIVE_REVIEW_SOURCE_SIGNAL_HANDLING = frozenset(
-    {"preserve_source_signal", "preserve_and_escalate_for_tuning"}
-)
-_SUPPRESSION_PROPOSAL_SCOPES = frozenset(
-    {
-        "detector_case_context",
-        "detector_alert_context",
-        "detector_evidence_context",
-        "reviewed_recurring_pattern",
-    }
-)
-_SUPPRESSION_PROPOSAL_SOURCE_SIGNAL_HANDLING = frozenset(
-    {"preserve_source_signal", "preserve_and_escalate_for_review"}
-)
-_SOURCE_HEALTH_STATES = frozenset(
-    {
-        "available",
-        "degraded",
-        "unavailable",
-        "stale_source",
-        "missing_agent",
-        "parser_failure",
-        "volume_anomaly",
-        "credential_degraded",
-        "detector_drift",
-        "mismatched",
-    }
-)
-_SOURCE_HEALTH_DETECTOR_DRIFT_STATES = frozenset(
-    {"none", "review_required", "mismatched"}
-)
-_SOURCE_HEALTH_CREDENTIAL_POSTURES = frozenset(
-    {"reviewed", "degraded", "unavailable"}
-)
 
 _RECONCILIATION_INGEST_DISPOSITIONS = frozenset(
     {
@@ -458,17 +363,7 @@ def _require_non_blank_fields(
 def _validate_record(record: ControlPlaneRecord) -> None:
     _validate_lifecycle_state(record)
 
-    if isinstance(record, DetectorLifecycleRecord):
-        _validate_detector_lifecycle_record(record)
-        return
-    if isinstance(record, FalsePositiveReviewRecord):
-        _validate_false_positive_review_record(record)
-        return
-    if isinstance(record, SuppressionProposalRecord):
-        _validate_suppression_proposal_record(record)
-        return
-    if isinstance(record, SourceHealthRecord):
-        _validate_source_health_record(record)
+    if validate_phase61_record(record):
         return
     if isinstance(record, AnalyticSignalRecord):
         _require_any_linkage(
@@ -560,318 +455,6 @@ def _validate_record(record: ControlPlaneRecord) -> None:
         _validate_coordination_reference_fields(record)
         return
     raise TypeError(f"Unsupported control-plane record type: {type(record).__name__}")
-
-
-def _validate_detector_lifecycle_record(record: DetectorLifecycleRecord) -> None:
-    _require_non_blank_fields(
-        record,
-        (
-            "owner",
-            "source_family",
-            "source_catalog_entry",
-            "detector_identifier",
-            "expected_signal_posture",
-            "review_cadence",
-            "rollback_owner",
-            "disable_owner",
-        ),
-    )
-    _require_non_empty_tuple(record, "lifecycle_audit_references")
-    for audit_reference in record.lifecycle_audit_references:
-        if not isinstance(audit_reference, str) or not _has_linkage_value(audit_reference):
-            raise ValueError(
-                f"{record.record_family} record {record.record_id!r} requires non-blank "
-                f"lifecycle_audit_references entries"
-            )
-    source_family = record.source_family.strip()
-    if source_family not in _DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY:
-        raise ValueError(
-            f"detector_lifecycle record {record.record_id!r} has unsupported source_family "
-            f"{record.source_family!r}; expected one of "
-            f"{sorted(_DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY)!r}"
-        )
-    source_catalog_entry = record.source_catalog_entry.strip()
-    if (
-        source_catalog_entry
-        not in _DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY[source_family]
-    ):
-        raise ValueError(
-            f"detector_lifecycle record {record.record_id!r} has unsupported source_catalog_entry "
-            f"{record.source_catalog_entry!r} for source_family {source_family!r}; expected one of "
-            f"{sorted(_DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY[source_family])!r}"
-        )
-
-    expected_reason_fields = frozenset(
-        _DETECTOR_STATE_REQUIRED_FIELDS.get(record.lifecycle_state, ())
-    )
-    for field_name in _DETECTOR_REASON_FIELDS:
-        reason_value = getattr(record, field_name)
-        if field_name in expected_reason_fields:
-            if not _has_linkage_value(reason_value):
-                raise ValueError(
-                    f"detector_lifecycle record {record.record_id!r} in state "
-                    f"{record.lifecycle_state!r} requires non-blank {field_name}"
-                )
-            continue
-        if _has_linkage_value(reason_value):
-            raise ValueError(
-                f"detector_lifecycle record {record.record_id!r} in state "
-                f"{record.lifecycle_state!r} must not set {field_name}; expected reason fields "
-                f"{sorted(expected_reason_fields)!r}"
-            )
-
-
-def _validate_false_positive_review_record(
-    record: FalsePositiveReviewRecord,
-) -> None:
-    _require_non_blank_fields(
-        record,
-        (
-            "detector_lifecycle_id",
-            "source_family",
-            "source_catalog_entry",
-            "owner",
-            "disposition",
-            "disposition_rationale",
-            "dispute_state",
-            "recurrence_posture",
-            "source_signal_handling",
-        ),
-    )
-    _require_non_empty_tuple(record, "review_evidence_references")
-    _require_tuple_or_list(record, "evidence_ids")
-    _require_any_linkage(record, ("alert_id", "case_id", "evidence_ids"))
-    if record.alert_id is None and record.case_id is None:
-        _require_non_empty_tuple(record, "evidence_ids")
-    for evidence_id in record.evidence_ids:
-        if not isinstance(evidence_id, str) or not _has_linkage_value(evidence_id):
-            raise ValueError(
-                f"{record.record_family} record {record.record_id!r} requires "
-                "non-blank evidence_ids entries"
-            )
-    for evidence_reference in record.review_evidence_references:
-        if not isinstance(evidence_reference, str) or not _has_linkage_value(
-            evidence_reference
-        ):
-            raise ValueError(
-                f"{record.record_family} record {record.record_id!r} requires "
-                "non-blank review_evidence_references entries"
-            )
-
-    source_family = record.source_family.strip()
-    if source_family not in _DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY:
-        raise ValueError(
-            f"false_positive_review record {record.record_id!r} has unsupported "
-            f"source_family {record.source_family!r}; expected one of "
-            f"{sorted(_DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY)!r}"
-        )
-    source_catalog_entry = record.source_catalog_entry.strip()
-    if (
-        source_catalog_entry
-        not in _DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY[source_family]
-    ):
-        raise ValueError(
-            f"false_positive_review record {record.record_id!r} has unsupported "
-            f"source_catalog_entry {record.source_catalog_entry!r} for "
-            f"source_family {source_family!r}; expected one of "
-            f"{sorted(_DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY[source_family])!r}"
-        )
-    if record.disposition not in _FALSE_POSITIVE_REVIEW_DISPOSITIONS:
-        raise ValueError(
-            f"false_positive_review record {record.record_id!r} has invalid disposition "
-            f"{record.disposition!r}; expected one of "
-            f"{sorted(_FALSE_POSITIVE_REVIEW_DISPOSITIONS)!r}"
-        )
-    if record.dispute_state not in _FALSE_POSITIVE_REVIEW_DISPUTE_STATES:
-        raise ValueError(
-            f"false_positive_review record {record.record_id!r} has invalid dispute_state "
-            f"{record.dispute_state!r}; expected one of "
-            f"{sorted(_FALSE_POSITIVE_REVIEW_DISPUTE_STATES)!r}"
-        )
-    if record.recurrence_posture not in _FALSE_POSITIVE_REVIEW_RECURRENCE_POSTURES:
-        raise ValueError(
-            f"false_positive_review record {record.record_id!r} has invalid "
-            f"recurrence_posture {record.recurrence_posture!r}; expected one of "
-            f"{sorted(_FALSE_POSITIVE_REVIEW_RECURRENCE_POSTURES)!r}"
-        )
-    if (
-        record.source_signal_handling
-        not in _FALSE_POSITIVE_REVIEW_SOURCE_SIGNAL_HANDLING
-    ):
-        raise ValueError(
-            f"false_positive_review record {record.record_id!r} must preserve source "
-            "signals and may not delete, hide, or silently suppress source-native truth"
-        )
-    if record.dispute_state == "disputed" and record.lifecycle_state != "disputed":
-        raise ValueError(
-            f"false_positive_review record {record.record_id!r} disputed reviews must "
-            "use lifecycle_state 'disputed'"
-        )
-    if (
-        record.dispute_state != "disputed"
-        and record.lifecycle_state == "disputed"
-    ):
-        raise ValueError(
-            f"false_positive_review record {record.record_id!r} lifecycle_state "
-            "'disputed' requires dispute_state 'disputed'"
-        )
-    if (
-        record.disposition == "recurring_benign_activity"
-        and record.recurrence_posture != "recurring_reviewed_pattern"
-    ):
-        raise ValueError(
-            f"false_positive_review record {record.record_id!r} repeated false positives "
-            "require recurrence_posture 'recurring_reviewed_pattern'"
-        )
-
-
-def _validate_suppression_proposal_record(
-    record: SuppressionProposalRecord,
-) -> None:
-    _require_non_blank_fields(
-        record,
-        (
-            "detector_lifecycle_id",
-            "source_family",
-            "source_catalog_entry",
-            "owner",
-            "rationale",
-            "review_cadence",
-            "expected_signal_impact",
-            "scope",
-            "source_signal_handling",
-        ),
-    )
-    _require_non_empty_tuple(record, "citation_references")
-    _require_tuple_or_list(record, "evidence_ids")
-    _require_any_linkage(record, ("alert_id", "case_id", "evidence_ids"))
-    if record.alert_id is None and record.case_id is None:
-        _require_non_empty_tuple(record, "evidence_ids")
-    for evidence_id in record.evidence_ids:
-        if not isinstance(evidence_id, str) or not _has_linkage_value(evidence_id):
-            raise ValueError(
-                f"{record.record_family} record {record.record_id!r} requires "
-                "non-blank evidence_ids entries"
-            )
-    for citation_reference in record.citation_references:
-        if not isinstance(citation_reference, str) or not _has_linkage_value(
-            citation_reference
-        ):
-            raise ValueError(
-                f"{record.record_family} record {record.record_id!r} requires "
-                "non-blank citation_references entries"
-            )
-    if record.expires_at is None:
-        raise ValueError(
-            f"suppression_proposal record {record.record_id!r} must set a finite expires_at"
-        )
-    source_family = record.source_family.strip()
-    if source_family not in _DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY:
-        raise ValueError(
-            f"suppression_proposal record {record.record_id!r} has unsupported "
-            f"source_family {record.source_family!r}; expected one of "
-            f"{sorted(_DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY)!r}"
-        )
-    source_catalog_entry = record.source_catalog_entry.strip()
-    if (
-        source_catalog_entry
-        not in _DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY[source_family]
-    ):
-        raise ValueError(
-            f"suppression_proposal record {record.record_id!r} has unsupported "
-            f"source_catalog_entry {record.source_catalog_entry!r} for "
-            f"source_family {source_family!r}; expected one of "
-            f"{sorted(_DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY[source_family])!r}"
-        )
-    if record.scope not in _SUPPRESSION_PROPOSAL_SCOPES:
-        raise ValueError(
-            f"suppression_proposal record {record.record_id!r} has invalid scope "
-            f"{record.scope!r}; expected one of {sorted(_SUPPRESSION_PROPOSAL_SCOPES)!r}"
-        )
-    if record.source_signal_handling not in _SUPPRESSION_PROPOSAL_SOURCE_SIGNAL_HANDLING:
-        raise ValueError(
-            f"suppression_proposal record {record.record_id!r} must preserve source "
-            "signals and may not delete, hide, silently suppress, or apply source-native truth"
-        )
-
-
-def _validate_source_health_record(record: SourceHealthRecord) -> None:
-    _require_non_blank_fields(
-        record,
-        (
-            "source_family",
-            "source_catalog_entry",
-            "health_state",
-            "reviewed_state",
-            "detector_drift",
-            "credential_posture",
-            "operator_visible_reason",
-        ),
-    )
-    _require_non_empty_tuple(record, "evidence_references")
-    for evidence_reference in record.evidence_references:
-        if not isinstance(evidence_reference, str) or not _has_linkage_value(
-            evidence_reference
-        ):
-            raise ValueError(
-                f"source_health record {record.record_id!r} requires non-blank "
-                "evidence_references entries"
-            )
-
-    source_family = record.source_family.strip()
-    if source_family not in _DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY:
-        raise ValueError(
-            f"source_health record {record.record_id!r} has unsupported source_family "
-            f"{record.source_family!r}; expected one of "
-            f"{sorted(_DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY)!r}"
-        )
-    source_catalog_entry = record.source_catalog_entry.strip()
-    if (
-        source_catalog_entry
-        not in _DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY[source_family]
-    ):
-        raise ValueError(
-            f"source_health record {record.record_id!r} has unsupported "
-            f"source_catalog_entry {record.source_catalog_entry!r} for "
-            f"source_family {source_family!r}; expected one of "
-            f"{sorted(_DETECTOR_SOURCE_CATALOG_ENTRIES_BY_FAMILY[source_family])!r}"
-        )
-    if record.health_state not in _SOURCE_HEALTH_STATES:
-        raise ValueError(
-            f"source_health record {record.record_id!r} has invalid health_state "
-            f"{record.health_state!r}; expected one of "
-            f"{sorted(_SOURCE_HEALTH_STATES)!r}"
-        )
-    if record.reviewed_state != record.lifecycle_state:
-        raise ValueError(
-            f"source_health record {record.record_id!r} requires reviewed_state to match lifecycle_state"
-        )
-    if record.detector_drift not in _SOURCE_HEALTH_DETECTOR_DRIFT_STATES:
-        raise ValueError(
-            f"source_health record {record.record_id!r} has invalid detector_drift "
-            f"{record.detector_drift!r}; expected one of "
-            f"{sorted(_SOURCE_HEALTH_DETECTOR_DRIFT_STATES)!r}"
-        )
-    if record.credential_posture not in _SOURCE_HEALTH_CREDENTIAL_POSTURES:
-        raise ValueError(
-            f"source_health record {record.record_id!r} has invalid credential_posture "
-            f"{record.credential_posture!r}; expected one of "
-            f"{sorted(_SOURCE_HEALTH_CREDENTIAL_POSTURES)!r}"
-        )
-    if record.observed_at > record.reviewed_at:
-        raise ValueError(
-            f"source_health record {record.record_id!r} requires observed_at <= reviewed_at"
-        )
-    if record.source_native_authority or record.display_state_authority:
-        raise ValueError(
-            f"source_health record {record.record_id!r} must remain subordinate "
-            "operational context and cannot become workflow truth"
-        )
-    if record.cache_sourced:
-        raise ValueError(
-            f"source_health record {record.record_id!r} must not be cache sourced; "
-            "stale-cache source health is refused"
-        )
 
 
 def _validate_coordination_reference_fields(

--- a/control-plane/aegisops/control_plane/record_validation.py
+++ b/control-plane/aegisops/control_plane/record_validation.py
@@ -24,7 +24,7 @@ from .models import (
     RecommendationRecord,
     SourceHealthRecord,
 )
-from .phase61_record_validators import (
+from .validation.phase61_record_validators import (
     _DETECTOR_LIFECYCLE_STATES,
     validate_phase61_record,
 )

--- a/control-plane/aegisops/control_plane/validation/__init__.py
+++ b/control-plane/aegisops/control_plane/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Validation helpers for control-plane record families."""

--- a/control-plane/aegisops/control_plane/validation/phase61_record_validators.py
+++ b/control-plane/aegisops/control_plane/validation/phase61_record_validators.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .models import (
+from ..models import (
     ControlPlaneRecord,
     DetectorLifecycleRecord,
     FalsePositiveReviewRecord,

--- a/control-plane/tests/test_phase61_detector_lifecycle_record_contract.py
+++ b/control-plane/tests/test_phase61_detector_lifecycle_record_contract.py
@@ -28,8 +28,8 @@ from aegisops.control_plane.service import (
     RECORD_TYPES_BY_FAMILY,
     _AUTHORITATIVE_PRIMARY_ID_FIELD_BY_FAMILY,
 )
-from aegisops.control_plane import phase61_record_validators
 from aegisops.control_plane.record_validation import _validate_record
+from aegisops.control_plane.validation import phase61_record_validators
 
 
 class _FakeLifecycleTransitionStore:

--- a/control-plane/tests/test_phase61_detector_lifecycle_record_contract.py
+++ b/control-plane/tests/test_phase61_detector_lifecycle_record_contract.py
@@ -28,6 +28,7 @@ from aegisops.control_plane.service import (
     RECORD_TYPES_BY_FAMILY,
     _AUTHORITATIVE_PRIMARY_ID_FIELD_BY_FAMILY,
 )
+from aegisops.control_plane import phase61_record_validators
 from aegisops.control_plane.record_validation import _validate_record
 
 
@@ -189,6 +190,30 @@ def _source_health_record(
 
 
 class Phase61DetectorLifecycleRecordContractTests(unittest.TestCase):
+    def test_phase61_record_validation_surface_is_extracted(self) -> None:
+        self.assertTrue(
+            callable(phase61_record_validators.validate_phase61_record),
+            "Phase 61 family-specific validators must live outside generic dispatch",
+        )
+        self.assertTrue(
+            phase61_record_validators.is_phase61_record_family(
+                _detector_lifecycle_record(lifecycle_state="candidate")
+            )
+        )
+        self.assertTrue(
+            phase61_record_validators.is_phase61_record_family(
+                _false_positive_review_record()
+            )
+        )
+        self.assertTrue(
+            phase61_record_validators.is_phase61_record_family(
+                _suppression_proposal_record()
+            )
+        )
+        self.assertTrue(
+            phase61_record_validators.is_phase61_record_family(_source_health_record())
+        )
+
     def test_restore_validation_accepts_detector_lifecycle_transition_subjects(self) -> None:
         detector = _detector_lifecycle_record(lifecycle_state="candidate")
         transition = LifecycleTransitionRecord(

--- a/scripts/verify-phase-61-2-detector-lifecycle-contract.sh
+++ b/scripts/verify-phase-61-2-detector-lifecycle-contract.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+exec bash "${repo_root}/scripts/verify-phase-61-2-detector-lifecycle-record-contract.sh" "${repo_root}"

--- a/scripts/verify-phase-61-4-false-positive-review-records.sh
+++ b/scripts/verify-phase-61-4-false-positive-review-records.sh
@@ -6,7 +6,7 @@ repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 validation_path="${repo_root}/docs/phase-61-4-false-positive-review-records-validation.md"
 test_path="${repo_root}/control-plane/tests/test_phase61_detector_lifecycle_record_contract.py"
 model_path="${repo_root}/control-plane/aegisops/control_plane/models.py"
-validation_code_path="${repo_root}/control-plane/aegisops/control_plane/record_validation.py"
+validation_code_path="${repo_root}/control-plane/aegisops/control_plane/phase61_record_validators.py"
 migration_path="${repo_root}/postgres/control-plane/migrations/0013_phase_61_detector_lifecycle_records.sql"
 
 for path in \

--- a/scripts/verify-phase-61-4-false-positive-review-records.sh
+++ b/scripts/verify-phase-61-4-false-positive-review-records.sh
@@ -6,7 +6,7 @@ repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 validation_path="${repo_root}/docs/phase-61-4-false-positive-review-records-validation.md"
 test_path="${repo_root}/control-plane/tests/test_phase61_detector_lifecycle_record_contract.py"
 model_path="${repo_root}/control-plane/aegisops/control_plane/models.py"
-validation_code_path="${repo_root}/control-plane/aegisops/control_plane/phase61_record_validators.py"
+validation_code_path="${repo_root}/control-plane/aegisops/control_plane/validation/phase61_record_validators.py"
 migration_path="${repo_root}/postgres/control-plane/migrations/0013_phase_61_detector_lifecycle_records.sql"
 
 for path in \

--- a/scripts/verify-phase-61-4-false-positive-review.sh
+++ b/scripts/verify-phase-61-4-false-positive-review.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+exec bash "${repo_root}/scripts/verify-phase-61-4-false-positive-review-records.sh" "${repo_root}"

--- a/scripts/verify-phase-61-5-suppression-candidate.sh
+++ b/scripts/verify-phase-61-5-suppression-candidate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+exec bash "${repo_root}/scripts/verify-phase-61-5-suppression-proposal-workflow.sh" "${repo_root}"

--- a/scripts/verify-phase-61-5-suppression-proposal-workflow.sh
+++ b/scripts/verify-phase-61-5-suppression-proposal-workflow.sh
@@ -6,7 +6,7 @@ repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 validation_path="${repo_root}/docs/phase-61-5-suppression-proposal-workflow-validation.md"
 test_path="${repo_root}/control-plane/tests/test_phase61_detector_lifecycle_record_contract.py"
 model_path="${repo_root}/control-plane/aegisops/control_plane/models.py"
-validation_code_path="${repo_root}/control-plane/aegisops/control_plane/phase61_record_validators.py"
+validation_code_path="${repo_root}/control-plane/aegisops/control_plane/validation/phase61_record_validators.py"
 migration_path="${repo_root}/postgres/control-plane/migrations/0013_phase_61_detector_lifecycle_records.sql"
 
 for path in \

--- a/scripts/verify-phase-61-5-suppression-proposal-workflow.sh
+++ b/scripts/verify-phase-61-5-suppression-proposal-workflow.sh
@@ -6,7 +6,7 @@ repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 validation_path="${repo_root}/docs/phase-61-5-suppression-proposal-workflow-validation.md"
 test_path="${repo_root}/control-plane/tests/test_phase61_detector_lifecycle_record_contract.py"
 model_path="${repo_root}/control-plane/aegisops/control_plane/models.py"
-validation_code_path="${repo_root}/control-plane/aegisops/control_plane/record_validation.py"
+validation_code_path="${repo_root}/control-plane/aegisops/control_plane/phase61_record_validators.py"
 migration_path="${repo_root}/postgres/control-plane/migrations/0013_phase_61_detector_lifecycle_records.sql"
 
 for path in \

--- a/scripts/verify-phase-61-6-source-health-dashboard.sh
+++ b/scripts/verify-phase-61-6-source-health-dashboard.sh
@@ -6,6 +6,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 required_files=(
   "control-plane/aegisops/control_plane/models.py"
   "control-plane/aegisops/control_plane/record_validation.py"
+  "control-plane/aegisops/control_plane/phase61_record_validators.py"
   "apps/operator-ui/src/app/operatorConsolePages/sourceHealthDashboardPages.tsx"
   "apps/operator-ui/src/app/OperatorRoutes.sourceHealthDashboard.testSuite.tsx"
   "postgres/control-plane/migrations/0014_phase_61_source_health_records.sql"
@@ -30,6 +31,7 @@ for expected in \
   "cache_sourced"; do
   if ! rg -q "${expected}" \
     "${repo_root}/control-plane/aegisops/control_plane/record_validation.py" \
+    "${repo_root}/control-plane/aegisops/control_plane/phase61_record_validators.py" \
     "${repo_root}/apps/operator-ui/src/operatorDataProvider/listSemantics.ts" \
     "${repo_root}/apps/operator-ui/src/app/operatorConsolePages/sourceHealthDashboardPages.tsx"; then
     echo "Missing Phase 61.6 source-health dashboard term: ${expected}" >&2

--- a/scripts/verify-phase-61-6-source-health-dashboard.sh
+++ b/scripts/verify-phase-61-6-source-health-dashboard.sh
@@ -6,7 +6,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 required_files=(
   "control-plane/aegisops/control_plane/models.py"
   "control-plane/aegisops/control_plane/record_validation.py"
-  "control-plane/aegisops/control_plane/phase61_record_validators.py"
+  "control-plane/aegisops/control_plane/validation/phase61_record_validators.py"
   "apps/operator-ui/src/app/operatorConsolePages/sourceHealthDashboardPages.tsx"
   "apps/operator-ui/src/app/OperatorRoutes.sourceHealthDashboard.testSuite.tsx"
   "postgres/control-plane/migrations/0014_phase_61_source_health_records.sql"
@@ -31,7 +31,7 @@ for expected in \
   "cache_sourced"; do
   if ! rg -q "${expected}" \
     "${repo_root}/control-plane/aegisops/control_plane/record_validation.py" \
-    "${repo_root}/control-plane/aegisops/control_plane/phase61_record_validators.py" \
+    "${repo_root}/control-plane/aegisops/control_plane/validation/phase61_record_validators.py" \
     "${repo_root}/apps/operator-ui/src/operatorDataProvider/listSemantics.ts" \
     "${repo_root}/apps/operator-ui/src/app/operatorConsolePages/sourceHealthDashboardPages.tsx"; then
     echo "Missing Phase 61.6 source-health dashboard term: ${expected}" >&2


### PR DESCRIPTION
## Summary
- Extracted Phase 61 detector lifecycle, false-positive review, suppression proposal, and source-health record validators into `phase61_record_validators.py`.
- Kept `record_validation._validate_record` and `_validate_lifecycle_state` as the public dispatch/compatibility boundary.
- Updated Phase 61 verifier scripts to inspect the extracted validator module and added wrappers for the issue-listed verifier command names.

## Verification
- `PYTHONPATH=control-plane python3 -m unittest control-plane.tests.test_phase61_detector_lifecycle_record_contract`
- `PYTHONPATH=control-plane python3 -m unittest control-plane.tests.test_phase61_7_record_search_filter`
- `PYTHONPATH=control-plane python3 -m unittest control-plane.tests.test_phase61_detector_lifecycle_record_contract control-plane.tests.test_phase61_7_record_search_filter`
- `bash scripts/verify-phase-61-2-detector-lifecycle-contract.sh`
- `bash scripts/verify-phase-61-4-false-positive-review.sh`
- `bash scripts/verify-phase-61-5-suppression-candidate.sh`
- `bash scripts/verify-phase-61-6-source-health-dashboard.sh`
- `bash scripts/verify-phase-61-7-record-search-filter.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `bash scripts/verify-maintainability-hotspots.sh`
- `python3 -m py_compile control-plane/aegisops/control_plane/record_validation.py control-plane/aegisops/control_plane/phase61_record_validators.py control-plane/tests/test_phase61_detector_lifecycle_record_contract.py`

Part of #1305
Closes #1306