### PR TITLE
Add Phase 62.1 reviewed automation catalog contract

### DIFF
--- a/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
+++ b/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
@@ -9,6 +9,8 @@ import unittest
 EXPECTED_CATALOG_COLUMNS = 10
 CATALOG_SECTION_HEADING = "## 3. Approved Default Catalog Entries"
 CATALOG_SECTION_END_HEADING = "## 4. Catalog Boundedness Rules"
+ALLOWED_DEFAULT_FAMILIES = {"Read", "Notify", "Soft Write"}
+DISALLOWED_DEFAULT_FAMILIES = {"Controlled Write", "Hard Write"}
 FORBIDDEN_OVERCLAIM_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "broad SOAR marketplace coverage is implemented",
@@ -24,7 +26,16 @@ FORBIDDEN_OVERCLAIM_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "template marketplace import is approved",
         re.compile(
-            r"\btemplate\s+marketplace\s+import\s+is\s+(?:approved|implemented)\b",
+            r"\b(?:workflow\s+)?template\s+marketplace\s+imports?\s+"
+            r"(?:is|are)\s+(?:approved|available|enabled|implemented|permitted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "template import from marketplace is approved",
+        re.compile(
+            r"\btemplate\s+imports?\s+from\s+(?:the\s+)?marketplace\s+"
+            r"(?:is|are)\s+(?:approved|available|enabled|implemented|permitted)\b",
             re.I,
         ),
     ),
@@ -191,11 +202,13 @@ FORBIDDEN_AUTHORITY_PROMOTION_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] 
     (
         "subordinate source is treated as AegisOps truth",
         re.compile(
-            r"\b(?:treats?\s+)?(?:shuffle\s+workflow\s+state|shuffle\s+workflow\s+"
-            r"success|shuffle\s+callback\s+payload|simulator\s+state|ticket\s+"
-            r"state|ticket\s+status|ui\s+cache|browser\s+state|ai\s+output|"
-            r"source-native\s+status|verifier\s+output|issue-lint\s+output|"
-            r"admin\s+configuration|admin\s+ui\s+state)\s+"
+            r"\b(?:treats?\s+)?(?:shuffle\s+workflow\s+state|workflow\s+state|"
+            r"shuffle\s+workflow\s+success|shuffle\s+workflow\s+failure|workflow\s+"
+            r"failure|workflow\s+status|shuffle\s+callback\s+payload|callback\s+"
+            r"payload|simulator\s+state|ticket\s+state|ticket\s+status|ui\s+cache|"
+            r"browser\s+state|ai\s+output|source-native\s+status|verifier\s+"
+            r"output|issue-lint\s+output|admin\s+configuration|admin\s+ui\s+state)"
+            r"\s+"
             r"(?:(?:is|are|becomes?|become)\s+|as\s+)aegisops\s+"
             r"(?:(?:action|case|reconciliation|execution\s+receipt|policy|"
             r"release|gate|limitation|closeout)\s+)?truth\b",
@@ -277,6 +290,100 @@ FORBIDDEN_AUTHORITY_PROMOTION_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] 
         "issue-lint output gates production readiness",
         re.compile(r"\bissue-lint\s+output\s+gates\s+production\s+readiness\b", re.I),
     ),
