### PR TITLE
Fence record search inspection boundaries

### DIFF
--- a/control-plane/aegisops/control_plane/inspection/record_search.py
+++ b/control-plane/aegisops/control_plane/inspection/record_search.py
@@ -45,6 +45,9 @@ RECORD_SEARCH_COMMON_REVIEWED_FIELDS = (
     "source_family",
     "lifecycle_state",
 )
+RECORD_SEARCH_RESULT_ROUTE_KIND = "reviewed_surface"
+RECORD_SEARCH_RESULT_AUTHORITY = "navigation_only"
+RECORD_SEARCH_RESULT_RAW_SOURCE_AUTHORITY = False
 RECORD_SEARCH_REVIEWED_FIELDS_BY_FAMILY = {
     "alert": (
         "alert_id",
@@ -123,6 +126,21 @@ RECORD_SEARCH_REVIEWED_FIELDS_BY_FAMILY = {
         "operator_visible_reason",
     ),
 }
+if set(RECORD_SEARCH_REVIEWED_FIELDS_BY_FAMILY) != set(
+    RECORD_SEARCH_RECORD_TYPES_BY_FAMILY
+):
+    missing_families = sorted(
+        set(RECORD_SEARCH_RECORD_TYPES_BY_FAMILY)
+        - set(RECORD_SEARCH_REVIEWED_FIELDS_BY_FAMILY)
+    )
+    extra_families = sorted(
+        set(RECORD_SEARCH_REVIEWED_FIELDS_BY_FAMILY)
+        - set(RECORD_SEARCH_RECORD_TYPES_BY_FAMILY)
+    )
+    raise RuntimeError(
+        "Record search reviewed field allow-list drift; "
+        f"missing={missing_families!r}; extra={extra_families!r}"
+    )
 
 
 class RecordSearchStore(Protocol):
@@ -315,9 +333,9 @@ class RecordSearchInspectionService:
             "lifecycle_state": record_lifecycle_state,
             "matched_query": query,
             "route": route,
-            "route_kind": "reviewed_surface",
-            "authority": "navigation_only",
-            "raw_source_authority": False,
+            "route_kind": RECORD_SEARCH_RESULT_ROUTE_KIND,
+            "authority": RECORD_SEARCH_RESULT_AUTHORITY,
+            "raw_source_authority": RECORD_SEARCH_RESULT_RAW_SOURCE_AUTHORITY,
             "summary": self._record_search_summary(payload, family, record_id),
         }
 
@@ -360,7 +378,10 @@ class RecordSearchInspectionService:
                 SourceHealthRecord,
             ),
         ):
-            return record.source_family.strip()
+            source_family = record.source_family.strip()
+            if source_family:
+                return source_family
+            return None
 
         return None
 
@@ -452,10 +473,8 @@ class RecordSearchInspectionService:
     def _record_search_payload_values(
         payload: Mapping[str, object],
     ) -> tuple[str, ...]:
-        family = payload.get("record_family")
-        selected_fields = (
-            *RECORD_SEARCH_COMMON_REVIEWED_FIELDS,
-            *RECORD_SEARCH_REVIEWED_FIELDS_BY_FAMILY.get(str(family), ()),
+        selected_fields = RecordSearchInspectionService._reviewed_field_names_for_family(
+            payload.get("record_family")
         )
         values: list[str] = []
         for field_name in selected_fields:
@@ -466,6 +485,20 @@ class RecordSearchInspectionService:
                     )
                 )
         return tuple(values)
+
+    @staticmethod
+    def _reviewed_field_names_for_family(record_family: object) -> tuple[str, ...]:
+        normalized_family = str(record_family).strip()
+        if normalized_family not in RECORD_SEARCH_REVIEWED_FIELDS_BY_FAMILY:
+            known_families = ", ".join(sorted(RECORD_SEARCH_REVIEWED_FIELDS_BY_FAMILY))
+            raise ValueError(
+                f"Unsupported search record family {normalized_family!r}; "
+                f"expected one of: {known_families}"
+            )
+        return (
+            *RECORD_SEARCH_COMMON_REVIEWED_FIELDS,
+            *RECORD_SEARCH_REVIEWED_FIELDS_BY_FAMILY[normalized_family],
+        )
 
     @staticmethod
     def _record_search_value_text(value: object) -> tuple[str, ...]:

--- a/control-plane/tests/test_phase61_7_record_search_filter.py
+++ b/control-plane/tests/test_phase61_7_record_search_filter.py
@@ -21,12 +21,38 @@ from aegisops.control_plane.models import (
     SourceHealthRecord,
     SuppressionProposalRecord,
 )
+from aegisops.control_plane.inspection.record_search import (
+    RECORD_SEARCH_RECORD_TYPES_BY_FAMILY,
+    RECORD_SEARCH_REVIEWED_FIELDS_BY_FAMILY,
+    RecordSearchInspectionService,
+)
 from support.service_persistence import ServicePersistenceTestBase
 
 GITHUB_AUDIT_CATALOG_ENTRY = "docs/source-families/github-audit/onboarding-package.md"
 
 
 class Phase617RecordSearchFilterTests(ServicePersistenceTestBase):
+    def test_record_search_requires_explicit_reviewed_fields_for_each_family(
+        self,
+    ) -> None:
+        self.assertEqual(
+            set(RECORD_SEARCH_REVIEWED_FIELDS_BY_FAMILY),
+            set(RECORD_SEARCH_RECORD_TYPES_BY_FAMILY),
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unsupported search record family",
+        ):
+            RecordSearchInspectionService._record_search_payload_values(
+                {
+                    "record_family": "native_detection",
+                    "record_id": "native-detection-001",
+                    "source_family": "wazuh_detection",
+                    "lifecycle_state": "collected",
+                }
+            )
+
     def test_record_search_returns_reviewed_navigation_results_only(self) -> None:
         store, service, case, evidence_id, _reviewed_at = (
             self._build_phase19_in_scope_case()


### PR DESCRIPTION
Part of: #1305
Closes: #1308

## Summary
- require every record-search family to declare explicit reviewed searchable fields
- make unknown record-family payload inspection fail closed instead of searching common fields
- centralize record-search result boundary labels for reviewed navigation-only output

## Verification
- `PYTHONPATH=control-plane python3 -m unittest control-plane.tests.test_phase61_7_record_search_filter`
- `bash scripts/verify-phase-61-7-record-search-filter.sh`
- `bash scripts/verify-phase-61-8-closeout-evaluation.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `bash scripts/verify-maintainability-hotspots.sh`

Note: `npm ci` was run first because workspace dependencies were absent before the Phase 61.7 verifier could run Vitest.