### PR TITLE
62.2: Add per-action policy registry

### DIFF
--- a/control-plane/aegisops/control_plane/actions/action_policy_registry.py
+++ b/control-plane/aegisops/control_plane/actions/action_policy_registry.py
@@ -12,6 +12,13 @@ _ROLE_ALIASES = {
     "platform-admin": "platform_admin",
     "platform": "platform_admin",
 }
+_KNOWN_ROLE_PREFIXES = (
+    ("read-only-auditor-", "read_only_auditor"),
+    ("readonly-auditor-", "read_only_auditor"),
+    ("platform-admin-", "platform_admin"),
+    ("analyst-", "analyst"),
+    ("approver-", "approver"),
+)
 
 
 @dataclass(frozen=True)
@@ -126,6 +133,9 @@ def requester_role_from_identity(identity: str) -> str:
     normalized = identity.strip().lower()
     if not normalized:
         return ""
+    for prefix, role in _KNOWN_ROLE_PREFIXES:
+        if normalized.startswith(prefix):
+            return role
     role_hint = normalized.rsplit("-", 1)[0]
     return _ROLE_ALIASES.get(role_hint, role_hint.replace("-", "_"))
 

--- a/control-plane/aegisops/control_plane/actions/action_policy_registry.py
+++ b/control-plane/aegisops/control_plane/actions/action_policy_registry.py
@@ -61,7 +61,7 @@ class ActionPolicyDecision:
     def as_policy_evaluation(self) -> dict[str, object]:
         routing_target = (
             "approval"
-            if self.policy.approval_requirement == "human_required"
+            if self.policy.approval_requirement.startswith("human_required")
             else "request"
         )
         return {
@@ -179,9 +179,7 @@ def evaluate_phase62_action_policy(
             denial_reasons.append("policy_expired")
     if policy.idempotency_required and not idempotency_key:
         denial_reasons.append("missing_idempotency_key")
-    denial_reasons.extend(
-        _target_scope_denial_reasons(policy.catalog_action, target_scope)
-    )
+    denial_reasons.extend(_target_scope_denial_reasons(policy, target_scope))
 
     return ActionPolicyDecision(
         policy=policy,
@@ -192,25 +190,28 @@ def evaluate_phase62_action_policy(
 
 
 def _target_scope_denial_reasons(
-    catalog_action: str,
+    policy: ActionPolicy,
     target_scope: Mapping[str, object],
 ) -> tuple[str, ...]:
     reasons: list[str] = []
-    if target_scope.get("protected_target") is True:
+    if (
+        target_scope.get("protected_target") is True
+        and policy.protected_target_posture != "approval_required_for_follow_up"
+    ):
         reasons.append("protected_target_misuse")
 
-    if catalog_action == "create_tracking_ticket":
+    if policy.catalog_action == "create_tracking_ticket":
         if target_scope.get("coordination_target_type") not in ("zammad", "glpi"):
             reasons.append("target_scope_not_allowed")
         if not target_scope.get("coordination_reference_id"):
             reasons.append("target_scope_not_allowed")
-    elif catalog_action == "operator_notification":
+    elif policy.catalog_action == "operator_notification":
         if not target_scope.get("recipient_identity"):
             reasons.append("target_scope_not_allowed")
-    elif catalog_action == "manual_escalation_request":
+    elif policy.catalog_action == "manual_escalation_request":
         if not target_scope.get("escalation_owner_ref"):
             reasons.append("target_scope_not_allowed")
-    elif catalog_action == "enrichment_only_lookup":
+    elif policy.catalog_action == "enrichment_only_lookup":
         if not target_scope.get("lookup_subject_ref"):
             reasons.append("target_scope_not_allowed")
 

--- a/control-plane/aegisops/control_plane/actions/action_policy_registry.py
+++ b/control-plane/aegisops/control_plane/actions/action_policy_registry.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Mapping
+
+
+_ROLE_ALIASES = {
+    "read-only-auditor": "read_only_auditor",
+    "readonly-auditor": "read_only_auditor",
+    "read-only": "read_only_auditor",
+    "platform-admin": "platform_admin",
+    "platform": "platform_admin",
+}
+
+
+@dataclass(frozen=True)
+class ActionPolicy:
+    catalog_action: str
+    family: str
+    approval_requirement: str
+    allowed_requester_roles: tuple[str, ...]
+    allowed_reviewer_roles: tuple[str, ...]
+    allowed_target_scope: str
+    idempotency_required: bool
+    protected_target_posture: str
+    registry_id: str
+    denied_by_default: bool = False
+
+
+@dataclass(frozen=True)
+class ActionPolicyDecision:
+    policy: ActionPolicy
+    requester_role: str
+    decision: str
+    denial_reasons: tuple[str, ...]
+
+    @property
+    def allowed(self) -> bool:
+        return self.decision == "allowed"
+
+    def as_policy_basis(self) -> dict[str, object]:
+        return {
+            "policy_registry_id": self.policy.registry_id,
+            "catalog_action": self.policy.catalog_action,
+            "family": self.policy.family,
+            "allowed_requester_roles": self.policy.allowed_requester_roles,
+            "allowed_reviewer_roles": self.policy.allowed_reviewer_roles,
+            "allowed_target_scope": self.policy.allowed_target_scope,
+            "idempotency_required": self.policy.idempotency_required,
+            "protected_target_posture": self.policy.protected_target_posture,
+        }
+
+    def as_policy_evaluation(self) -> dict[str, object]:
+        routing_target = (
+            "approval"
+            if self.policy.approval_requirement == "human_required"
+            else "request"
+        )
+        return {
+            "policy_registry_id": self.policy.registry_id,
+            "policy_decision": self.decision,
+            "denial_reasons": self.denial_reasons,
+            "requester_role": self.requester_role,
+            "approval_requirement": self.policy.approval_requirement,
+            "approval_requirement_override": self.policy.approval_requirement,
+            "routing_target": routing_target,
+            "execution_surface_type": "automation_substrate",
+            "execution_surface_id": "shuffle",
+        }
+
+
+PHASE62_ACTION_POLICIES: Mapping[str, ActionPolicy] = {
+    "enrichment_only_lookup": ActionPolicy(
+        catalog_action="enrichment_only_lookup",
+        family="Read",
+        approval_requirement="policy_not_required",
+        allowed_requester_roles=("analyst", "approver"),
+        allowed_reviewer_roles=("approver",),
+        allowed_target_scope="single_lookup_subject",
+        idempotency_required=True,
+        protected_target_posture="mutation_forbidden",
+        registry_id="phase62.2:enrichment_only_lookup",
+    ),
+    "operator_notification": ActionPolicy(
+        catalog_action="operator_notification",
+        family="Notify",
+        approval_requirement="policy_not_required",
+        allowed_requester_roles=("analyst", "approver"),
+        allowed_reviewer_roles=("approver",),
+        allowed_target_scope="single_recipient",
+        idempotency_required=True,
+        protected_target_posture="mutation_forbidden",
+        registry_id="phase62.2:operator_notification",
+    ),
+    "manual_escalation_request": ActionPolicy(
+        catalog_action="manual_escalation_request",
+        family="Notify",
+        approval_requirement="human_required_for_protected_follow_up",
+        allowed_requester_roles=("analyst", "approver"),
+        allowed_reviewer_roles=("approver",),
+        allowed_target_scope="single_escalation_owner",
+        idempotency_required=True,
+        protected_target_posture="approval_required_for_follow_up",
+        registry_id="phase62.2:manual_escalation_request",
+    ),
+    "create_tracking_ticket": ActionPolicy(
+        catalog_action="create_tracking_ticket",
+        family="Soft Write",
+        approval_requirement="human_required",
+        allowed_requester_roles=("analyst", "approver"),
+        allowed_reviewer_roles=("approver",),
+        allowed_target_scope="single_external_ticket",
+        idempotency_required=True,
+        protected_target_posture="mutation_forbidden",
+        registry_id="phase62.2:create_tracking_ticket",
+    ),
+}
+
+ACTION_TYPE_POLICY_ALIASES = {
+    "notify_identity_owner": "operator_notification",
+}
+
+
+def requester_role_from_identity(identity: str) -> str:
+    normalized = identity.strip().lower()
+    if not normalized:
+        return ""
+    role_hint = normalized.rsplit("-", 1)[0]
+    return _ROLE_ALIASES.get(role_hint, role_hint.replace("-", "_"))
+
+
+def evaluate_phase62_action_policy(
+    *,
+    action_type: str,
+    requester_identity: str,
+    target_scope: Mapping[str, object],
+    expires_at: datetime | None,
+    idempotency_key: str | None,
+    now: datetime | None = None,
+) -> ActionPolicyDecision:
+    catalog_action = ACTION_TYPE_POLICY_ALIASES.get(action_type, action_type)
+    policy = PHASE62_ACTION_POLICIES.get(catalog_action)
+    if policy is None:
+        policy = ActionPolicy(
+            catalog_action=catalog_action,
+            family="unreviewed",
+            approval_requirement="denied",
+            allowed_requester_roles=(),
+            allowed_reviewer_roles=(),
+            allowed_target_scope="none",
+            idempotency_required=True,
+            protected_target_posture="denied",
+            registry_id=f"phase62.2:{catalog_action}:missing",
+            denied_by_default=True,
+        )
+
+    requester_role = requester_role_from_identity(requester_identity)
+    denial_reasons: list[str] = []
+    if policy.denied_by_default:
+        denial_reasons.append("missing_reviewed_policy")
+    if requester_role not in policy.allowed_requester_roles:
+        denial_reasons.append("requester_role_not_allowed")
+    if expires_at is None:
+        denial_reasons.append("missing_expiry")
+    else:
+        comparison_now = now or datetime.now(timezone.utc)
+        if expires_at <= comparison_now:
+            denial_reasons.append("policy_expired")
+    if policy.idempotency_required and not idempotency_key:
+        denial_reasons.append("missing_idempotency_key")
+    denial_reasons.extend(
+        _target_scope_denial_reasons(policy.catalog_action, target_scope)
+    )
+
+    return ActionPolicyDecision(
+        policy=policy,
+        requester_role=requester_role,
+        decision="denied" if denial_reasons else "allowed",
+        denial_reasons=tuple(denial_reasons),
+    )
+
+
+def _target_scope_denial_reasons(
+    catalog_action: str,
+    target_scope: Mapping[str, object],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if target_scope.get("protected_target") is True:
+        reasons.append("protected_target_misuse")
+
+    if catalog_action == "create_tracking_ticket":
+        if target_scope.get("coordination_target_type") not in ("zammad", "glpi"):
+            reasons.append("target_scope_not_allowed")
+        if not target_scope.get("coordination_reference_id"):
+            reasons.append("target_scope_not_allowed")
+    elif catalog_action == "operator_notification":
+        if not target_scope.get("recipient_identity"):
+            reasons.append("target_scope_not_allowed")
+    elif catalog_action == "manual_escalation_request":
+        if not target_scope.get("escalation_owner_ref"):
+            reasons.append("target_scope_not_allowed")
+    elif catalog_action == "enrichment_only_lookup":
+        if not target_scope.get("lookup_subject_ref"):
+            reasons.append("target_scope_not_allowed")
+
+    return tuple(dict.fromkeys(reasons))

--- a/control-plane/aegisops/control_plane/actions/execution_coordinator_action_requests.py
+++ b/control-plane/aegisops/control_plane/actions/execution_coordinator_action_requests.py
@@ -10,6 +10,7 @@ from .execution_coordinator import (
     _approved_payload_binding_hash,
     _json_ready,
 )
+from .action_policy_registry import evaluate_phase62_action_policy
 from ..models import ActionRequestRecord
 
 
@@ -153,6 +154,28 @@ class ReviewedActionRequestCoordinator:
                 "notify-identity-owner:"
                 + hashlib.sha256(idempotency_material.encode("utf-8")).hexdigest()
             )
+            policy_decision = evaluate_phase62_action_policy(
+                action_type="notify_identity_owner",
+                requester_identity=requester_identity,
+                target_scope=target_scope,
+                expires_at=expires_at,
+                idempotency_key=idempotency_key,
+                now=requested_at,
+            )
+            if not policy_decision.allowed:
+                raise ValueError(
+                    "action policy denied notify_identity_owner: "
+                    + ", ".join(policy_decision.denial_reasons)
+                )
+            policy_evaluation = policy_decision.as_policy_evaluation()
+            policy_evaluation.update(
+                {
+                    "approval_requirement": "human_required",
+                    "approval_requirement_override": "human_required",
+                    "routing_target": "approval",
+                    "policy_elevation_reason": "legacy_identity_owner_notification_requires_human_approval",
+                }
+            )
             for existing in self._service._store.list(ActionRequestRecord):
                 if existing.idempotency_key == idempotency_key:
                     self._service._emit_structured_event(
@@ -187,6 +210,7 @@ class ReviewedActionRequestCoordinator:
                     requester_identity=requester_identity,
                     requested_payload=requested_payload,
                     policy_basis={
+                        **policy_decision.as_policy_basis(),
                         "severity": "low",
                         "target_scope": "single_identity",
                         "action_reversibility": "reversible",
@@ -195,13 +219,7 @@ class ReviewedActionRequestCoordinator:
                         "blast_radius": "single_target",
                         "execution_constraint": "routine_allowed",
                     },
-                    policy_evaluation={
-                        "approval_requirement": "human_required",
-                        "approval_requirement_override": "human_required",
-                        "routing_target": "approval",
-                        "execution_surface_type": "automation_substrate",
-                        "execution_surface_id": "shuffle",
-                    },
+                    policy_evaluation=policy_evaluation,
                 ),
                 transitioned_at=requested_at,
             )
@@ -350,6 +368,19 @@ class ReviewedActionRequestCoordinator:
                 "create-tracking-ticket:"
                 + hashlib.sha256(idempotency_material.encode("utf-8")).hexdigest()
             )
+            policy_decision = evaluate_phase62_action_policy(
+                action_type="create_tracking_ticket",
+                requester_identity=requester_identity,
+                target_scope=target_scope,
+                expires_at=expires_at,
+                idempotency_key=idempotency_key,
+                now=requested_at,
+            )
+            if not policy_decision.allowed:
+                raise ValueError(
+                    "action policy denied create_tracking_ticket: "
+                    + ", ".join(policy_decision.denial_reasons)
+                )
             for existing in self._service._store.list(ActionRequestRecord):
                 if existing.idempotency_key == idempotency_key:
                     self._service._emit_structured_event(
@@ -384,6 +415,7 @@ class ReviewedActionRequestCoordinator:
                     requester_identity=requester_identity,
                     requested_payload=requested_payload,
                     policy_basis={
+                        **policy_decision.as_policy_basis(),
                         "severity": "low",
                         "target_scope": "single_asset",
                         "action_reversibility": "bounded_reversible",
@@ -392,13 +424,7 @@ class ReviewedActionRequestCoordinator:
                         "blast_radius": "single_target",
                         "execution_constraint": "routine_allowed",
                     },
-                    policy_evaluation={
-                        "approval_requirement": "human_required",
-                        "approval_requirement_override": "human_required",
-                        "routing_target": "approval",
-                        "execution_surface_type": "automation_substrate",
-                        "execution_surface_id": "shuffle",
-                    },
+                    policy_evaluation=policy_decision.as_policy_evaluation(),
                 ),
                 transitioned_at=requested_at,
             )

--- a/control-plane/tests/test_cli_inspection_action_reviews.py
+++ b/control-plane/tests/test_cli_inspection_action_reviews.py
@@ -125,8 +125,21 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
         self.assertEqual(payload["requester_identity"], "analyst-001")
         self.assertEqual(payload["lifecycle_state"], "pending_approval")
         self.assertEqual(
-            payload["policy_evaluation"],
             {
+                key: payload["policy_evaluation"][key]
+                for key in (
+                    "policy_registry_id",
+                    "policy_decision",
+                    "approval_requirement",
+                    "approval_requirement_override",
+                    "routing_target",
+                    "execution_surface_type",
+                    "execution_surface_id",
+                )
+            },
+            {
+                "policy_registry_id": "phase62.2:operator_notification",
+                "policy_decision": "allowed",
                 "approval_requirement": "human_required",
                 "approval_requirement_override": "human_required",
                 "routing_target": "approval",

--- a/control-plane/tests/test_phase19_operator_workflow_validation.py
+++ b/control-plane/tests/test_phase19_operator_workflow_validation.py
@@ -398,8 +398,21 @@ class Phase19OperatorWorkflowValidationTests(unittest.TestCase):
                 self.assertEqual(action_request["requester_identity"], "analyst-001")
                 self.assertEqual(action_request["lifecycle_state"], "pending_approval")
                 self.assertEqual(
-                    action_request["policy_evaluation"],
                     {
+                        key: action_request["policy_evaluation"][key]
+                        for key in (
+                            "policy_registry_id",
+                            "policy_decision",
+                            "approval_requirement",
+                            "approval_requirement_override",
+                            "routing_target",
+                            "execution_surface_type",
+                            "execution_surface_id",
+                        )
+                    },
+                    {
+                        "policy_registry_id": "phase62.2:operator_notification",
+                        "policy_decision": "allowed",
                         "approval_requirement": "human_required",
                         "approval_requirement_override": "human_required",
                         "routing_target": "approval",

--- a/control-plane/tests/test_phase62_action_policy_registry.py
+++ b/control-plane/tests/test_phase62_action_policy_registry.py
@@ -42,7 +42,7 @@ class Phase62ActionPolicyRegistryTests(unittest.TestCase):
     def test_validation_allows_reviewed_tracking_ticket_policy(self) -> None:
         decision = evaluate_phase62_action_policy(
             action_type="create_tracking_ticket",
-            requester_identity="analyst-001",
+            requester_identity="analyst-phase62-001",
             target_scope={
                 "case_id": "case-001",
                 "coordination_reference_id": "coordination-ref-001",

--- a/control-plane/tests/test_phase62_action_policy_registry.py
+++ b/control-plane/tests/test_phase62_action_policy_registry.py
@@ -113,6 +113,27 @@ class Phase62ActionPolicyRegistryTests(unittest.TestCase):
         self.assertFalse(decision.allowed)
         self.assertEqual(decision.denial_reasons, ("protected_target_misuse",))
 
+    def test_validation_routes_protected_manual_escalation_to_approval(self) -> None:
+        decision = evaluate_phase62_action_policy(
+            action_type="manual_escalation_request",
+            requester_identity="analyst-001",
+            target_scope={
+                "escalation_owner_ref": "it-operations-duty-owner",
+                "protected_target": True,
+            },
+            expires_at=self.now + timedelta(hours=4),
+            idempotency_key="manual-escalation:abc",
+            now=self.now,
+        )
+
+        self.assertTrue(decision.allowed)
+        self.assertEqual(decision.denial_reasons, ())
+        self.assertEqual(
+            decision.as_policy_evaluation()["approval_requirement"],
+            "human_required_for_protected_follow_up",
+        )
+        self.assertEqual(decision.as_policy_evaluation()["routing_target"], "approval")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/control-plane/tests/test_phase62_action_policy_registry.py
+++ b/control-plane/tests/test_phase62_action_policy_registry.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import pathlib
+import sys
+import unittest
+
+TESTS_ROOT = pathlib.Path(__file__).resolve().parent
+CONTROL_PLANE_ROOT = TESTS_ROOT.parent
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
+
+from aegisops.control_plane.actions.action_policy_registry import (  # noqa: E402
+    PHASE62_ACTION_POLICIES,
+    evaluate_phase62_action_policy,
+)
+
+
+class Phase62ActionPolicyRegistryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.now = datetime(2026, 5, 17, 8, 30, tzinfo=timezone.utc)
+
+    def test_registry_contains_reviewed_phase62_actions(self) -> None:
+        self.assertEqual(
+            set(PHASE62_ACTION_POLICIES),
+            {
+                "enrichment_only_lookup",
+                "operator_notification",
+                "manual_escalation_request",
+                "create_tracking_ticket",
+            },
+        )
+        self.assertEqual(
+            PHASE62_ACTION_POLICIES["create_tracking_ticket"].registry_id,
+            "phase62.2:create_tracking_ticket",
+        )
+        self.assertEqual(
+            PHASE62_ACTION_POLICIES["create_tracking_ticket"].allowed_reviewer_roles,
+            ("approver",),
+        )
+
+    def test_validation_allows_reviewed_tracking_ticket_policy(self) -> None:
+        decision = evaluate_phase62_action_policy(
+            action_type="create_tracking_ticket",
+            requester_identity="analyst-001",
+            target_scope={
+                "case_id": "case-001",
+                "coordination_reference_id": "coordination-ref-001",
+                "coordination_target_type": "zammad",
+            },
+            expires_at=self.now + timedelta(hours=4),
+            idempotency_key="create-tracking-ticket:abc",
+            now=self.now,
+        )
+
+        self.assertTrue(decision.allowed)
+        self.assertEqual(decision.decision, "allowed")
+        self.assertEqual(decision.denial_reasons, ())
+
+    def test_validation_denies_missing_policy(self) -> None:
+        decision = evaluate_phase62_action_policy(
+            action_type="disable_account",
+            requester_identity="analyst-001",
+            target_scope={"case_id": "case-001"},
+            expires_at=self.now + timedelta(hours=4),
+            idempotency_key="disable-account:abc",
+            now=self.now,
+        )
+
+        self.assertFalse(decision.allowed)
+        self.assertIn("missing_reviewed_policy", decision.denial_reasons)
+
+    def test_validation_denies_expired_wrong_role_wrong_scope_and_missing_idempotency(
+        self,
+    ) -> None:
+        decision = evaluate_phase62_action_policy(
+            action_type="create_tracking_ticket",
+            requester_identity="read-only-auditor-001",
+            target_scope={
+                "case_id": "case-001",
+                "coordination_reference_id": "coordination-ref-001",
+                "coordination_target_type": "unreviewed-ticket-system",
+            },
+            expires_at=self.now - timedelta(minutes=1),
+            idempotency_key=None,
+            now=self.now,
+        )
+
+        self.assertFalse(decision.allowed)
+        self.assertEqual(
+            decision.denial_reasons,
+            (
+                "requester_role_not_allowed",
+                "policy_expired",
+                "missing_idempotency_key",
+                "target_scope_not_allowed",
+            ),
+        )
+
+    def test_validation_denies_protected_target_misuse(self) -> None:
+        decision = evaluate_phase62_action_policy(
+            action_type="operator_notification",
+            requester_identity="analyst-001",
+            target_scope={
+                "recipient_identity": "operator-001",
+                "protected_target": True,
+            },
+            expires_at=self.now + timedelta(hours=4),
+            idempotency_key="operator-notification:abc",
+            now=self.now,
+        )
+
+        self.assertFalse(decision.allowed)
+        self.assertEqual(decision.denial_reasons, ("protected_target_misuse",))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_service_persistence_action_reconciliation_reviewed_requests.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_reviewed_requests.py
@@ -29,6 +29,100 @@ from _service_persistence_support import (
 )
 
 class ReviewedActionRequestPersistenceTests(ServicePersistenceTestBase):
+    def _build_ready_recommendation(self):
+        store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        observation = service.record_case_observation(
+            case_id=promoted_case.case_id,
+            author_identity="analyst-001",
+            observed_at=reviewed_at,
+            scope_statement="Observed repository permission change requires tracked review.",
+            supporting_evidence_ids=(evidence_id,),
+        )
+        lead = service.record_case_lead(
+            case_id=promoted_case.case_id,
+            triage_owner="analyst-001",
+            triage_rationale="Privilege-impacting change needs durable business-hours follow-up.",
+            observation_id=observation.observation_id,
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Review repository owner change evidence before any approval-bound response.",
+            lead_id=lead.lead_id,
+        )
+        return store, service, promoted_case, evidence_id, recommendation
+
+    def test_service_records_phase62_policy_decision_on_tracking_ticket_request(
+        self,
+    ) -> None:
+        _store, service, promoted_case, _evidence_id, recommendation = (
+            self._build_ready_recommendation()
+        )
+
+        action_request = service.create_reviewed_tracking_ticket_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            coordination_reference_id="coordination-ref-phase62-policy-001",
+            coordination_target_type="zammad",
+            ticket_title="Review repository owner change",
+            ticket_description="Coordinate reviewed follow-up without making ticket state authoritative.",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+        )
+
+        self.assertEqual(action_request.case_id, promoted_case.case_id)
+        self.assertEqual(
+            action_request.policy_evaluation["policy_registry_id"],
+            "phase62.2:create_tracking_ticket",
+        )
+        self.assertEqual(
+            action_request.policy_evaluation["policy_decision"],
+            "allowed",
+        )
+        self.assertEqual(
+            action_request.policy_evaluation["approval_requirement"],
+            "human_required",
+        )
+        self.assertEqual(
+            action_request.policy_evaluation["requester_role"],
+            "analyst",
+        )
+        self.assertEqual(
+            action_request.policy_evaluation["denial_reasons"],
+            (),
+        )
+        self.assertEqual(
+            action_request.policy_basis["allowed_target_scope"],
+            "single_external_ticket",
+        )
+
+    def test_service_rejects_tracking_ticket_request_from_read_only_role(
+        self,
+    ) -> None:
+        store, service, _promoted_case, _evidence_id, recommendation = (
+            self._build_ready_recommendation()
+        )
+        baseline_requests = store.list(ActionRequestRecord)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "action policy denied create_tracking_ticket: requester_role_not_allowed",
+        ):
+            service.create_reviewed_tracking_ticket_request_from_advisory(
+                record_family="recommendation",
+                record_id=recommendation.recommendation_id,
+                requester_identity="read-only-auditor-001",
+                coordination_reference_id="coordination-ref-phase62-policy-002",
+                coordination_target_type="zammad",
+                ticket_title="Review repository owner change",
+                ticket_description="Coordinate reviewed follow-up without making ticket state authoritative.",
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=4),
+            )
+
+        self.assertEqual(store.list(ActionRequestRecord), baseline_requests)
+
     def test_service_creates_approval_bound_action_request_from_reviewed_recommendation(
         self,
     ) -> None:
@@ -110,8 +204,21 @@ class ReviewedActionRequestPersistenceTests(ServicePersistenceTestBase):
         self.assertEqual(action_request.expires_at, expires_at)
         self.assertEqual(action_request.lifecycle_state, "pending_approval")
         self.assertEqual(
-            action_request.policy_evaluation,
             {
+                key: action_request.policy_evaluation[key]
+                for key in (
+                    "policy_registry_id",
+                    "policy_decision",
+                    "approval_requirement",
+                    "approval_requirement_override",
+                    "routing_target",
+                    "execution_surface_type",
+                    "execution_surface_id",
+                )
+            },
+            {
+                "policy_registry_id": "phase62.2:operator_notification",
+                "policy_decision": "allowed",
                 "approval_requirement": "human_required",
                 "approval_requirement_override": "human_required",
                 "routing_target": "approval",
@@ -370,8 +477,21 @@ class ReviewedActionRequestPersistenceTests(ServicePersistenceTestBase):
         )
         self.assertEqual(action_request.expires_at, expires_at)
         self.assertEqual(
-            action_request.policy_evaluation,
             {
+                key: action_request.policy_evaluation[key]
+                for key in (
+                    "policy_registry_id",
+                    "policy_decision",
+                    "approval_requirement",
+                    "approval_requirement_override",
+                    "routing_target",
+                    "execution_surface_type",
+                    "execution_surface_id",
+                )
+            },
+            {
+                "policy_registry_id": "phase62.2:create_tracking_ticket",
+                "policy_decision": "allowed",
                 "approval_requirement": "human_required",
                 "approval_requirement_override": "human_required",
                 "routing_target": "approval",

--- a/scripts/verify-phase-62-2-action-policy-registry.sh
+++ b/scripts/verify-phase-62-2-action-policy-registry.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+required_paths=(
+  "${repo_root}/control-plane/aegisops/control_plane/actions/action_policy_registry.py"
+  "${repo_root}/control-plane/tests/test_phase62_action_policy_registry.py"
+  "${repo_root}/control-plane/tests/test_service_persistence_action_reconciliation_reviewed_requests.py"
+)
+
+for path in "${required_paths[@]}"; do
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing Phase 62.2 action policy registry artifact: ${path}" >&2
+    exit 1
+  fi
+done
+
+require_phrase() {
+  local file_path="$1"
+  local expected="$2"
+  if ! grep -Fq -- "${expected}" "${file_path}"; then
+    echo "Missing Phase 62.2 action policy registry statement in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+registry_path="${repo_root}/control-plane/aegisops/control_plane/actions/action_policy_registry.py"
+for phrase in \
+  '"enrichment_only_lookup"' \
+  '"operator_notification"' \
+  '"manual_escalation_request"' \
+  '"create_tracking_ticket"' \
+  'allowed_requester_roles' \
+  'allowed_reviewer_roles' \
+  'allowed_target_scope' \
+  'idempotency_required' \
+  'protected_target_posture' \
+  'missing_reviewed_policy' \
+  'requester_role_not_allowed' \
+  'policy_expired' \
+  'missing_idempotency_key' \
+  'target_scope_not_allowed' \
+  'protected_target_misuse'; do
+  require_phrase "${registry_path}" "${phrase}"
+done
+
+(cd "${repo_root}" && PYTHONPATH="${repo_root}/control-plane:${repo_root}/control-plane/tests" python3 -m unittest \
+  control-plane.tests.test_phase62_action_policy_registry \
+  control-plane.tests.test_service_persistence_action_reconciliation_reviewed_requests.ReviewedActionRequestPersistenceTests.test_service_records_phase62_policy_decision_on_tracking_ticket_request \
+  control-plane.tests.test_service_persistence_action_reconciliation_reviewed_requests.ReviewedActionRequestPersistenceTests.test_service_rejects_tracking_ticket_request_from_read_only_role)
+
+path_hygiene_stderr="${repo_root}/.tmp-phase62-2-action-policy-path-hygiene.err"
+trap 'rm -f "${path_hygiene_stderr}"' EXIT
+if ! bash "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" >/dev/null 2>"${path_hygiene_stderr}"; then
+  cat "${path_hygiene_stderr}" >&2
+  echo "Forbidden Phase 62.2 action policy registry absolute path usage detected" >&2
+  exit 1
+fi
+
+echo "Phase 62.2 action policy registry and focused request-boundary tests pass."


### PR DESCRIPTION
## Summary
- add the Phase 62.2 per-action policy registry for reviewed catalog actions
- validate requester role, expiry, target scope, idempotency, missing policy, and protected-target posture before persisting action requests
- record policy registry metadata on reviewed notification and tracking-ticket request records without executing actions

## Verification
- `bash scripts/verify-phase-62-2-action-policy-registry.sh`
- `PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest control-plane.tests.test_phase62_action_policy_registry control-plane.tests.test_service_persistence_action_reconciliation_reviewed_requests control-plane.tests.test_service_persistence_action_reconciliation_create_tracking_ticket`
- `PYTHONPATH="${PWD}/control-plane:${PWD}/control-plane/tests" python3 -m unittest control-plane.tests.test_phase19_operator_workflow_validation control-plane.tests.test_cli_inspection_action_reviews.CliInspectionActionReviewTests.test_cli_creates_reviewed_action_request_from_recommendation_context control-plane.tests.test_service_persistence_action_reconciliation_delegation`
- `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`
- `bash scripts/verify-phase-54-9-shuffle-authority-boundary-negative-tests.sh`
- `bash scripts/verify-phase-62-1-reviewed-automation-catalog-contract.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1316 --config <supervisor-config-path>`

Closes #1316