+)
+FORBIDDEN_BYPASS_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "default entry permits direct workflow launch",
+        re.compile(
+            r"\b(?:default\s+entr(?:y|ies)\s+permits?|catalog\s+(?:allows?|enables?)|"
+            r"direct\s+(?:ad-?hoc\s+)?shuffle\s+launch\s+is)\s+"
+            r"(?:direct\s+(?:ad-?hoc\s+)?shuffle\s+launch|allowed|approved|"
+            r"enabled|permitted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "autonomous approval is permitted",
+        re.compile(
+            r"\b(?:default\s+entr(?:y|ies)\s+permits?|autonomous\s+approval\s+is)\s+"
+            r"(?:autonomous\s+approval|allowed|approved|enabled|permitted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "autonomous remediation is permitted",
+        re.compile(
+            r"\b(?:default\s+entr(?:y|ies)\s+permits?|autonomous\s+remediation\s+is)\s+"
+            r"(?:autonomous\s+remediation|allowed|approved|enabled|permitted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "protected target mutation is permitted",
+        re.compile(
+            r"\b(?:default\s+entr(?:y|ies)\s+permits?|protected\s+target\s+mutation\s+is)\s+"
+            r"(?:protected\s+target\s+mutation|allowed|approved|enabled|permitted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "case closure is permitted",
+        re.compile(
+            r"\b(?:default\s+entr(?:y|ies)\s+permits?|case\s+closure\s+is)\s+"
+            r"(?:case\s+closure|allowed|approved|enabled|permitted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "ticket closure is permitted",
+        re.compile(
+            r"\b(?:default\s+entr(?:y|ies)\s+permits?|ticket\s+closure\s+is)\s+"
+            r"(?:ticket\s+closure|allowed|approved|enabled|permitted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "detector activation is permitted",
+        re.compile(
+            r"\b(?:default\s+entr(?:y|ies)\s+permits?|detector\s+activation\s+is)\s+"
+            r"(?:detector\s+activation|allowed|approved|enabled|permitted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "suppression activation is permitted",
+        re.compile(
+            r"\b(?:default\s+entr(?:y|ies)\s+permits?|suppression\s+activation\s+is)\s+"
+            r"(?:suppression\s+activation|allowed|approved|enabled|permitted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "approval bypass is permitted",
+        re.compile(
+            r"\b(?:default\s+entr(?:y|ies)\s+permits?|approval\s+bypass\s+is)\s+"
+            r"(?:approval\s+bypass|allowed|approved|enabled|permitted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "reconciliation bypass is permitted",
+        re.compile(
+            r"\b(?:default\s+entr(?:y|ies)\s+permits?|reconciliation\s+bypass\s+is)\s+"
+            r"(?:reconciliation\s+bypass|allowed|approved|enabled|permitted)\b",
+            re.I,
+        ),
+    ),
+)
+FAIL_CLOSED_REJECTION_ITEM_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bmissing\b", re.I),
+    re.compile(r"\bdoes\s+not\s+include\b", re.I),
+    re.compile(r"\buses\s+(?:controlled\s+write|hard\s+write)\b", re.I),
+    re.compile(r"\bpermits\s+", re.I),
+    re.compile(r"\bpromotes\s+.*\baegisops\s+truth\b", re.I),
+    re.compile(r"\bclaims?\s+appear\s+outside\s+explicit\s+rejection\b", re.I),
+    re.compile(r"\btreated\s+as\s+valid\s+setup\s+state\b", re.I),
+    re.compile(r"\buses\s+workstation-local\s+absolute\s+paths\b", re.I),
 )
 PLACEHOLDER_CELL_PATTERN = re.compile(
     r"^(?:-|todo|tbd|placeholder|sample|fake)(?:\b|[:\s-])",
@@ -364,7 +471,8 @@ def _is_rejection_context(
     stripped = line.strip()
     normalized = stripped.casefold()
     if in_fail_closed_rule_list and stripped.startswith("- "):
-        return True
+        item_text = stripped[2:].strip()
+        return any(pattern.search(item_text) for pattern in FAIL_CLOSED_REJECTION_ITEM_PATTERNS)
 
     explicit_negation_patterns = (
         r"^(?:[-*]\s*)?no\b",
@@ -447,7 +555,7 @@ def _non_rejection_segments(catalog_text: str) -> list[str]:
             if current_lines:
                 current_lines.append(" ")
             continue
-        current_lines.append(stripped)
+        current_lines.append(re.sub(r"^[-*]\s+", "", stripped))
 
     flush()
     return segments
@@ -498,8 +606,10 @@ def _catalog_validation_errors(catalog_text: str) -> list[str]:
         for index, column_name in enumerate(required_columns):
             if _is_placeholder_cell(row[index]):
                 errors.append(f"{action} missing {column_name}")
-        if family in {"Controlled Write", "Hard Write"}:
+        if family in DISALLOWED_DEFAULT_FAMILIES:
             errors.append(f"{action} uses disallowed default family {family}")
+        elif family not in ALLOWED_DEFAULT_FAMILIES:
+            errors.append(f"{action} uses unknown default family {family}")
         if "owner" in row[2].lower() and "missing" in row[2].lower():
             errors.append(f"{action} missing owner")
         if "direct ad-hoc Shuffle launch" not in row[3]:
@@ -535,6 +645,11 @@ def _catalog_validation_errors(catalog_text: str) -> list[str]:
             if pattern.search(segment):
                 errors.append(
                     f"forbidden authority promotion outside rejection context: {claim}"
+                )
+        for claim, pattern in FORBIDDEN_BYPASS_PATTERNS:
+            if pattern.search(segment):
+                errors.append(
+                    f"forbidden action boundary bypass outside rejection context: {claim}"
                 )
     return errors
 
@@ -662,6 +777,18 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             _catalog_validation_errors(hard_text),
         )
 
+    def test_rejects_unknown_default_catalog_family(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        unknown_family_text = catalog_text.replace(
+            "| `operator_notification` | Notify |",
+            "| `operator_notification` | Autonomous Write |",
+        )
+
+        self.assertIn(
+            "operator_notification uses unknown default family Autonomous Write",
+            _catalog_validation_errors(unknown_family_text),
+        )
+
     def test_rejects_malformed_and_duplicate_catalog_rows(self) -> None:
         catalog_text = self.catalog_doc.read_text(encoding="utf-8")
         malformed_text = catalog_text.replace(
@@ -770,10 +897,18 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             "Phase 62.1 records the default reviewed automation catalog",
             "Phase 62.1 records that template marketplace import is approved and the default reviewed automation catalog",
         )
+        marketplace_source_text = catalog_text.replace(
+            "Phase 62.1 records the default reviewed automation catalog",
+            "Phase 62.1 records that template imports from the marketplace are enabled and the default reviewed automation catalog",
+        )
 
         self.assertIn(
             "forbidden overclaim outside rejection context: template marketplace import is approved",
             _catalog_validation_errors(overclaim_text),
+        )
+        self.assertIn(
+            "forbidden overclaim outside rejection context: template import from marketplace is approved",
+            _catalog_validation_errors(marketplace_source_text),
         )
 
     def test_scans_non_rejection_validation_rules_lines_for_overclaims(self) -> None:
@@ -783,10 +918,19 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             "The verifier reports Phase 62.1 claims GA readiness.\n\n"
             "The Phase 62.1 reviewed automation catalog verifier must fail closed when:",
         )
+        bullet_overclaim_text = catalog_text.replace(
+            "- the catalog contract or validation record is missing;",
+            "- Phase 62.1 claims GA readiness.\n"
+            "- the catalog contract or validation record is missing;",
+        )
 
         self.assertIn(
             "forbidden overclaim outside rejection context: Phase 62.1 claims GA",
             _catalog_validation_errors(overclaim_text),
+        )
+        self.assertIn(
+            "forbidden overclaim outside rejection context: Phase 62.1 claims GA",
+            _catalog_validation_errors(bullet_overclaim_text),
         )
 
     def test_rejects_overclaims_with_not_marker_and_line_wrapping(self) -> None:
@@ -808,6 +952,10 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             "## 8. Non-Goals",
             "Phase 62.1 claims\n\nRC readiness\n## 8. Non-Goals",
         )
+        bullet_blank_wrapped_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "Phase 62.1 claims\n\n- RC readiness\n## 8. Non-Goals",
+        )
         long_wrapped_text = catalog_text.replace(
             "## 8. Non-Goals",
             "Phase 62.1 "
@@ -825,6 +973,7 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
         self.assertIn(expected, _catalog_validation_errors(does_not_marker_text))
         self.assertIn(expected, _catalog_validation_errors(wrapped_text))
         self.assertIn(expected, _catalog_validation_errors(blank_wrapped_text))
+        self.assertIn(expected, _catalog_validation_errors(bullet_blank_wrapped_text))
         self.assertIn(expected, _catalog_validation_errors(long_wrapped_text))
         self.assertIn(
             "forbidden overclaim outside rejection context: Phase 62.1 claims GA",
@@ -941,15 +1090,20 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
                 (
                     "Direct ad-hoc Shuffle launch is approved.",
                     "Shuffle workflow success is AegisOps reconciliation truth.",
+                    "Shuffle workflow state is AegisOps reconciliation truth.",
+                    "Workflow failure becomes AegisOps gate truth.",
                     "Shuffle callback payload is AegisOps execution receipt truth.",
+                    "Simulator state is AegisOps case truth.",
                     "Shuffle workflow status closes AegisOps cases.",
                     "Ticket status is AegisOps case truth.",
                     "Phase 62.1 treats ticket status as AegisOps case truth.",
                     "Ticket close is AegisOps reconciliation truth.",
                     "UI cache is AegisOps action policy truth.",
                     "Browser state is AegisOps case truth.",
+                    "Browser state becomes AegisOps release truth.",
                     "Phase 62.1 treats browser state as AegisOps action truth.",
                     "Admin configuration is AegisOps action truth.",
+                    "Admin UI state becomes AegisOps gate truth.",
                     "Phase 62.1 treats admin configuration as AegisOps reconciliation truth.",
                     "AI output approves automation.",
                     "Source-native status reconciles automation.",
@@ -976,6 +1130,44 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             "forbidden authority promotion outside rejection context: source-native status reconciles automation",
             "forbidden authority promotion outside rejection context: verifier output gates production readiness",
             "forbidden authority promotion outside rejection context: issue-lint output gates production readiness",
+        ):
+            self.assertIn(expected, validation_errors)
+
+    def test_rejects_action_boundary_bypass_claims_outside_rejection_context(
+        self,
+    ) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        bypass_claim_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "\n".join(
+                (
+                    "Default entry permits direct ad-hoc Shuffle launch.",
+                    "Autonomous approval is enabled.",
+                    "Autonomous remediation is approved.",
+                    "Protected target mutation is permitted.",
+                    "Case closure is allowed.",
+                    "Ticket closure is allowed.",
+                    "Detector activation is enabled.",
+                    "Suppression activation is approved.",
+                    "Approval bypass is permitted.",
+                    "Reconciliation bypass is permitted.",
+                    "## 8. Non-Goals",
+                )
+            ),
+        )
+        validation_errors = _catalog_validation_errors(bypass_claim_text)
+
+        for expected in (
+            "forbidden action boundary bypass outside rejection context: default entry permits direct workflow launch",
+            "forbidden action boundary bypass outside rejection context: autonomous approval is permitted",
+            "forbidden action boundary bypass outside rejection context: autonomous remediation is permitted",
+            "forbidden action boundary bypass outside rejection context: protected target mutation is permitted",
+            "forbidden action boundary bypass outside rejection context: case closure is permitted",
+            "forbidden action boundary bypass outside rejection context: ticket closure is permitted",
+            "forbidden action boundary bypass outside rejection context: detector activation is permitted",
+            "forbidden action boundary bypass outside rejection context: suppression activation is permitted",
+            "forbidden action boundary bypass outside rejection context: approval bypass is permitted",
+            "forbidden action boundary bypass outside rejection context: reconciliation bypass is permitted",
         ):
             self.assertIn(expected, validation_errors)
 

--- a/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
+++ b/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
@@ -5,6 +5,9 @@ import re
 import unittest
 
 
+EXPECTED_CATALOG_COLUMNS = 10
+
+
 def _doc_path(relative_path: str) -> pathlib.Path:
     return pathlib.Path(__file__).resolve().parents[2] / relative_path
 
@@ -25,9 +28,38 @@ def _catalog_rows(catalog_text: str) -> list[list[str]]:
         if re.fullmatch(r"\|[ \-:|]+\|", line):
             continue
         cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
-        if len(cells) == 10:
-            rows.append(cells)
+        rows.append(cells)
     return rows
+
+
+def _is_forbidden_claims_heading(line: str) -> bool:
+    return bool(re.fullmatch(r"##\s+\d+\.\s+Forbidden Claims", line.strip()))
+
+
+def _is_section_heading(line: str) -> bool:
+    return bool(re.fullmatch(r"##\s+\d+\..*", line.strip()))
+
+
+def _is_rejection_context(line: str, in_forbidden_claims: bool) -> bool:
+    if in_forbidden_claims:
+        return True
+
+    normalized = line.casefold()
+    rejection_markers = (
+        "cannot",
+        "does not",
+        "fail closed",
+        "forbidden",
+        "must be rejected",
+        "no ",
+        "not ",
+        "non-goal",
+        "out of scope",
+        "rejected",
+        "remain blocked",
+        "without ",
+    )
+    return any(marker in normalized for marker in rejection_markers)
 
 
 def _catalog_validation_errors(catalog_text: str) -> list[str]:
@@ -35,6 +67,7 @@ def _catalog_validation_errors(catalog_text: str) -> list[str]:
     errors: list[str] = []
     required_families = {"Read", "Notify", "Soft Write"}
     seen_families: set[str] = set()
+    seen_actions: set[str] = set()
     required_columns = (
         "action",
         "family",
@@ -52,7 +85,18 @@ def _catalog_validation_errors(catalog_text: str) -> list[str]:
         errors.append("missing catalog rows")
 
     for row in rows:
-        action = row[0].strip("`")
+        action = row[0].strip("`") if row else "<missing action>"
+        if len(row) != EXPECTED_CATALOG_COLUMNS:
+            errors.append(
+                f"{action} malformed catalog row has {len(row)} columns; "
+                f"expected {EXPECTED_CATALOG_COLUMNS}"
+            )
+            continue
+
+        if action in seen_actions:
+            errors.append(f"{action} duplicate catalog action")
+        seen_actions.add(action)
+
         family = row[1]
         seen_families.add(family)
         for index, column_name in enumerate(required_columns):
@@ -84,13 +128,30 @@ def _catalog_validation_errors(catalog_text: str) -> list[str]:
         "broad SOAR marketplace coverage is implemented",
         "arbitrary SOAR connector marketplace import is approved",
         "Phase 62.1 claims Beta",
+        "Phase 62.1 claims RC",
+        "Phase 62.1 claims GA",
+        "Phase 62.1 claims commercial readiness",
+        "Phase 62.1 claims broad SOAR replacement readiness",
+        "Phase 62.1 implements Phase 63 evidence expansion",
+        "Phase 62.1 implements Phase 66 RC proof",
         "Controlled Write is a default Phase 62.1 catalog entry",
         "Hard Write is a default Phase 62.1 catalog entry",
     )
-    rendered_without_forbidden = catalog_text.split("## 6. Forbidden Claims", 1)[0]
-    for claim in broad_claims:
-        if claim in rendered_without_forbidden:
-            errors.append(f"forbidden overclaim outside rejection context: {claim}")
+    in_forbidden_claims = False
+    for line in catalog_text.splitlines():
+        if _is_forbidden_claims_heading(line):
+            in_forbidden_claims = True
+            continue
+        if in_forbidden_claims and _is_section_heading(line):
+            in_forbidden_claims = False
+
+        if _is_rejection_context(line, in_forbidden_claims):
+            continue
+
+        normalized_line = line.casefold()
+        for claim in broad_claims:
+            if claim.casefold() in normalized_line:
+                errors.append(f"forbidden overclaim outside rejection context: {claim}")
     return errors
 
 
@@ -120,8 +181,13 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
     def test_catalog_covers_default_read_notify_soft_write_entries(self) -> None:
         catalog_text = self.catalog_doc.read_text(encoding="utf-8")
         rows = _catalog_rows(catalog_text)
+        actions = [row[0].strip("`") for row in rows]
+        duplicate_actions = sorted(
+            {action for action in actions if actions.count(action) > 1}
+        )
         by_action = {row[0].strip("`"): row for row in rows}
 
+        self.assertEqual([], duplicate_actions)
         self.assertEqual(
             {
                 "enrichment_only_lookup",
@@ -131,6 +197,7 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             },
             set(by_action),
         )
+        self.assertEqual(4, len(rows))
         self.assertEqual("Read", by_action["enrichment_only_lookup"][1])
         self.assertEqual("Notify", by_action["operator_notification"][1])
         self.assertEqual("Notify", by_action["manual_escalation_request"][1])
@@ -175,6 +242,26 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             _catalog_validation_errors(hard_text),
         )
 
+    def test_rejects_malformed_and_duplicate_catalog_rows(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        malformed_text = catalog_text.replace(
+            "| `operator_notification` | Notify | AegisOps maintainers and IT Operations, Information Systems Department |",
+            "| `operator_notification` | Notify | AegisOps maintainers\n",
+        )
+        duplicate_text = catalog_text.replace(
+            "| `manual_escalation_request` | Notify |",
+            "| `operator_notification` | Notify |",
+        )
+
+        self.assertIn(
+            "operator_notification malformed catalog row has 3 columns; expected 10",
+            _catalog_validation_errors(malformed_text),
+        )
+        self.assertIn(
+            "operator_notification duplicate catalog action",
+            _catalog_validation_errors(duplicate_text),
+        )
+
     def test_rejects_missing_owner_receipt_and_limitation(self) -> None:
         catalog_text = self.catalog_doc.read_text(encoding="utf-8")
         missing_owner = catalog_text.replace(
@@ -216,6 +303,34 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             "forbidden overclaim outside rejection context: broad SOAR marketplace coverage is implemented",
             _catalog_validation_errors(overclaim_text),
         )
+
+    def test_rejects_case_insensitive_readiness_and_later_phase_overclaims(
+        self,
+    ) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        overclaim_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "\n".join(
+                (
+                    "Phase 62.1 CLAIMS rc",
+                    "Phase 62.1 claims GA",
+                    "Phase 62.1 claims commercial readiness",
+                    "Phase 62.1 implements Phase 63 evidence expansion",
+                    "Phase 62.1 implements Phase 66 RC proof",
+                    "## 8. Non-Goals",
+                )
+            ),
+        )
+        validation_errors = _catalog_validation_errors(overclaim_text)
+
+        for expected in (
+            "forbidden overclaim outside rejection context: Phase 62.1 claims RC",
+            "forbidden overclaim outside rejection context: Phase 62.1 claims GA",
+            "forbidden overclaim outside rejection context: Phase 62.1 claims commercial readiness",
+            "forbidden overclaim outside rejection context: Phase 62.1 implements Phase 63 evidence expansion",
+            "forbidden overclaim outside rejection context: Phase 62.1 implements Phase 66 RC proof",
+        ):
+            self.assertIn(expected, validation_errors)
 
     def test_validation_file_states_pass_and_handoff_limitations(self) -> None:
         validation_text = self.validation_doc.read_text(encoding="utf-8")

--- a/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
+++ b/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
@@ -3,9 +3,74 @@ from __future__ import annotations
 import pathlib
 import re
 import unittest
+from collections import Counter
 
 
 EXPECTED_CATALOG_COLUMNS = 10
+FORBIDDEN_OVERCLAIM_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "broad SOAR marketplace coverage is implemented",
+        re.compile(r"\bbroad\s+soar\s+marketplace\s+coverage\s+is\s+implemented\b", re.I),
+    ),
+    (
+        "arbitrary SOAR connector marketplace import is approved",
+        re.compile(
+            r"\barbitrary\s+soar\s+connector\s+marketplace\s+import\s+is\s+approved\b",
+            re.I,
+        ),
+    ),
+    (
+        "Phase 62.1 claims Beta",
+        re.compile(r"\bphase\s+62\.1\s+claims\s+beta(?:\s+readiness)?\b", re.I),
+    ),
+    (
+        "Phase 62.1 claims RC",
+        re.compile(r"\bphase\s+62\.1\s+claims\s+rc(?:\s+readiness)?\b", re.I),
+    ),
+    (
+        "Phase 62.1 claims GA",
+        re.compile(r"\bphase\s+62\.1\s+claims\s+ga(?:\s+readiness)?\b", re.I),
+    ),
+    (
+        "Phase 62.1 claims commercial readiness",
+        re.compile(
+            r"\bphase\s+62\.1\s+claims\s+commercial(?:\s+replacement)?\s+readiness\b",
+            re.I,
+        ),
+    ),
+    (
+        "Phase 62.1 claims broad SOAR replacement readiness",
+        re.compile(
+            r"\bphase\s+62\.1\s+claims\s+broad\s+soar\s+replacement\s+readiness\b",
+            re.I,
+        ),
+    ),
+    (
+        "Phase 62.1 implements Phase 63 evidence expansion",
+        re.compile(
+            r"\bphase\s+62\.1\s+implements\s+phase\s+63\s+evidence\s+expansion\b",
+            re.I,
+        ),
+    ),
+    (
+        "Phase 62.1 implements Phase 66 RC proof",
+        re.compile(r"\bphase\s+62\.1\s+implements\s+phase\s+66\s+rc\s+proof\b", re.I),
+    ),
+    (
+        "Controlled Write is a default Phase 62.1 catalog entry",
+        re.compile(
+            r"\bcontrolled\s+write\s+is\s+a\s+default\s+phase\s+62\.1\s+catalog\s+entry\b",
+            re.I,
+        ),
+    ),
+    (
+        "Hard Write is a default Phase 62.1 catalog entry",
+        re.compile(
+            r"\bhard\s+write\s+is\s+a\s+default\s+phase\s+62\.1\s+catalog\s+entry\b",
+            re.I,
+        ),
+    ),
+)
 
 
 def _doc_path(relative_path: str) -> pathlib.Path:
@@ -124,19 +189,6 @@ def _catalog_validation_errors(catalog_text: str) -> list[str]:
     for family in required_families - seen_families:
         errors.append(f"missing required family {family}")
 
-    broad_claims = (
-        "broad SOAR marketplace coverage is implemented",
-        "arbitrary SOAR connector marketplace import is approved",
-        "Phase 62.1 claims Beta",
-        "Phase 62.1 claims RC",
-        "Phase 62.1 claims GA",
-        "Phase 62.1 claims commercial readiness",
-        "Phase 62.1 claims broad SOAR replacement readiness",
-        "Phase 62.1 implements Phase 63 evidence expansion",
-        "Phase 62.1 implements Phase 66 RC proof",
-        "Controlled Write is a default Phase 62.1 catalog entry",
-        "Hard Write is a default Phase 62.1 catalog entry",
-    )
     in_forbidden_claims = False
     for line in catalog_text.splitlines():
         if _is_forbidden_claims_heading(line):
@@ -148,9 +200,8 @@ def _catalog_validation_errors(catalog_text: str) -> list[str]:
         if _is_rejection_context(line, in_forbidden_claims):
             continue
 
-        normalized_line = line.casefold()
-        for claim in broad_claims:
-            if claim.casefold() in normalized_line:
+        for claim, pattern in FORBIDDEN_OVERCLAIM_PATTERNS:
+            if pattern.search(line):
                 errors.append(f"forbidden overclaim outside rejection context: {claim}")
     return errors
 
@@ -182,10 +233,10 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
         catalog_text = self.catalog_doc.read_text(encoding="utf-8")
         rows = _catalog_rows(catalog_text)
         actions = [row[0].strip("`") for row in rows]
+        action_counts = Counter(actions)
         duplicate_actions = sorted(
-            {action for action in actions if actions.count(action) > 1}
+            action for action, count in action_counts.items() if count > 1
         )
-        by_action = {row[0].strip("`"): row for row in rows}
 
         self.assertEqual([], duplicate_actions)
         self.assertEqual(
@@ -195,9 +246,10 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
                 "manual_escalation_request",
                 "create_tracking_ticket",
             },
-            set(by_action),
+            set(actions),
         )
         self.assertEqual(4, len(rows))
+        by_action = {row[0].strip("`"): row for row in rows}
         self.assertEqual("Read", by_action["enrichment_only_lookup"][1])
         self.assertEqual("Notify", by_action["operator_notification"][1])
         self.assertEqual("Notify", by_action["manual_escalation_request"][1])
@@ -313,8 +365,9 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             "\n".join(
                 (
                     "Phase 62.1 CLAIMS rc",
-                    "Phase 62.1 claims GA",
-                    "Phase 62.1 claims commercial readiness",
+                    "Phase 62.1 claims RC readiness",
+                    "Phase 62.1 claims GA readiness",
+                    "Phase 62.1 claims commercial replacement readiness",
                     "Phase 62.1 implements Phase 63 evidence expansion",
                     "Phase 62.1 implements Phase 66 RC proof",
                     "## 8. Non-Goals",

--- a/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
+++ b/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
@@ -14,12 +14,25 @@ DISALLOWED_DEFAULT_FAMILIES = {"Controlled Write", "Hard Write"}
 FORBIDDEN_OVERCLAIM_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "broad SOAR marketplace coverage is implemented",
-        re.compile(r"\bbroad\s+soar\s+marketplace\s+coverage\s+is\s+implemented\b", re.I),
+        re.compile(
+            r"\bbroad\s+soar\s+marketplace\s+coverage\s+is\s+"
+            r"(?:approved|enabled|implemented|permitted)\b",
+            re.I,
+        ),
     ),
     (
         "arbitrary SOAR connector marketplace import is approved",
         re.compile(
-            r"\barbitrary\s+soar\s+connector\s+marketplace\s+import\s+is\s+approved\b",
+            r"\barbitrary\s+soar\s+connector\s+marketplace\s+import\s+is\s+"
+            r"(?:approved|enabled|implemented|permitted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "broad SOAR replacement readiness appears",
+        re.compile(
+            r"\bbroad\s+soar\s+replacement\s+readiness\s+is\s+"
+            r"(?:approved|enabled|implemented|permitted)\b",
             re.I,
         ),
     ),
@@ -210,7 +223,7 @@ FORBIDDEN_AUTHORITY_PROMOTION_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] 
             r"output|issue-lint\s+output|admin\s+configuration|admin\s+ui\s+state)"
             r"\s+"
             r"(?:(?:is|are|becomes?|become)\s+|as\s+)aegisops\s+"
-            r"(?:(?:action|case|reconciliation|execution\s+receipt|policy|"
+            r"(?:(?:action\s+policy|action|case|reconciliation|execution\s+receipt|policy|"
             r"release|gate|limitation|closeout)\s+)?truth\b",
             re.I,
         ),
@@ -262,7 +275,7 @@ FORBIDDEN_AUTHORITY_PROMOTION_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] 
         "browser state is AegisOps truth",
         re.compile(
             r"\bbrowser\s+state\s+is\s+aegisops\s+"
-            r"(?:(?:action|case|reconciliation|release|gate)\s+)?truth\b",
+            r"(?:(?:action\s+policy|action|case|reconciliation|release|gate)\s+)?truth\b",
             re.I,
         ),
     ),
@@ -478,7 +491,6 @@ def _is_rejection_context(
         r"^(?:[-*]\s*)?no\b",
         r"\bdoes\s+not\s+(?:broaden|claim|dispatch|enable|grant|implement|import|"
         r"launch|let|replace)\b",
-        r"\bdo\s+not\b",
         r"\bmust\s+fail\s+closed\b",
         r"\bmust\s+be\s+rejected\b",
         r"\b(?:is|are)\s+rejected\b",
@@ -891,6 +903,28 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             _catalog_validation_errors(overclaim_text),
         )
 
+    def test_rejects_marketplace_overclaim_wording_variants(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        overclaim_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "\n".join(
+                (
+                    "Broad SOAR marketplace coverage is approved.",
+                    "Arbitrary SOAR connector marketplace import is implemented.",
+                    "Broad SOAR replacement readiness is implemented.",
+                    "## 8. Non-Goals",
+                )
+            ),
+        )
+        validation_errors = _catalog_validation_errors(overclaim_text)
+
+        for expected in (
+            "forbidden overclaim outside rejection context: broad SOAR marketplace coverage is implemented",
+            "forbidden overclaim outside rejection context: arbitrary SOAR connector marketplace import is approved",
+            "forbidden overclaim outside rejection context: broad SOAR replacement readiness appears",
+        ):
+            self.assertIn(expected, validation_errors)
+
     def test_rejects_template_marketplace_import_overclaim(self) -> None:
         catalog_text = self.catalog_doc.read_text(encoding="utf-8")
         overclaim_text = catalog_text.replace(
@@ -967,6 +1001,11 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             "The catalog cannot hide that Phase 62.1 claims GA readiness.\n"
             "## 8. Non-Goals",
         )
+        do_not_marker_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "Operators do not dispute that Phase 62.1 claims GA readiness.\n"
+            "## 8. Non-Goals",
+        )
 
         expected = "forbidden overclaim outside rejection context: Phase 62.1 claims RC"
         self.assertIn(expected, _catalog_validation_errors(not_marker_text))
@@ -978,6 +1017,10 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
         self.assertIn(
             "forbidden overclaim outside rejection context: Phase 62.1 claims GA",
             _catalog_validation_errors(cannot_marker_text),
+        )
+        self.assertIn(
+            "forbidden overclaim outside rejection context: Phase 62.1 claims GA",
+            _catalog_validation_errors(do_not_marker_text),
         )
 
     def test_rejects_case_insensitive_readiness_and_later_phase_overclaims(
@@ -1100,6 +1143,7 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
                     "Ticket close is AegisOps reconciliation truth.",
                     "UI cache is AegisOps action policy truth.",
                     "Browser state is AegisOps case truth.",
+                    "Browser state is AegisOps action policy truth.",
                     "Browser state becomes AegisOps release truth.",
                     "Phase 62.1 treats browser state as AegisOps action truth.",
                     "Admin configuration is AegisOps action truth.",

--- a/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
+++ b/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+
+def _doc_path(relative_path: str) -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[2] / relative_path
+
+
+def _catalog_rows(catalog_text: str) -> list[list[str]]:
+    in_table = False
+    rows: list[list[str]] = []
+    for line in catalog_text.splitlines():
+        if line.startswith("| Catalog action | Family | Owner |"):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not line.startswith("|"):
+            if rows:
+                break
+            continue
+        if re.fullmatch(r"\|[ \-:|]+\|", line):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) == 10:
+            rows.append(cells)
+    return rows
+
+
+def _catalog_validation_errors(catalog_text: str) -> list[str]:
+    rows = _catalog_rows(catalog_text)
+    errors: list[str] = []
+    required_families = {"Read", "Notify", "Soft Write"}
+    seen_families: set[str] = set()
+    required_columns = (
+        "action",
+        "family",
+        "owner",
+        "substrate mapping need",
+        "approval posture",
+        "receipt shape",
+        "reconciliation expectation",
+        "allowed roles",
+        "idempotency posture",
+        "explicit limitations",
+    )
+
+    if not rows:
+        errors.append("missing catalog rows")
+
+    for row in rows:
+        action = row[0].strip("`")
+        family = row[1]
+        seen_families.add(family)
+        for index, column_name in enumerate(required_columns):
+            if not row[index] or row[index] in {"-", "TBD", "TODO"}:
+                errors.append(f"{action} missing {column_name}")
+        if family in {"Controlled Write", "Hard Write"}:
+            errors.append(f"{action} uses disallowed default family {family}")
+        if "owner" in row[2].lower() and "missing" in row[2].lower():
+            errors.append(f"{action} missing owner")
+        if "direct ad-hoc Shuffle launch" not in row[3]:
+            errors.append(f"{action} missing direct Shuffle launch rejection")
+        if "AegisOps" not in row[4] or "action request" not in row[4]:
+            errors.append(f"{action} missing action request approval posture")
+        if "AegisOps execution receipt" not in row[5]:
+            errors.append(f"{action} missing AegisOps receipt expectation")
+        if "cannot" not in row[6].lower():
+            errors.append(f"{action} missing reconciliation limitation")
+        if "`analyst`" not in row[7] or "`approver`" not in row[7]:
+            errors.append(f"{action} missing role boundary")
+        if "Idempotency key" not in row[8]:
+            errors.append(f"{action} missing idempotency posture")
+        if "No " not in row[9]:
+            errors.append(f"{action} missing explicit negative limitation")
+
+    for family in required_families - seen_families:
+        errors.append(f"missing required family {family}")
+
+    broad_claims = (
+        "broad SOAR marketplace coverage is implemented",
+        "arbitrary SOAR connector marketplace import is approved",
+        "Phase 62.1 claims Beta",
+        "Controlled Write is a default Phase 62.1 catalog entry",
+        "Hard Write is a default Phase 62.1 catalog entry",
+    )
+    rendered_without_forbidden = catalog_text.split("## 6. Forbidden Claims", 1)[0]
+    for claim in broad_claims:
+        if claim in rendered_without_forbidden:
+            errors.append(f"forbidden overclaim outside rejection context: {claim}")
+    return errors
+
+
+class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
+    catalog_doc = _doc_path("docs/phase-62-reviewed-automation-catalog-contract.md")
+    validation_doc = _doc_path(
+        "docs/phase-62-1-reviewed-automation-catalog-validation.md"
+    )
+    phase54_closeout = _doc_path("docs/phase-54-closeout-evaluation.md")
+    phase56_closeout = _doc_path("docs/phase-56-closeout-evaluation.md")
+    phase57_closeout = _doc_path("docs/phase-57-closeout-evaluation.md")
+    phase61_closeout = _doc_path("docs/phase-61-closeout-evaluation.md")
+    policy_doc = _doc_path("docs/phase-51-6-authority-boundary-negative-test-policy.md")
+
+    def test_required_artifacts_exist(self) -> None:
+        for path in (
+            self.catalog_doc,
+            self.validation_doc,
+            self.phase54_closeout,
+            self.phase56_closeout,
+            self.phase57_closeout,
+            self.phase61_closeout,
+            self.policy_doc,
+        ):
+            self.assertTrue(path.exists(), f"expected {path} to exist")
+
+    def test_catalog_covers_default_read_notify_soft_write_entries(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        rows = _catalog_rows(catalog_text)
+        by_action = {row[0].strip("`"): row for row in rows}
+
+        self.assertEqual(
+            {
+                "enrichment_only_lookup",
+                "operator_notification",
+                "manual_escalation_request",
+                "create_tracking_ticket",
+            },
+            set(by_action),
+        )
+        self.assertEqual("Read", by_action["enrichment_only_lookup"][1])
+        self.assertEqual("Notify", by_action["operator_notification"][1])
+        self.assertEqual("Notify", by_action["manual_escalation_request"][1])
+        self.assertEqual("Soft Write", by_action["create_tracking_ticket"][1])
+
+    def test_catalog_rows_have_required_contract_fields(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+
+        self.assertEqual([], _catalog_validation_errors(catalog_text))
+
+    def test_catalog_references_reviewed_shuffle_without_direct_launch(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+
+        required_terms = (
+            "reviewed Phase 54 Shuffle profile",
+            "reviewed Phase 54 Shuffle `enrichment_only_lookup` template contract",
+            "reviewed Phase 54 Shuffle `operator_notification` template contract",
+            "reviewed Phase 54 Shuffle `manual_escalation_request` template contract",
+            "reviewed Phase 54 Shuffle `create_tracking_ticket` template import contract",
+            "No direct ad-hoc Shuffle launch.",
+        )
+        for term in required_terms:
+            self.assertIn(term, catalog_text)
+
+    def test_rejects_controlled_and_hard_write_default_entries(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        controlled_text = catalog_text.replace(
+            "| `operator_notification` | Notify |",
+            "| `operator_notification` | Controlled Write |",
+        )
+        hard_text = catalog_text.replace(
+            "| `create_tracking_ticket` | Soft Write |",
+            "| `create_tracking_ticket` | Hard Write |",
+        )
+
+        self.assertIn(
+            "operator_notification uses disallowed default family Controlled Write",
+            _catalog_validation_errors(controlled_text),
+        )
+        self.assertIn(
+            "create_tracking_ticket uses disallowed default family Hard Write",
+            _catalog_validation_errors(hard_text),
+        )
+
+    def test_rejects_missing_owner_receipt_and_limitation(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        missing_owner = catalog_text.replace(
+            "| `enrichment_only_lookup` | Read | AegisOps maintainers and IT Operations, Information Systems Department |",
+            "| `enrichment_only_lookup` | Read | TODO |",
+        )
+        missing_receipt = catalog_text.replace(
+            "AegisOps execution receipt with `action_request_id`, `catalog_action`, `family`, `reviewed_template_version`, `correlation_id`, `idempotency_key`, `started_at`, `finished_at`, `status`, and subordinate lookup evidence reference.",
+            "TODO",
+        )
+        missing_limitation = catalog_text.replace(
+            "Read-only enrichment context. No protected target mutation, credential change, ticket mutation, case closure, detector activation, suppression activation, direct source actioning, or marketplace expansion.",
+            "TODO",
+        )
+
+        self.assertIn(
+            "enrichment_only_lookup missing owner",
+            _catalog_validation_errors(missing_owner),
+        )
+        self.assertIn(
+            "enrichment_only_lookup missing receipt shape",
+            _catalog_validation_errors(missing_receipt),
+        )
+        self.assertIn(
+            "enrichment_only_lookup missing explicit limitations",
+            _catalog_validation_errors(missing_limitation),
+        )
+
+    def test_rejects_marketplace_and_readiness_overclaim_outside_forbidden_context(
+        self,
+    ) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        overclaim_text = catalog_text.replace(
+            "Phase 62.1 records the default reviewed automation catalog",
+            "Phase 62.1 records that broad SOAR marketplace coverage is implemented and the default reviewed automation catalog",
+        )
+
+        self.assertIn(
+            "forbidden overclaim outside rejection context: broad SOAR marketplace coverage is implemented",
+            _catalog_validation_errors(overclaim_text),
+        )
+
+    def test_validation_file_states_pass_and_handoff_limitations(self) -> None:
+        validation_text = self.validation_doc.read_text(encoding="utf-8")
+
+        required_terms = (
+            "# Phase 62.1 Reviewed Automation Catalog Contract Validation",
+            "- Validation status: PASS",
+            "Read: `enrichment_only_lookup`",
+            "Notify: `operator_notification`, `manual_escalation_request`",
+            "Soft Write: `create_tracking_ticket`",
+            "Controlled Write and Hard Write default entries",
+            "No deviations.",
+            "Controlled Write and Hard Write remain blocked from default enablement",
+        )
+        for term in required_terms:
+            self.assertIn(term, validation_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
+++ b/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
@@ -22,21 +22,28 @@ FORBIDDEN_OVERCLAIM_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
         ),
     ),
     (
+        "template marketplace import is approved",
+        re.compile(
+            r"\btemplate\s+marketplace\s+import\s+is\s+(?:approved|implemented)\b",
+            re.I,
+        ),
+    ),
+    (
         "Phase 62.1 claims Beta",
-        re.compile(r"\bphase\s+62\.1\b.{0,80}\bclaims?\s+beta(?:\s+readiness)?\b", re.I),
+        re.compile(r"\bphase\s+62\.1\b.*\bclaims?\s+beta(?:\s+readiness)?\b", re.I),
     ),
     (
         "Phase 62.1 claims RC",
-        re.compile(r"\bphase\s+62\.1\b.{0,80}\bclaims?\s+rc(?:\s+readiness)?\b", re.I),
+        re.compile(r"\bphase\s+62\.1\b.*\bclaims?\s+rc(?:\s+readiness)?\b", re.I),
     ),
     (
         "Phase 62.1 claims GA",
-        re.compile(r"\bphase\s+62\.1\b.{0,80}\bclaims?\s+ga(?:\s+readiness)?\b", re.I),
+        re.compile(r"\bphase\s+62\.1\b.*\bclaims?\s+ga(?:\s+readiness)?\b", re.I),
     ),
     (
         "Phase 62.1 claims commercial readiness",
         re.compile(
-            r"\bphase\s+62\.1\b.{0,80}\bclaims?\s+commercial"
+            r"\bphase\s+62\.1\b.*\bclaims?\s+commercial"
             r"(?:\s+replacement)?\s+readiness\b",
             re.I,
         ),
@@ -44,7 +51,7 @@ FORBIDDEN_OVERCLAIM_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "Phase 62.1 claims broad SOAR replacement readiness",
         re.compile(
-            r"\bphase\s+62\.1\b.{0,80}\bclaims?\s+broad\s+soar\s+replacement"
+            r"\bphase\s+62\.1\b.*\bclaims?\s+broad\s+soar\s+replacement"
             r"\s+readiness\b",
             re.I,
         ),
@@ -52,7 +59,7 @@ FORBIDDEN_OVERCLAIM_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "Phase 62.1 is or claims standalone replacement readiness",
         re.compile(
-            r"\bphase\s+62\.1\b.{0,80}\b(?:is|claims?)\s+(?:a\s+)?standalone\s+replacement"
+            r"\bphase\s+62\.1\b.*\b(?:is|claims?)\s+(?:a\s+)?standalone\s+replacement"
             r"(?:\s+readiness)?\b",
             re.I,
         ),
@@ -194,6 +201,22 @@ FORBIDDEN_AUTHORITY_PROMOTION_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] 
         ),
     ),
     (
+        "browser state is AegisOps truth",
+        re.compile(
+            r"\bbrowser\s+state\s+is\s+aegisops\s+"
+            r"(?:(?:action|case|reconciliation|release|gate)\s+)?truth\b",
+            re.I,
+        ),
+    ),
+    (
+        "admin configuration is AegisOps truth",
+        re.compile(
+            r"\badmin\s+(?:configuration|ui\s+state)\s+is\s+aegisops\s+"
+            r"(?:(?:action|case|reconciliation|release|gate)\s+)?truth\b",
+            re.I,
+        ),
+    ),
+    (
         "AI output approves automation",
         re.compile(r"\bai\s+output\s+approves\s+automation\b", re.I),
     ),
@@ -214,6 +237,29 @@ PLACEHOLDER_CELL_PATTERN = re.compile(
     r"^(?:-|todo|tbd|placeholder|sample|fake)(?:\b|[:\s-])",
     re.I,
 )
+LIMITATION_BOUNDARY_TERMS = (
+    "account disablement",
+    "approval decision",
+    "automatic approval",
+    "autonomous remediation",
+    "broad escalation marketplace",
+    "broad notification marketplace",
+    "case closure",
+    "case-close authority",
+    "credential change",
+    "credential rotation",
+    "detector activation",
+    "direct source actioning",
+    "group membership change",
+    "marketplace expansion",
+    "protected target mutation",
+    "readiness claim",
+    "support-authority override",
+    "suppression activation",
+    "ticket closure",
+    "ticket-close authority",
+    "workflow state mutation",
+)
 
 
 def _doc_path(relative_path: str) -> pathlib.Path:
@@ -225,21 +271,22 @@ def _catalog_rows(catalog_text: str) -> list[list[str]]:
     seen_header = False
     rows: list[list[str]] = []
     for line in catalog_text.splitlines():
-        if line == CATALOG_SECTION_HEADING:
+        stripped_line = line.strip()
+        if stripped_line == CATALOG_SECTION_HEADING:
             in_section = True
             continue
-        if line == CATALOG_SECTION_END_HEADING:
+        if stripped_line == CATALOG_SECTION_END_HEADING:
             break
         if not in_section:
             continue
-        if line.startswith("| Catalog action | Family | Owner |"):
+        if stripped_line.startswith("| Catalog action | Family | Owner |"):
             seen_header = True
             continue
-        if not seen_header or not line.startswith("|"):
+        if not seen_header or not stripped_line.startswith("|"):
             continue
-        if re.fullmatch(r"\|[ \-:|]+\|", line):
+        if re.fullmatch(r"\|[ \-:|]+\|", stripped_line):
             continue
-        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        cells = [cell.strip() for cell in stripped_line.strip("|").split("|")]
         rows.append(cells)
     return rows
 
@@ -264,28 +311,38 @@ def _is_rejection_context(
     line: str,
     in_forbidden_claims: bool,
     in_non_goals: bool,
+    in_fail_closed_rule_list: bool,
 ) -> bool:
     if in_forbidden_claims or in_non_goals:
         return True
 
-    normalized = line.casefold()
-    rejection_markers = (
-        "cannot",
-        "fail closed",
-        "forbidden",
-        "must be rejected",
-        "non-goal",
-        "out of scope",
-        "rejected",
-        "remain blocked",
+    stripped = line.strip()
+    normalized = stripped.casefold()
+    if in_fail_closed_rule_list and stripped.startswith("- "):
+        return True
+
+    explicit_negation_patterns = (
+        r"^(?:[-*]\s*)?no\b",
+        r"\bdoes\s+not\s+(?:broaden|dispatch|enable|grant|import|launch|let)\b",
+        r"\bdo\s+not\b",
+        r"\bmust\s+fail\s+closed\b",
+        r"\bmust\s+be\s+rejected\b",
+        r"\b(?:is|are)\s+rejected\b",
+        r"\brejected\s+when\b",
+        r"\bremain\s+blocked\b",
+        r"\bnon-goals?\b",
+        r"\bout\s+of\s+scope\b",
+        r"\boutside\s+explicit\s+rejection\s+or\s+non-goal\s+context\b",
+        r"\bcannot\s+(?:approve|become|claim|close|execute|gate|reconcile|replace)\b",
     )
-    return any(marker in normalized for marker in rejection_markers)
+    return any(re.search(pattern, normalized) for pattern in explicit_negation_patterns)
 
 
 def _non_rejection_segments(catalog_text: str) -> list[str]:
     in_forbidden_claims = False
     in_non_goals = False
     in_validation_rules = False
+    in_fail_closed_rule_list = False
     segments: list[str] = []
     current_lines: list[str] = []
 
@@ -300,37 +357,49 @@ def _non_rejection_segments(catalog_text: str) -> list[str]:
             in_forbidden_claims = True
             in_non_goals = False
             in_validation_rules = False
+            in_fail_closed_rule_list = False
             continue
         if _is_non_goals_heading(line):
             flush()
             in_forbidden_claims = False
             in_non_goals = True
             in_validation_rules = False
+            in_fail_closed_rule_list = False
             continue
         if _is_validation_rules_heading(line):
             flush()
             in_forbidden_claims = False
             in_non_goals = False
             in_validation_rules = True
+            in_fail_closed_rule_list = False
             continue
         if (
             in_forbidden_claims or in_non_goals or in_validation_rules
         ) and _is_section_heading(line):
+            flush()
             in_forbidden_claims = False
             in_non_goals = False
             in_validation_rules = False
+            in_fail_closed_rule_list = False
+
+        if in_validation_rules and "must fail closed when" in line.casefold():
+            flush()
+            in_fail_closed_rule_list = True
+            continue
 
         if _is_rejection_context(
             line,
-            in_forbidden_claims or in_validation_rules,
+            in_forbidden_claims,
             in_non_goals,
+            in_fail_closed_rule_list,
         ):
             flush()
             continue
 
         stripped = line.strip()
         if not stripped:
-            flush()
+            if current_lines:
+                current_lines.append(" ")
             continue
         current_lines.append(stripped)
 
@@ -399,8 +468,12 @@ def _catalog_validation_errors(catalog_text: str) -> list[str]:
             errors.append(f"{action} missing role boundary")
         if "Idempotency key" not in row[8]:
             errors.append(f"{action} missing idempotency posture")
-        if "No " not in row[9]:
+        limitation = row[9]
+        normalized_limitation = limitation.casefold()
+        if not re.search(r"\bno\b", normalized_limitation):
             errors.append(f"{action} missing explicit negative limitation")
+        if not any(term in normalized_limitation for term in LIMITATION_BOUNDARY_TERMS):
+            errors.append(f"{action} missing limitation boundary semantics")
 
     for family in required_families - seen_families:
         errors.append(f"missing required family {family}")
@@ -489,8 +562,16 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             CATALOG_SECTION_END_HEADING,
             f"{operator_notification_row}\n\n{CATALOG_SECTION_END_HEADING}",
         )
+        indented_section_row = catalog_text.replace(
+            operator_notification_row,
+            f"    {operator_notification_row}",
+        )
 
         self.assertEqual(4, len(_catalog_rows(prefixed_text)))
+        self.assertIn(
+            "operator_notification",
+            [row[0].strip("`") for row in _catalog_rows(indented_section_row)],
+        )
         self.assertIn(
             "operator_notification duplicate catalog action",
             _catalog_validation_errors(extra_section_row),
@@ -583,6 +664,18 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             _catalog_validation_errors(missing_limitation),
         )
 
+    def test_rejects_limitation_without_boundary_semantics(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        weak_limitation = catalog_text.replace(
+            "Read-only enrichment context. No protected target mutation, credential change, ticket mutation, case closure, detector activation, suppression activation, direct source actioning, or marketplace expansion.",
+            "No delay.",
+        )
+
+        self.assertIn(
+            "enrichment_only_lookup missing limitation boundary semantics",
+            _catalog_validation_errors(weak_limitation),
+        )
+
     def test_rejects_placeholder_required_columns_case_insensitively(self) -> None:
         catalog_text = self.catalog_doc.read_text(encoding="utf-8")
         missing_owner = catalog_text.replace(
@@ -625,6 +718,31 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             _catalog_validation_errors(overclaim_text),
         )
 
+    def test_rejects_template_marketplace_import_overclaim(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        overclaim_text = catalog_text.replace(
+            "Phase 62.1 records the default reviewed automation catalog",
+            "Phase 62.1 records that template marketplace import is approved and the default reviewed automation catalog",
+        )
+
+        self.assertIn(
+            "forbidden overclaim outside rejection context: template marketplace import is approved",
+            _catalog_validation_errors(overclaim_text),
+        )
+
+    def test_scans_non_rejection_validation_rules_lines_for_overclaims(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        overclaim_text = catalog_text.replace(
+            "The Phase 62.1 reviewed automation catalog verifier must fail closed when:",
+            "The verifier reports Phase 62.1 claims GA readiness.\n\n"
+            "The Phase 62.1 reviewed automation catalog verifier must fail closed when:",
+        )
+
+        self.assertIn(
+            "forbidden overclaim outside rejection context: Phase 62.1 claims GA",
+            _catalog_validation_errors(overclaim_text),
+        )
+
     def test_rejects_overclaims_with_not_marker_and_line_wrapping(self) -> None:
         catalog_text = self.catalog_doc.read_text(encoding="utf-8")
         not_marker_text = catalog_text.replace(
@@ -640,11 +758,32 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             "## 8. Non-Goals",
             "Phase 62.1 claims\nRC readiness\n## 8. Non-Goals",
         )
+        blank_wrapped_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "Phase 62.1 claims\n\nRC readiness\n## 8. Non-Goals",
+        )
+        long_wrapped_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "Phase 62.1 "
+            + "records reviewed catalog scope without expanding authority " * 5
+            + "claims RC readiness\n## 8. Non-Goals",
+        )
+        cannot_marker_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "The catalog cannot hide that Phase 62.1 claims GA readiness.\n"
+            "## 8. Non-Goals",
+        )
 
         expected = "forbidden overclaim outside rejection context: Phase 62.1 claims RC"
         self.assertIn(expected, _catalog_validation_errors(not_marker_text))
         self.assertIn(expected, _catalog_validation_errors(does_not_marker_text))
         self.assertIn(expected, _catalog_validation_errors(wrapped_text))
+        self.assertIn(expected, _catalog_validation_errors(blank_wrapped_text))
+        self.assertIn(expected, _catalog_validation_errors(long_wrapped_text))
+        self.assertIn(
+            "forbidden overclaim outside rejection context: Phase 62.1 claims GA",
+            _catalog_validation_errors(cannot_marker_text),
+        )
 
     def test_rejects_case_insensitive_readiness_and_later_phase_overclaims(
         self,
@@ -747,6 +886,8 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
                     "Ticket status is AegisOps case truth.",
                     "Ticket close is AegisOps reconciliation truth.",
                     "UI cache is AegisOps action policy truth.",
+                    "Browser state is AegisOps case truth.",
+                    "Admin configuration is AegisOps action truth.",
                     "AI output approves automation.",
                     "Source-native status reconciles automation.",
                     "Verifier output gates production readiness.",
@@ -765,6 +906,8 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             "forbidden authority promotion outside rejection context: ticket status is AegisOps case truth",
             "forbidden authority promotion outside rejection context: ticket close is AegisOps reconciliation truth",
             "forbidden authority promotion outside rejection context: UI cache is AegisOps action policy truth",
+            "forbidden authority promotion outside rejection context: browser state is AegisOps truth",
+            "forbidden authority promotion outside rejection context: admin configuration is AegisOps truth",
             "forbidden authority promotion outside rejection context: AI output approves automation",
             "forbidden authority promotion outside rejection context: source-native status reconciles automation",
             "forbidden authority promotion outside rejection context: verifier output gates production readiness",

--- a/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
+++ b/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
@@ -23,29 +23,43 @@ FORBIDDEN_OVERCLAIM_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ),
     (
         "Phase 62.1 claims Beta",
-        re.compile(r"\bphase\s+62\.1\s+claims\s+beta(?:\s+readiness)?\b", re.I),
+        re.compile(r"\bphase\s+62\.1\b.{0,80}\bclaims?\s+beta(?:\s+readiness)?\b", re.I),
     ),
     (
         "Phase 62.1 claims RC",
-        re.compile(r"\bphase\s+62\.1\s+claims\s+rc(?:\s+readiness)?\b", re.I),
+        re.compile(r"\bphase\s+62\.1\b.{0,80}\bclaims?\s+rc(?:\s+readiness)?\b", re.I),
     ),
     (
         "Phase 62.1 claims GA",
-        re.compile(r"\bphase\s+62\.1\s+claims\s+ga(?:\s+readiness)?\b", re.I),
+        re.compile(r"\bphase\s+62\.1\b.{0,80}\bclaims?\s+ga(?:\s+readiness)?\b", re.I),
     ),
     (
         "Phase 62.1 claims commercial readiness",
         re.compile(
-            r"\bphase\s+62\.1\s+claims\s+commercial(?:\s+replacement)?\s+readiness\b",
+            r"\bphase\s+62\.1\b.{0,80}\bclaims?\s+commercial"
+            r"(?:\s+replacement)?\s+readiness\b",
             re.I,
         ),
     ),
     (
         "Phase 62.1 claims broad SOAR replacement readiness",
         re.compile(
-            r"\bphase\s+62\.1\s+claims\s+broad\s+soar\s+replacement\s+readiness\b",
+            r"\bphase\s+62\.1\b.{0,80}\bclaims?\s+broad\s+soar\s+replacement"
+            r"\s+readiness\b",
             re.I,
         ),
+    ),
+    (
+        "Phase 62.1 is or claims standalone replacement readiness",
+        re.compile(
+            r"\bphase\s+62\.1\b.{0,80}\b(?:is|claims?)\s+(?:a\s+)?standalone\s+replacement"
+            r"(?:\s+readiness)?\b",
+            re.I,
+        ),
+    ),
+    (
+        "standalone replacement claims are approved",
+        re.compile(r"\bstandalone\s+replacement\s+claims?\s+are\s+approved\b", re.I),
     ),
     (
         "Phase 62.1 implements Phase 63 evidence expansion",
@@ -72,6 +86,133 @@ FORBIDDEN_OVERCLAIM_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
             re.I,
         ),
     ),
+)
+FORBIDDEN_SETUP_TRUST_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "placeholder credentials are valid",
+        re.compile(
+            r"\bplaceholder\s+(?:shuffle\s+)?(?:api\s+keys?|secrets?|credentials?|tokens?)"
+            r"\s+(?:(?:are|is)\s+(?:valid|trusted|approved|accepted)|as\s+valid"
+            r"\s+setup\s+state)\b",
+            re.I,
+        ),
+    ),
+    (
+        "sample credentials are valid",
+        re.compile(
+            r"\bsample\s+(?:secrets?|credentials?|tokens?)"
+            r"\s+(?:are|is)\s+(?:valid|trusted|approved|accepted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "fake values are valid",
+        re.compile(
+            r"\bfake\s+values?\s+(?:are|is)\s+(?:valid|trusted|approved|accepted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "TODO values are valid",
+        re.compile(
+            r"\btodo\s+values?\s+(?:are|is)\s+(?:valid|trusted|approved|accepted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "unsigned tokens are valid",
+        re.compile(
+            r"\bunsigned\s+tokens?\s+(?:are|is)\s+(?:valid|trusted|approved|accepted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "inline secrets are valid",
+        re.compile(
+            r"\binline\s+secrets?\s+(?:are|is)\s+(?:valid|trusted|approved|accepted)\b",
+            re.I,
+        ),
+    ),
+    (
+        "raw forwarded headers are trusted",
+        re.compile(
+            r"\braw\s+forwarded\s+headers?\s+(?:are|is)\s+trusted\b",
+            re.I,
+        ),
+    ),
+    (
+        "inferred linkage is valid",
+        re.compile(
+            r"\binferred\s+(?:tenant|source|delegation)\s+linkage\s+"
+            r"(?:is|are)\s+(?:valid|trusted|approved|accepted)\b",
+            re.I,
+        ),
+    ),
+)
+FORBIDDEN_AUTHORITY_PROMOTION_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "direct ad-hoc Shuffle launch is approved",
+        re.compile(r"\bdirect\s+ad-?hoc\s+shuffle\s+launch\s+is\s+approved\b", re.I),
+    ),
+    (
+        "Shuffle workflow success is AegisOps reconciliation truth",
+        re.compile(
+            r"\bshuffle\s+workflow\s+success\s+is\s+aegisops\s+reconciliation\s+truth\b",
+            re.I,
+        ),
+    ),
+    (
+        "Shuffle callback payload is AegisOps execution receipt truth",
+        re.compile(
+            r"\bshuffle\s+callback\s+payload\s+is\s+aegisops\s+execution\s+receipt\s+truth\b",
+            re.I,
+        ),
+    ),
+    (
+        "Shuffle workflow status closes AegisOps cases",
+        re.compile(
+            r"\bshuffle\s+workflow\s+status\s+closes\s+aegisops\s+cases\b",
+            re.I,
+        ),
+    ),
+    (
+        "ticket status is AegisOps case truth",
+        re.compile(r"\bticket\s+status\s+is\s+aegisops\s+case\s+truth\b", re.I),
+    ),
+    (
+        "ticket close is AegisOps reconciliation truth",
+        re.compile(
+            r"\bticket\s+close\s+is\s+aegisops\s+reconciliation\s+truth\b",
+            re.I,
+        ),
+    ),
+    (
+        "UI cache is AegisOps action policy truth",
+        re.compile(
+            r"\bui\s+cache\s+is\s+aegisops\s+action\s+policy\s+truth\b",
+            re.I,
+        ),
+    ),
+    (
+        "AI output approves automation",
+        re.compile(r"\bai\s+output\s+approves\s+automation\b", re.I),
+    ),
+    (
+        "source-native status reconciles automation",
+        re.compile(r"\bsource-native\s+status\s+reconciles\s+automation\b", re.I),
+    ),
+    (
+        "verifier output gates production readiness",
+        re.compile(r"\bverifier\s+output\s+gates\s+production\s+readiness\b", re.I),
+    ),
+    (
+        "issue-lint output gates production readiness",
+        re.compile(r"\bissue-lint\s+output\s+gates\s+production\s+readiness\b", re.I),
+    ),
+)
+PLACEHOLDER_CELL_PATTERN = re.compile(
+    r"^(?:-|todo|tbd|placeholder|sample|fake)(?:\b|[:\s-])",
+    re.I,
 )
 
 
@@ -111,6 +252,10 @@ def _is_non_goals_heading(line: str) -> bool:
     return bool(re.fullmatch(r"##\s+\d+\.\s+Non-Goals", line.strip()))
 
 
+def _is_validation_rules_heading(line: str) -> bool:
+    return bool(re.fullmatch(r"##\s+\d+\.\s+Validation Rules", line.strip()))
+
+
 def _is_section_heading(line: str) -> bool:
     return bool(re.fullmatch(r"##\s+\d+\..*", line.strip()))
 
@@ -126,7 +271,6 @@ def _is_rejection_context(
     normalized = line.casefold()
     rejection_markers = (
         "cannot",
-        "does not",
         "fail closed",
         "forbidden",
         "must be rejected",
@@ -141,6 +285,7 @@ def _is_rejection_context(
 def _non_rejection_segments(catalog_text: str) -> list[str]:
     in_forbidden_claims = False
     in_non_goals = False
+    in_validation_rules = False
     segments: list[str] = []
     current_lines: list[str] = []
 
@@ -154,17 +299,32 @@ def _non_rejection_segments(catalog_text: str) -> list[str]:
             flush()
             in_forbidden_claims = True
             in_non_goals = False
+            in_validation_rules = False
             continue
         if _is_non_goals_heading(line):
             flush()
             in_forbidden_claims = False
             in_non_goals = True
+            in_validation_rules = False
             continue
-        if (in_forbidden_claims or in_non_goals) and _is_section_heading(line):
+        if _is_validation_rules_heading(line):
+            flush()
             in_forbidden_claims = False
             in_non_goals = False
+            in_validation_rules = True
+            continue
+        if (
+            in_forbidden_claims or in_non_goals or in_validation_rules
+        ) and _is_section_heading(line):
+            in_forbidden_claims = False
+            in_non_goals = False
+            in_validation_rules = False
 
-        if _is_rejection_context(line, in_forbidden_claims, in_non_goals):
+        if _is_rejection_context(
+            line,
+            in_forbidden_claims or in_validation_rules,
+            in_non_goals,
+        ):
             flush()
             continue
 
@@ -176,6 +336,11 @@ def _non_rejection_segments(catalog_text: str) -> list[str]:
 
     flush()
     return segments
+
+
+def _is_placeholder_cell(cell: str) -> bool:
+    normalized = cell.strip().strip("`").strip()
+    return not normalized or bool(PLACEHOLDER_CELL_PATTERN.search(normalized))
 
 
 def _catalog_validation_errors(catalog_text: str) -> list[str]:
@@ -216,7 +381,7 @@ def _catalog_validation_errors(catalog_text: str) -> list[str]:
         family = row[1]
         seen_families.add(family)
         for index, column_name in enumerate(required_columns):
-            if not row[index] or row[index] in {"-", "TBD", "TODO"}:
+            if _is_placeholder_cell(row[index]):
                 errors.append(f"{action} missing {column_name}")
         if family in {"Controlled Write", "Hard Write"}:
             errors.append(f"{action} uses disallowed default family {family}")
@@ -244,6 +409,14 @@ def _catalog_validation_errors(catalog_text: str) -> list[str]:
         for claim, pattern in FORBIDDEN_OVERCLAIM_PATTERNS:
             if pattern.search(segment):
                 errors.append(f"forbidden overclaim outside rejection context: {claim}")
+        for claim, pattern in FORBIDDEN_SETUP_TRUST_PATTERNS:
+            if pattern.search(segment):
+                errors.append(f"forbidden setup trust outside rejection context: {claim}")
+        for claim, pattern in FORBIDDEN_AUTHORITY_PROMOTION_PATTERNS:
+            if pattern.search(segment):
+                errors.append(
+                    f"forbidden authority promotion outside rejection context: {claim}"
+                )
     return errors
 
 
@@ -410,6 +583,34 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             _catalog_validation_errors(missing_limitation),
         )
 
+    def test_rejects_placeholder_required_columns_case_insensitively(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        missing_owner = catalog_text.replace(
+            "| `enrichment_only_lookup` | Read | AegisOps maintainers and IT Operations, Information Systems Department |",
+            "| `enrichment_only_lookup` | Read | todo owner to wire later |",
+        )
+        missing_receipt = catalog_text.replace(
+            "AegisOps execution receipt with `action_request_id`, `catalog_action`, `family`, `reviewed_template_version`, `correlation_id`, `idempotency_key`, `started_at`, `finished_at`, `status`, and subordinate lookup evidence reference.",
+            "ToDo: add receipt shape after implementation",
+        )
+        missing_limitation = catalog_text.replace(
+            "Read-only enrichment context. No protected target mutation, credential change, ticket mutation, case closure, detector activation, suppression activation, direct source actioning, or marketplace expansion.",
+            "tbd - add explicit limitation text",
+        )
+
+        self.assertIn(
+            "enrichment_only_lookup missing owner",
+            _catalog_validation_errors(missing_owner),
+        )
+        self.assertIn(
+            "enrichment_only_lookup missing receipt shape",
+            _catalog_validation_errors(missing_receipt),
+        )
+        self.assertIn(
+            "enrichment_only_lookup missing explicit limitations",
+            _catalog_validation_errors(missing_limitation),
+        )
+
     def test_rejects_marketplace_and_readiness_overclaim_outside_forbidden_context(
         self,
     ) -> None:
@@ -430,6 +631,11 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             "## 8. Non-Goals",
             "Phase 62.1 claims RC, not just Beta\n## 8. Non-Goals",
         )
+        does_not_marker_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "Phase 62.1 does not just claim RC readiness; it claims GA readiness\n"
+            "## 8. Non-Goals",
+        )
         wrapped_text = catalog_text.replace(
             "## 8. Non-Goals",
             "Phase 62.1 claims\nRC readiness\n## 8. Non-Goals",
@@ -437,6 +643,7 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
 
         expected = "forbidden overclaim outside rejection context: Phase 62.1 claims RC"
         self.assertIn(expected, _catalog_validation_errors(not_marker_text))
+        self.assertIn(expected, _catalog_validation_errors(does_not_marker_text))
         self.assertIn(expected, _catalog_validation_errors(wrapped_text))
 
     def test_rejects_case_insensitive_readiness_and_later_phase_overclaims(
@@ -465,6 +672,103 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             "forbidden overclaim outside rejection context: Phase 62.1 claims commercial readiness",
             "forbidden overclaim outside rejection context: Phase 62.1 implements Phase 63 evidence expansion",
             "forbidden overclaim outside rejection context: Phase 62.1 implements Phase 66 RC proof",
+        ):
+            self.assertIn(expected, validation_errors)
+
+    def test_rejects_standalone_replacement_claims_outside_rejection_context(
+        self,
+    ) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        overclaim_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "\n".join(
+                (
+                    "Phase 62.1 is a standalone replacement.",
+                    "Phase 62.1 claims standalone replacement readiness",
+                    "Standalone replacement claims are approved",
+                    "## 8. Non-Goals",
+                )
+            ),
+        )
+        validation_errors = _catalog_validation_errors(overclaim_text)
+
+        self.assertIn(
+            "forbidden overclaim outside rejection context: Phase 62.1 is or claims standalone replacement readiness",
+            validation_errors,
+        )
+        self.assertIn(
+            "forbidden overclaim outside rejection context: standalone replacement claims are approved",
+            validation_errors,
+        )
+
+    def test_rejects_setup_trust_claims_outside_rejection_context(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        trust_claim_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "\n".join(
+                (
+                    "Phase 62.1 treats placeholder Shuffle API keys as valid setup state.",
+                    "Placeholder Shuffle API keys are valid credentials.",
+                    "Sample credentials are accepted.",
+                    "Fake values are valid setup state.",
+                    "TODO values are valid setup state.",
+                    "Unsigned tokens are trusted.",
+                    "Inline secrets are approved.",
+                    "Raw forwarded headers are trusted callback identity.",
+                    "Inferred tenant linkage is valid.",
+                    "## 8. Non-Goals",
+                )
+            ),
+        )
+        validation_errors = _catalog_validation_errors(trust_claim_text)
+
+        for expected in (
+            "forbidden setup trust outside rejection context: placeholder credentials are valid",
+            "forbidden setup trust outside rejection context: sample credentials are valid",
+            "forbidden setup trust outside rejection context: fake values are valid",
+            "forbidden setup trust outside rejection context: TODO values are valid",
+            "forbidden setup trust outside rejection context: unsigned tokens are valid",
+            "forbidden setup trust outside rejection context: inline secrets are valid",
+            "forbidden setup trust outside rejection context: raw forwarded headers are trusted",
+            "forbidden setup trust outside rejection context: inferred linkage is valid",
+        ):
+            self.assertIn(expected, validation_errors)
+
+    def test_rejects_authority_promotion_claims_outside_rejection_context(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        authority_claim_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "\n".join(
+                (
+                    "Direct ad-hoc Shuffle launch is approved.",
+                    "Shuffle workflow success is AegisOps reconciliation truth.",
+                    "Shuffle callback payload is AegisOps execution receipt truth.",
+                    "Shuffle workflow status closes AegisOps cases.",
+                    "Ticket status is AegisOps case truth.",
+                    "Ticket close is AegisOps reconciliation truth.",
+                    "UI cache is AegisOps action policy truth.",
+                    "AI output approves automation.",
+                    "Source-native status reconciles automation.",
+                    "Verifier output gates production readiness.",
+                    "Issue-lint output gates production readiness.",
+                    "## 8. Non-Goals",
+                )
+            ),
+        )
+        validation_errors = _catalog_validation_errors(authority_claim_text)
+
+        for expected in (
+            "forbidden authority promotion outside rejection context: direct ad-hoc Shuffle launch is approved",
+            "forbidden authority promotion outside rejection context: Shuffle workflow success is AegisOps reconciliation truth",
+            "forbidden authority promotion outside rejection context: Shuffle callback payload is AegisOps execution receipt truth",
+            "forbidden authority promotion outside rejection context: Shuffle workflow status closes AegisOps cases",
+            "forbidden authority promotion outside rejection context: ticket status is AegisOps case truth",
+            "forbidden authority promotion outside rejection context: ticket close is AegisOps reconciliation truth",
+            "forbidden authority promotion outside rejection context: UI cache is AegisOps action policy truth",
+            "forbidden authority promotion outside rejection context: AI output approves automation",
+            "forbidden authority promotion outside rejection context: source-native status reconciles automation",
+            "forbidden authority promotion outside rejection context: verifier output gates production readiness",
+            "forbidden authority promotion outside rejection context: issue-lint output gates production readiness",
         ):
             self.assertIn(expected, validation_errors)
 

--- a/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
+++ b/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from collections import Counter
 import pathlib
 import re
 import unittest
-from collections import Counter
 
 
 EXPECTED_CATALOG_COLUMNS = 10
+CATALOG_SECTION_HEADING = "## 3. Approved Default Catalog Entries"
+CATALOG_SECTION_END_HEADING = "## 4. Catalog Boundedness Rules"
 FORBIDDEN_OVERCLAIM_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "broad SOAR marketplace coverage is implemented",
@@ -78,17 +80,21 @@ def _doc_path(relative_path: str) -> pathlib.Path:
 
 
 def _catalog_rows(catalog_text: str) -> list[list[str]]:
-    in_table = False
+    in_section = False
+    seen_header = False
     rows: list[list[str]] = []
     for line in catalog_text.splitlines():
+        if line == CATALOG_SECTION_HEADING:
+            in_section = True
+            continue
+        if line == CATALOG_SECTION_END_HEADING:
+            break
+        if not in_section:
+            continue
         if line.startswith("| Catalog action | Family | Owner |"):
-            in_table = True
+            seen_header = True
             continue
-        if not in_table:
-            continue
-        if not line.startswith("|"):
-            if rows:
-                break
+        if not seen_header or not line.startswith("|"):
             continue
         if re.fullmatch(r"\|[ \-:|]+\|", line):
             continue
@@ -101,12 +107,20 @@ def _is_forbidden_claims_heading(line: str) -> bool:
     return bool(re.fullmatch(r"##\s+\d+\.\s+Forbidden Claims", line.strip()))
 
 
+def _is_non_goals_heading(line: str) -> bool:
+    return bool(re.fullmatch(r"##\s+\d+\.\s+Non-Goals", line.strip()))
+
+
 def _is_section_heading(line: str) -> bool:
     return bool(re.fullmatch(r"##\s+\d+\..*", line.strip()))
 
 
-def _is_rejection_context(line: str, in_forbidden_claims: bool) -> bool:
-    if in_forbidden_claims:
+def _is_rejection_context(
+    line: str,
+    in_forbidden_claims: bool,
+    in_non_goals: bool,
+) -> bool:
+    if in_forbidden_claims or in_non_goals:
         return True
 
     normalized = line.casefold()
@@ -116,15 +130,52 @@ def _is_rejection_context(line: str, in_forbidden_claims: bool) -> bool:
         "fail closed",
         "forbidden",
         "must be rejected",
-        "no ",
-        "not ",
         "non-goal",
         "out of scope",
         "rejected",
         "remain blocked",
-        "without ",
     )
     return any(marker in normalized for marker in rejection_markers)
+
+
+def _non_rejection_segments(catalog_text: str) -> list[str]:
+    in_forbidden_claims = False
+    in_non_goals = False
+    segments: list[str] = []
+    current_lines: list[str] = []
+
+    def flush() -> None:
+        if current_lines:
+            segments.append(" ".join(current_lines))
+            current_lines.clear()
+
+    for line in catalog_text.splitlines():
+        if _is_forbidden_claims_heading(line):
+            flush()
+            in_forbidden_claims = True
+            in_non_goals = False
+            continue
+        if _is_non_goals_heading(line):
+            flush()
+            in_forbidden_claims = False
+            in_non_goals = True
+            continue
+        if (in_forbidden_claims or in_non_goals) and _is_section_heading(line):
+            in_forbidden_claims = False
+            in_non_goals = False
+
+        if _is_rejection_context(line, in_forbidden_claims, in_non_goals):
+            flush()
+            continue
+
+        stripped = line.strip()
+        if not stripped:
+            flush()
+            continue
+        current_lines.append(stripped)
+
+    flush()
+    return segments
 
 
 def _catalog_validation_errors(catalog_text: str) -> list[str]:
@@ -189,19 +240,9 @@ def _catalog_validation_errors(catalog_text: str) -> list[str]:
     for family in required_families - seen_families:
         errors.append(f"missing required family {family}")
 
-    in_forbidden_claims = False
-    for line in catalog_text.splitlines():
-        if _is_forbidden_claims_heading(line):
-            in_forbidden_claims = True
-            continue
-        if in_forbidden_claims and _is_section_heading(line):
-            in_forbidden_claims = False
-
-        if _is_rejection_context(line, in_forbidden_claims):
-            continue
-
+    for segment in _non_rejection_segments(catalog_text):
         for claim, pattern in FORBIDDEN_OVERCLAIM_PATTERNS:
-            if pattern.search(line):
+            if pattern.search(segment):
                 errors.append(f"forbidden overclaim outside rejection context: {claim}")
     return errors
 
@@ -254,6 +295,33 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
         self.assertEqual("Notify", by_action["operator_notification"][1])
         self.assertEqual("Notify", by_action["manual_escalation_request"][1])
         self.assertEqual("Soft Write", by_action["create_tracking_ticket"][1])
+
+    def test_catalog_parser_uses_approved_section_and_all_section_rows(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        fake_table = "\n".join(
+            (
+                "| Catalog action | Family | Owner | Substrate mapping need | Required approval posture | Expected receipt shape | Reconciliation expectation | Allowed roles | Idempotency posture | Explicit limitations |",
+                "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+                "| `fake_pre_section_action` | Hard Write | Fake owner | Fake mapping | Fake approval | Fake receipt | Fake reconciliation | Fake role | Fake idempotency | Fake limitation |",
+                "",
+            )
+        )
+        prefixed_text = catalog_text.replace(CATALOG_SECTION_HEADING, fake_table + CATALOG_SECTION_HEADING)
+        operator_notification_row = next(
+            line
+            for line in catalog_text.splitlines()
+            if line.startswith("| `operator_notification` |")
+        )
+        extra_section_row = catalog_text.replace(
+            CATALOG_SECTION_END_HEADING,
+            f"{operator_notification_row}\n\n{CATALOG_SECTION_END_HEADING}",
+        )
+
+        self.assertEqual(4, len(_catalog_rows(prefixed_text)))
+        self.assertIn(
+            "operator_notification duplicate catalog action",
+            _catalog_validation_errors(extra_section_row),
+        )
 
     def test_catalog_rows_have_required_contract_fields(self) -> None:
         catalog_text = self.catalog_doc.read_text(encoding="utf-8")
@@ -355,6 +423,21 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
             "forbidden overclaim outside rejection context: broad SOAR marketplace coverage is implemented",
             _catalog_validation_errors(overclaim_text),
         )
+
+    def test_rejects_overclaims_with_not_marker_and_line_wrapping(self) -> None:
+        catalog_text = self.catalog_doc.read_text(encoding="utf-8")
+        not_marker_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "Phase 62.1 claims RC, not just Beta\n## 8. Non-Goals",
+        )
+        wrapped_text = catalog_text.replace(
+            "## 8. Non-Goals",
+            "Phase 62.1 claims\nRC readiness\n## 8. Non-Goals",
+        )
+
+        expected = "forbidden overclaim outside rejection context: Phase 62.1 claims RC"
+        self.assertIn(expected, _catalog_validation_errors(not_marker_text))
+        self.assertIn(expected, _catalog_validation_errors(wrapped_text))
 
     def test_rejects_case_insensitive_readiness_and_later_phase_overclaims(
         self,

--- a/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
+++ b/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py
@@ -65,6 +65,10 @@ FORBIDDEN_OVERCLAIM_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
         ),
     ),
     (
+        "standalone replacement claim appears",
+        re.compile(r"\bstandalone\s+replacement\b", re.I),
+    ),
+    (
         "standalone replacement claims are approved",
         re.compile(r"\bstandalone\s+replacement\s+claims?\s+are\s+approved\b", re.I),
     ),
@@ -98,8 +102,11 @@ FORBIDDEN_SETUP_TRUST_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "placeholder credentials are valid",
         re.compile(
-            r"\bplaceholder\s+(?:shuffle\s+)?(?:api\s+keys?|secrets?|credentials?|tokens?)"
-            r"\s+(?:(?:are|is)\s+(?:valid|trusted|approved|accepted)|as\s+valid"
+            r"\b(?:treats?\s+)?placeholder\s+(?:shuffle\s+)?"
+            r"(?:api\s+keys?|secrets?|credentials?|tokens?)\s+"
+            r"(?:(?:are|is)\s+(?:valid|trusted|approved|accepted)|"
+            r"(?:are|is)\s+treated\s+as\s+(?:valid|trusted|approved|accepted)"
+            r"(?:\s+setup\s+state)?|as\s+(?:valid|trusted|approved|accepted)"
             r"\s+setup\s+state)\b",
             re.I,
         ),
@@ -107,56 +114,94 @@ FORBIDDEN_SETUP_TRUST_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "sample credentials are valid",
         re.compile(
-            r"\bsample\s+(?:secrets?|credentials?|tokens?)"
-            r"\s+(?:are|is)\s+(?:valid|trusted|approved|accepted)\b",
+            r"\b(?:treats?\s+)?sample\s+(?:secrets?|credentials?|tokens?)\s+"
+            r"(?:(?:are|is)\s+(?:valid|trusted|approved|accepted)|"
+            r"(?:are|is)\s+treated\s+as\s+(?:valid|trusted|approved|accepted)"
+            r"(?:\s+setup\s+state)?|as\s+(?:valid|trusted|approved|accepted)"
+            r"\s+setup\s+state)\b",
             re.I,
         ),
     ),
     (
         "fake values are valid",
         re.compile(
-            r"\bfake\s+values?\s+(?:are|is)\s+(?:valid|trusted|approved|accepted)\b",
+            r"\b(?:treats?\s+)?fake\s+values?\s+"
+            r"(?:(?:are|is)\s+(?:valid|trusted|approved|accepted)|"
+            r"(?:are|is)\s+treated\s+as\s+(?:valid|trusted|approved|accepted)"
+            r"(?:\s+setup\s+state)?|as\s+(?:valid|trusted|approved|accepted)"
+            r"\s+setup\s+state)\b",
             re.I,
         ),
     ),
     (
         "TODO values are valid",
         re.compile(
-            r"\btodo\s+values?\s+(?:are|is)\s+(?:valid|trusted|approved|accepted)\b",
+            r"\b(?:treats?\s+)?todo\s+values?\s+"
+            r"(?:(?:are|is)\s+(?:valid|trusted|approved|accepted)|"
+            r"(?:are|is)\s+treated\s+as\s+(?:valid|trusted|approved|accepted)"
+            r"(?:\s+setup\s+state)?|as\s+(?:valid|trusted|approved|accepted)"
+            r"\s+setup\s+state)\b",
             re.I,
         ),
     ),
     (
         "unsigned tokens are valid",
         re.compile(
-            r"\bunsigned\s+tokens?\s+(?:are|is)\s+(?:valid|trusted|approved|accepted)\b",
+            r"\b(?:treats?\s+)?unsigned\s+tokens?\s+"
+            r"(?:(?:are|is)\s+(?:valid|trusted|approved|accepted)|"
+            r"(?:are|is)\s+treated\s+as\s+(?:valid|trusted|approved|accepted)"
+            r"(?:\s+setup\s+state)?|as\s+(?:valid|trusted|approved|accepted)"
+            r"\s+setup\s+state)\b",
             re.I,
         ),
     ),
     (
         "inline secrets are valid",
         re.compile(
-            r"\binline\s+secrets?\s+(?:are|is)\s+(?:valid|trusted|approved|accepted)\b",
+            r"\b(?:treats?\s+)?inline\s+secrets?\s+"
+            r"(?:(?:are|is)\s+(?:valid|trusted|approved|accepted)|"
+            r"(?:are|is)\s+treated\s+as\s+(?:valid|trusted|approved|accepted)"
+            r"(?:\s+setup\s+state)?|as\s+(?:valid|trusted|approved|accepted)"
+            r"\s+setup\s+state)\b",
             re.I,
         ),
     ),
     (
         "raw forwarded headers are trusted",
         re.compile(
-            r"\braw\s+forwarded\s+headers?\s+(?:are|is)\s+trusted\b",
+            r"\b(?:treats?\s+)?raw\s+forwarded\s+headers?\s+"
+            r"(?:(?:are|is)\s+trusted|(?:are|is)\s+treated\s+as\s+trusted"
+            r"(?:\s+(?:identity|setup\s+state))?|as\s+trusted\s+identity)\b",
             re.I,
         ),
     ),
     (
         "inferred linkage is valid",
         re.compile(
-            r"\binferred\s+(?:tenant|source|delegation)\s+linkage\s+"
-            r"(?:is|are)\s+(?:valid|trusted|approved|accepted)\b",
+            r"\b(?:treats?\s+)?inferred\s+(?:tenant|source|delegation)\s+linkage\s+"
+            r"(?:(?:is|are)\s+(?:valid|trusted|approved|accepted)|"
+            r"(?:is|are)\s+treated\s+as\s+(?:valid|trusted|approved|accepted)"
+            r"(?:\s+setup\s+state)?|as\s+(?:valid|trusted|approved|accepted)"
+            r"\s+setup\s+state)\b",
             re.I,
         ),
     ),
 )
 FORBIDDEN_AUTHORITY_PROMOTION_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "subordinate source is treated as AegisOps truth",
+        re.compile(
+            r"\b(?:treats?\s+)?(?:shuffle\s+workflow\s+state|shuffle\s+workflow\s+"
+            r"success|shuffle\s+callback\s+payload|simulator\s+state|ticket\s+"
+            r"state|ticket\s+status|ui\s+cache|browser\s+state|ai\s+output|"
+            r"source-native\s+status|verifier\s+output|issue-lint\s+output|"
+            r"admin\s+configuration|admin\s+ui\s+state)\s+"
+            r"(?:(?:is|are|becomes?|become)\s+|as\s+)aegisops\s+"
+            r"(?:(?:action|case|reconciliation|execution\s+receipt|policy|"
+            r"release|gate|limitation|closeout)\s+)?truth\b",
+            re.I,
+        ),
+    ),
     (
         "direct ad-hoc Shuffle launch is approved",
         re.compile(r"\bdirect\s+ad-?hoc\s+shuffle\s+launch\s+is\s+approved\b", re.I),
@@ -323,7 +368,8 @@ def _is_rejection_context(
 
     explicit_negation_patterns = (
         r"^(?:[-*]\s*)?no\b",
-        r"\bdoes\s+not\s+(?:broaden|dispatch|enable|grant|import|launch|let)\b",
+        r"\bdoes\s+not\s+(?:broaden|claim|dispatch|enable|grant|implement|import|"
+        r"launch|let|replace)\b",
         r"\bdo\s+not\b",
         r"\bmust\s+fail\s+closed\b",
         r"\bmust\s+be\s+rejected\b",
@@ -824,6 +870,8 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
                 (
                     "Phase 62.1 is a standalone replacement.",
                     "Phase 62.1 claims standalone replacement readiness",
+                    "Standalone replacement is implemented for this catalog.",
+                    "This catalog includes standalone replacement readiness.",
                     "Standalone replacement claims are approved",
                     "## 8. Non-Goals",
                 )
@@ -833,6 +881,10 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
 
         self.assertIn(
             "forbidden overclaim outside rejection context: Phase 62.1 is or claims standalone replacement readiness",
+            validation_errors,
+        )
+        self.assertIn(
+            "forbidden overclaim outside rejection context: standalone replacement claim appears",
             validation_errors,
         )
         self.assertIn(
@@ -848,13 +900,21 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
                 (
                     "Phase 62.1 treats placeholder Shuffle API keys as valid setup state.",
                     "Placeholder Shuffle API keys are valid credentials.",
+                    "Placeholder credentials are treated as valid setup state.",
                     "Sample credentials are accepted.",
+                    "Sample tokens are treated as trusted setup state.",
                     "Fake values are valid setup state.",
+                    "Fake values are treated as approved setup state.",
                     "TODO values are valid setup state.",
+                    "TODO values are treated as accepted setup state.",
                     "Unsigned tokens are trusted.",
+                    "Unsigned tokens are treated as valid setup state.",
                     "Inline secrets are approved.",
+                    "Inline secrets are treated as trusted setup state.",
                     "Raw forwarded headers are trusted callback identity.",
+                    "Raw forwarded headers are treated as trusted identity.",
                     "Inferred tenant linkage is valid.",
+                    "Inferred source linkage is treated as valid setup state.",
                     "## 8. Non-Goals",
                 )
             ),
@@ -884,10 +944,13 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
                     "Shuffle callback payload is AegisOps execution receipt truth.",
                     "Shuffle workflow status closes AegisOps cases.",
                     "Ticket status is AegisOps case truth.",
+                    "Phase 62.1 treats ticket status as AegisOps case truth.",
                     "Ticket close is AegisOps reconciliation truth.",
                     "UI cache is AegisOps action policy truth.",
                     "Browser state is AegisOps case truth.",
+                    "Phase 62.1 treats browser state as AegisOps action truth.",
                     "Admin configuration is AegisOps action truth.",
+                    "Phase 62.1 treats admin configuration as AegisOps reconciliation truth.",
                     "AI output approves automation.",
                     "Source-native status reconciles automation.",
                     "Verifier output gates production readiness.",
@@ -899,6 +962,7 @@ class Phase62ReviewedAutomationCatalogContractTests(unittest.TestCase):
         validation_errors = _catalog_validation_errors(authority_claim_text)
 
         for expected in (
+            "forbidden authority promotion outside rejection context: subordinate source is treated as AegisOps truth",
             "forbidden authority promotion outside rejection context: direct ad-hoc Shuffle launch is approved",
             "forbidden authority promotion outside rejection context: Shuffle workflow success is AegisOps reconciliation truth",
             "forbidden authority promotion outside rejection context: Shuffle callback payload is AegisOps execution receipt truth",

--- a/docs/phase-62-1-reviewed-automation-catalog-validation.md
+++ b/docs/phase-62-1-reviewed-automation-catalog-validation.md
@@ -1,0 +1,46 @@
+# Phase 62.1 Reviewed Automation Catalog Contract Validation
+
+- Validation date: 2026-05-17
+- Validation scope: Phase 62.1 reviewed automation catalog contract boundedness, default Read/Notify/Soft Write coverage, reviewed Shuffle posture linkage, receipt and reconciliation expectations, role and idempotency posture, and negative rejection of Controlled Write, Hard Write, missing fields, and marketplace overclaim.
+- Baseline references: `docs/phase-62-reviewed-automation-catalog-contract.md`, `docs/phase-54-closeout-evaluation.md`, `docs/phase-56-closeout-evaluation.md`, `docs/phase-57-closeout-evaluation.md`, `docs/phase-61-closeout-evaluation.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`.
+- Verification commands: `bash scripts/verify-phase-62-1-reviewed-automation-catalog-contract.sh`.
+- Validation status: PASS
+
+## Required Artifacts
+
+- `docs/phase-62-reviewed-automation-catalog-contract.md`
+- `docs/phase-62-1-reviewed-automation-catalog-validation.md`
+- `control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py`
+- `scripts/verify-phase-62-1-reviewed-automation-catalog-contract.sh`
+
+## Outcome
+
+The Phase 62.1 reviewed automation catalog now covers the default `smb-single-node` Read, Notify, and Soft Write actions:
+
+- Read: `enrichment_only_lookup`
+- Notify: `operator_notification`, `manual_escalation_request`
+- Soft Write: `create_tracking_ticket`
+
+Each entry records owner, family, substrate mapping need, required approval posture, expected receipt shape, reconciliation expectation, allowed roles, idempotency posture, and explicit limitations.
+
+## Negative Coverage
+
+The verifier and focused tests reject:
+
+- Controlled Write and Hard Write default entries.
+- Missing owner, missing family, missing approval posture, missing receipt expectation, missing reconciliation expectation, missing role boundary, missing idempotency posture, and missing limitation.
+- Direct ad-hoc Shuffle launch.
+- Downstream workflow, ticket, UI, browser, AI, source-native, verifier, issue-lint, or admin configuration truth promotion.
+- Broad SOAR marketplace overclaim, arbitrary connector marketplace import, Phase 63/66 overreach, and Beta/RC/GA/commercial readiness claims.
+
+## Cross-Link Review
+
+The catalog remains aligned to the Phase 54 Shuffle profile and template posture. It preserves the Phase 56 operator-surface authority boundary, the Phase 57 role and action-policy administration boundary, and the Phase 61 source handoff boundary without converting source or detector state into action authority.
+
+## Deviations
+
+- No deviations.
+
+## Handoff Notes
+
+Later Phase 62 issues may add reviewed action families only by adding explicit catalog entries with owner, policy, receipt, reconciliation, idempotency, role, and limitation fields. Controlled Write and Hard Write remain blocked from default enablement until separate reviewed policy treatment lands.

--- a/docs/phase-62-reviewed-automation-catalog-contract.md
+++ b/docs/phase-62-reviewed-automation-catalog-contract.md
@@ -1,0 +1,106 @@
+# AegisOps Phase 62.1 Reviewed Automation Catalog Contract
+
+- **Status**: Accepted contract
+- **Date**: 2026-05-17
+- **Owner**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-54-closeout-evaluation.md`, `docs/deployment/shuffle-smb-single-node-profile-contract.md`, `docs/deployment/shuffle-reviewed-workflow-template-contract.md`, `docs/deployment/shuffle-read-notify-template-contracts.md`, `docs/deployment/shuffle-create-tracking-ticket-template-import-contract.md`, `docs/phase-56-closeout-evaluation.md`, `docs/phase-57-closeout-evaluation.md`, `docs/phase-61-closeout-evaluation.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`
+- **Related Issues**: #1314, #1315
+
+This contract defines the minimum reviewed automation catalog for Phase 62.1. It covers default `smb-single-node` Read, Notify, and Soft Write automation actions only. It does not launch Shuffle directly, broaden SOAR marketplace coverage, enable Controlled Write or Hard Write default actions, grant autonomous remediation, or claim Beta, RC, GA, commercial readiness, or broad SOAR replacement readiness.
+
+## 1. Purpose
+
+Phase 62.1 records the default reviewed automation catalog that later Phase 62 work can consume before expanding SOAR breadth. Each catalog entry must carry action family, owner, substrate mapping need, required approval posture, expected receipt shape, reconciliation expectation, allowed roles, idempotency posture, and explicit limitations.
+
+The catalog consumes the reviewed Phase 54 Shuffle profile, template, delegation, receipt, and fallback posture as a substrate evidence pattern. It does not import new workflow templates, dispatch workflow runs, or let downstream workflow state become AegisOps truth.
+
+## 2. Authority Boundary
+
+Every automation action must route through AegisOps action request, approval when required, execution receipt, and reconciliation records. AegisOps records remain authoritative for case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth.
+
+Shuffle workflow state, simulator state, ticket state, UI cache, browser state, AI output, source-native state, verifier output, and issue-lint output remain subordinate context. They cannot approve, execute, reconcile, close, gate, or claim readiness by themselves.
+
+Missing owner, action family, substrate mapping, approval posture, receipt expectation, reconciliation expectation, role boundary, idempotency posture, limitation, correlation, action request, approval decision, or reviewed template/version signal must fail closed instead of being inferred from workflow names, template paths, comments, issue text, source names, case names, ticket titles, tenant names, or nearby metadata.
+
+## 3. Approved Default Catalog Entries
+
+| Catalog action | Family | Owner | Substrate mapping need | Required approval posture | Expected receipt shape | Reconciliation expectation | Allowed roles | Idempotency posture | Explicit limitations |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `enrichment_only_lookup` | Read | AegisOps maintainers and IT Operations, Information Systems Department | Must map only to the reviewed Phase 54 Shuffle `enrichment_only_lookup` template contract or an equivalent later reviewed Read substrate mapping. No direct ad-hoc Shuffle launch. | AegisOps action request required. Separate approval is not required by default unless action policy marks the request elevated, but the approval posture must be recorded explicitly as policy-not-required or approved. | AegisOps execution receipt with `action_request_id`, `catalog_action`, `family`, `reviewed_template_version`, `correlation_id`, `idempotency_key`, `started_at`, `finished_at`, `status`, and subordinate lookup evidence reference. | Reconciliation may attach subordinate lookup context to the linked AegisOps record. It cannot close cases, approve actions, mutate protected targets, or replace source/evidence truth. | `analyst` may request within assigned scope; `approver` may approve elevated policy paths; `platform_admin` may administer catalog posture only; `read_only_auditor` may inspect. | Idempotency key must bind action request, subject, reviewed template version, and normalized lookup inputs. Duplicate keys must return or link the existing receipt instead of creating a new authoritative outcome. | Read-only enrichment context. No protected target mutation, credential change, ticket mutation, case closure, detector activation, suppression activation, direct source actioning, or marketplace expansion. |
+| `operator_notification` | Notify | AegisOps maintainers and IT Operations, Information Systems Department | Must map only to the reviewed Phase 54 Shuffle `operator_notification` template contract or an equivalent later reviewed Notify substrate mapping. No direct ad-hoc Shuffle launch. | AegisOps action request required. Separate approval is not required by default unless action policy marks the request elevated, but recipient and scope must be explicit. | AegisOps execution receipt with `action_request_id`, `catalog_action`, `family`, `recipient_ref`, `reviewed_template_version`, `correlation_id`, `idempotency_key`, delivery-attempt status, and normalized receipt reference. | Reconciliation may record notification attempted, delivered, failed, or fallback-needed as subordinate context. It cannot approve, execute, reconcile other actions, close tickets, or close cases. | `analyst` may request within assigned scope; `approver` may approve elevated policy paths; `platform_admin` may administer catalog posture only; `read_only_auditor` may inspect. | Idempotency key must bind action request, recipient, subject, message intent, and reviewed template version. Retries must preserve the original action request and receipt lineage. | Notification-only. No authoritative workflow state mutation, ticket closure, case closure, approval decision, reconciliation decision, protected target mutation, broad notification marketplace, or readiness claim. |
+| `manual_escalation_request` | Notify | AegisOps maintainers and IT Operations, Information Systems Department | Must map only to the reviewed Phase 54 Shuffle `manual_escalation_request` template contract or an equivalent later reviewed Notify substrate mapping. No direct ad-hoc Shuffle launch. | AegisOps action request required. Escalation owner, subject, reason, and policy posture must be explicit. Approval is required when the escalation request asks for protected-target follow-up. | AegisOps execution receipt with `action_request_id`, `catalog_action`, `family`, `escalation_owner_ref`, `reviewed_template_version`, `correlation_id`, `idempotency_key`, delivery-attempt status, and fallback-needed flag when applicable. | Reconciliation may record that human escalation was requested and whether fallback is needed. It cannot create automatic approval, bypass approval, close cases, close tickets, or mark remediation complete. | `analyst` may request within assigned scope; `approver` may approve protected follow-up paths; `platform_admin` may administer catalog posture only; `read_only_auditor` may inspect. | Idempotency key must bind action request, escalation owner, subject, reason, and reviewed template version. Repeated escalation attempts must keep the original request lineage visible. | Request-only escalation. No automatic approval, autonomous remediation, protected target mutation, case closure, ticket closure, broad escalation marketplace, or support-authority override. |
+| `create_tracking_ticket` | Soft Write | AegisOps maintainers and IT Operations, Information Systems Department | Must map only to the reviewed Phase 54 Shuffle `create_tracking_ticket` template import contract or an equivalent later reviewed Soft Write substrate mapping. No direct ad-hoc Shuffle launch. | AegisOps action request and reviewed approval posture required before delegation. The approver must be distinct from the requester on approval-sensitive paths. | AegisOps execution receipt with `action_request_id`, `approval_decision_id`, `catalog_action`, `family`, `ticket_pointer_id`, `ticket_system_id`, `ticket_pointer_custody`, `reviewed_template_version`, `correlation_id`, `idempotency_key`, delivery status, and normalized receipt reference. | Reconciliation may link a non-authoritative ticket pointer and record ticket-coordination outcome. Ticket state cannot become case truth, reconciliation truth, limitation truth, release truth, gate truth, or closeout truth. | `analyst` may request within assigned scope; `approver` may approve when policy requires approval; `platform_admin` may administer catalog posture only; `read_only_auditor` may inspect. | Idempotency key must bind action request, approved scope, ticket system, subject, and reviewed template version. Duplicate requests must reuse or link the existing ticket pointer rather than creating competing durable truth. | Soft Write coordination only. No protected target mutation, ticket-close authority, case-close authority, account disablement, credential rotation, group membership change, suppression activation, autonomous remediation, or marketplace expansion. |
+
+## 4. Catalog Boundedness Rules
+
+- This catalog must stay bounded to the four default entries above for Phase 62.1.
+- The default catalog families are exactly Read, Notify, and Soft Write.
+- Controlled Write and Hard Write are not default catalog families and must be rejected when marked as default entries.
+- Unreviewed integrations, arbitrary SOAR connectors, broad SOAR marketplace language, template marketplace import, and broad Shuffle replacement claims are rejected.
+- Each entry must include owner, family, substrate mapping need, approval posture, receipt expectation, reconciliation expectation, allowed roles, idempotency posture, and explicit limitations.
+- Each entry must reference the reviewed Shuffle/product-profile posture without using that posture as authority to launch workflows directly.
+- Action policy configuration, admin UI state, Shuffle state, ticket state, source-native state, AI output, verifier output, and issue-lint output remain subordinate and cannot become approval, execution, reconciliation, closeout, release, or gate truth.
+
+## 5. Validation Rules
+
+The Phase 62.1 reviewed automation catalog verifier must fail closed when:
+
+- the catalog contract or validation record is missing;
+- the catalog does not include at least one Read action, one Notify action, and one Soft Write action;
+- an entry is missing owner, family, substrate mapping need, approval posture, expected receipt shape, reconciliation expectation, allowed roles, idempotency posture, or limitation;
+- a default entry uses Controlled Write or Hard Write;
+- a default entry permits direct ad-hoc Shuffle launch, autonomous approval, autonomous remediation, protected target mutation, case closure, ticket closure, detector activation, suppression activation, approval bypass, or reconciliation bypass;
+- a default entry promotes Shuffle workflow state, simulator state, ticket state, UI cache, browser state, AI output, source-native state, verifier output, issue-lint output, or admin configuration to AegisOps truth;
+- broad SOAR marketplace, arbitrary connector marketplace, broad Shuffle replacement, Beta, RC, GA, commercial readiness, Phase 63 evidence expansion, Phase 66 RC proof, or standalone replacement claims appear outside explicit rejection or non-goal context;
+- placeholder secrets, sample credentials, fake values, TODO values, unsigned tokens, inline secrets, raw forwarded headers, or inferred tenant/source/delegation linkage are treated as valid setup state; or
+- publishable guidance uses workstation-local absolute paths instead of repo-relative commands, documented environment variables, or placeholders such as `<supervisor-config-path>`, `<codex-supervisor-root>`, `<shuffle-template-path>`, and `<aegisops-shuffle-callback-url>`.
+
+## 6. Forbidden Claims
+
+- Controlled Write is a default Phase 62.1 catalog entry.
+- Hard Write is a default Phase 62.1 catalog entry.
+- Broad SOAR marketplace coverage is implemented.
+- Arbitrary SOAR connector marketplace import is approved.
+- Direct ad-hoc Shuffle launch is approved.
+- Shuffle workflow success is AegisOps reconciliation truth.
+- Shuffle callback payload is AegisOps execution receipt truth.
+- Shuffle workflow status closes AegisOps cases.
+- Ticket status is AegisOps case truth.
+- Ticket close is AegisOps reconciliation truth.
+- UI cache is AegisOps action policy truth.
+- AI output approves automation.
+- Source-native status reconciles automation.
+- Verifier output gates production readiness.
+- Issue-lint output gates production readiness.
+- Placeholder Shuffle API keys are valid credentials.
+- Raw forwarded headers are trusted callback identity.
+- `enrichment_only_lookup` mutates protected target state.
+- `operator_notification` changes authoritative workflow state.
+- `manual_escalation_request` creates automatic approval.
+- `create_tracking_ticket` closes cases or tickets.
+- Phase 62.1 implements Phase 63 evidence expansion.
+- Phase 62.1 implements Phase 66 RC proof.
+- Phase 62.1 claims Beta, RC, GA, commercial readiness, broad SOAR replacement readiness, Controlled Write default enablement, or Hard Write default enablement.
+
+## 7. Validation
+
+Run `bash scripts/verify-phase-62-1-reviewed-automation-catalog-contract.sh`.
+
+Run `bash scripts/test-verify-phase-62-1-reviewed-automation-catalog-contract.sh`.
+
+Run `python3 -m unittest control-plane.tests.test_phase62_reviewed_automation_catalog_contract`.
+
+Run `bash scripts/verify-phase-54-9-shuffle-authority-boundary-negative-tests.sh`.
+
+Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1314 --config <supervisor-config-path>`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1315 --config <supervisor-config-path>`.
+
+## 8. Non-Goals
+
+- No Controlled Write or Hard Write default enablement, autonomous remediation, destructive response, protected-target mutation, approval bypass, reconciliation bypass, direct workflow launch, arbitrary SOAR marketplace, template marketplace import, production secret material, customer-private data, Phase 63 evidence expansion, Phase 66 RC proof, Beta readiness, RC readiness, GA readiness, commercial replacement readiness, or broad SOAR replacement readiness is implemented here.
+- No Shuffle workflow success, workflow failure, workflow status, simulator state, callback payload, execution log, workflow canvas, generated config, API response, template metadata, ticket state, UI cache, browser state, AI output, source-native status, verifier output, issue-lint output, admin configuration, downstream receipt, or operator-facing summary becomes authoritative AegisOps truth.

--- a/scripts/test-verify-phase-62-1-reviewed-automation-catalog-contract.sh
+++ b/scripts/test-verify-phase-62-1-reviewed-automation-catalog-contract.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+bash "${repo_root}/scripts/verify-phase-62-1-reviewed-automation-catalog-contract.sh" "${repo_root}"

--- a/scripts/verify-phase-62-1-reviewed-automation-catalog-contract.sh
+++ b/scripts/verify-phase-62-1-reviewed-automation-catalog-contract.sh
@@ -71,10 +71,19 @@ catalog_table="$(
   ' "${catalog_path}"
 )"
 
-if grep -Eq 'Controlled Write|Hard Write' <<<"${catalog_table}"; then
-  echo "Controlled Write or Hard Write appeared in the default Phase 62.1 catalog table" >&2
-  exit 1
-fi
+while IFS= read -r catalog_line; do
+  if [[ ! "${catalog_line}" =~ ^\|[[:space:]]+\` ]]; then
+    continue
+  fi
+  family="$(
+    awk -F'|' '{ gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); print $3 }' \
+      <<<"${catalog_line}"
+  )"
+  if [[ "${family}" == "Controlled Write" || "${family}" == "Hard Write" ]]; then
+    echo "Disallowed default Phase 62.1 catalog family for row: ${catalog_line}" >&2
+    exit 1
+  fi
+done <<<"${catalog_table}"
 
 require_catalog_row_field() {
   local action="$1"

--- a/scripts/verify-phase-62-1-reviewed-automation-catalog-contract.sh
+++ b/scripts/verify-phase-62-1-reviewed-automation-catalog-contract.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+catalog_path="${repo_root}/docs/phase-62-reviewed-automation-catalog-contract.md"
+validation_path="${repo_root}/docs/phase-62-1-reviewed-automation-catalog-validation.md"
+policy_path="${repo_root}/docs/phase-51-6-authority-boundary-negative-test-policy.md"
+test_path="${repo_root}/control-plane/tests/test_phase62_reviewed_automation_catalog_contract.py"
+
+for path in "${catalog_path}" "${validation_path}" "${policy_path}" "${test_path}"; do
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing Phase 62.1 reviewed automation catalog artifact: ${path}" >&2
+    exit 1
+  fi
+done
+
+require_phrase() {
+  local file_path="$1"
+  local expected="$2"
+  if ! grep -Fq -- "${expected}" "${file_path}"; then
+    echo "Missing Phase 62.1 reviewed automation catalog statement in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+catalog_required_phrases=(
+  '# AegisOps Phase 62.1 Reviewed Automation Catalog Contract'
+  '## 3. Approved Default Catalog Entries'
+  '| Catalog action | Family | Owner | Substrate mapping need | Required approval posture | Expected receipt shape | Reconciliation expectation | Allowed roles | Idempotency posture | Explicit limitations |'
+  '| `enrichment_only_lookup` | Read |'
+  '| `operator_notification` | Notify |'
+  '| `manual_escalation_request` | Notify |'
+  '| `create_tracking_ticket` | Soft Write |'
+  'AegisOps execution receipt'
+  'Idempotency key'
+  'No direct ad-hoc Shuffle launch.'
+  'This catalog must stay bounded to the four default entries above for Phase 62.1.'
+  'The default catalog families are exactly Read, Notify, and Soft Write.'
+  'Controlled Write and Hard Write are not default catalog families and must be rejected when marked as default entries.'
+  'Unreviewed integrations, arbitrary SOAR connectors, broad SOAR marketplace language, template marketplace import, and broad Shuffle replacement claims are rejected.'
+  'Run `python3 -m unittest control-plane.tests.test_phase62_reviewed_automation_catalog_contract`.'
+)
+
+for phrase in "${catalog_required_phrases[@]}"; do
+  require_phrase "${catalog_path}" "${phrase}"
+done
+
+validation_required_phrases=(
+  '# Phase 62.1 Reviewed Automation Catalog Contract Validation'
+  'Validation date:'
+  'Phase 62.1 reviewed automation catalog contract'
+  '- Validation status: PASS'
+  'Read: `enrichment_only_lookup`'
+  'Notify: `operator_notification`, `manual_escalation_request`'
+  'Soft Write: `create_tracking_ticket`'
+  'Controlled Write and Hard Write default entries'
+  '## Deviations'
+  '- No deviations.'
+)
+
+for phrase in "${validation_required_phrases[@]}"; do
+  require_phrase "${validation_path}" "${phrase}"
+done
+
+catalog_table="$(
+  awk '
+    /^## 3\. Approved Default Catalog Entries$/ { in_section = 1; next }
+    /^## 4\. Catalog Boundedness Rules$/ { in_section = 0 }
+    in_section { print }
+  ' "${catalog_path}"
+)"
+
+if grep -Eq 'Controlled Write|Hard Write' <<<"${catalog_table}"; then
+  echo "Controlled Write or Hard Write appeared in the default Phase 62.1 catalog table" >&2
+  exit 1
+fi
+
+require_catalog_row_field() {
+  local action="$1"
+  local expected="$2"
+  if ! grep -F -- "| \`${action}\` |" <<<"${catalog_table}" | grep -Fq -- "${expected}"; then
+    echo "Missing Phase 62.1 catalog row field for ${action}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+for action in enrichment_only_lookup operator_notification manual_escalation_request create_tracking_ticket; do
+  require_catalog_row_field "${action}" 'AegisOps execution receipt'
+  require_catalog_row_field "${action}" 'Idempotency key'
+  require_catalog_row_field "${action}" '`analyst`'
+  require_catalog_row_field "${action}" '`approver`'
+  require_catalog_row_field "${action}" 'No '
+done
+
+(cd "${repo_root}" && python3 -m unittest control-plane.tests.test_phase62_reviewed_automation_catalog_contract)
+
+path_hygiene_stderr="${repo_root}/.tmp-phase62-automation-catalog-path-hygiene.err"
+trap 'rm -f "${path_hygiene_stderr}"' EXIT
+if ! bash "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" >/dev/null 2>"${path_hygiene_stderr}"; then
+  cat "${path_hygiene_stderr}" >&2
+  echo "Forbidden Phase 62.1 reviewed automation catalog absolute path usage detected" >&2
+  exit 1
+fi
+
+echo "Phase 62.1 reviewed automation catalog contract and focused catalog tests pass."


### PR DESCRIPTION
## Summary
- Add the Phase 62.1 reviewed automation catalog contract for default SMB Read, Notify, and Soft Write actions.
- Add validation evidence plus focused unittest coverage for required fields and negative Controlled Write / Hard Write / marketplace overclaim paths.
- Add the Phase 62.1 verifier and test-verifier wrapper.

## Verification
- python3 -m unittest control-plane.tests.test_phase62_reviewed_automation_catalog_contract
- bash scripts/verify-phase-62-1-reviewed-automation-catalog-contract.sh
- bash scripts/test-verify-phase-62-1-reviewed-automation-catalog-contract.sh
- bash scripts/verify-phase-54-9-shuffle-authority-boundary-negative-tests.sh
- bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh
- bash scripts/verify-publishable-path-hygiene.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1314 --config <supervisor-config-path>
- node <codex-supervisor-root>/dist/index.js issue-lint 1315 --config <supervisor-config-path>

Closes #1315
Part of #1314