### PR TITLE
[codex] 62.3: Add per-action reconciliation contract

### DIFF
--- a/control-plane/aegisops/control_plane/actions/action_policy_registry.py
+++ b/control-plane/aegisops/control_plane/actions/action_policy_registry.py
@@ -31,6 +31,9 @@ class ActionPolicy:
     allowed_target_scope: str
     idempotency_required: bool
     protected_target_posture: str
+    expected_receipt_fields: tuple[str, ...]
+    correlation_fields: tuple[str, ...]
+    reconciliation_outcomes: tuple[str, ...]
     registry_id: str
     denied_by_default: bool = False
 
@@ -56,6 +59,9 @@ class ActionPolicyDecision:
             "allowed_target_scope": self.policy.allowed_target_scope,
             "idempotency_required": self.policy.idempotency_required,
             "protected_target_posture": self.policy.protected_target_posture,
+            "expected_receipt_fields": self.policy.expected_receipt_fields,
+            "correlation_fields": self.policy.correlation_fields,
+            "reconciliation_outcomes": self.policy.reconciliation_outcomes,
         }
 
     def as_policy_evaluation(self) -> dict[str, object]:
@@ -77,6 +83,39 @@ class ActionPolicyDecision:
         }
 
 
+_COMMON_RECEIPT_FIELDS = (
+    "action_request_id",
+    "catalog_action",
+    "family",
+    "reviewed_template_version",
+    "correlation_id",
+    "idempotency_key",
+    "execution_run_id",
+    "started_at",
+    "finished_at",
+    "status",
+)
+_COMMON_CORRELATION_FIELDS = (
+    "action_request_id",
+    "approval_decision_id",
+    "delegation_id",
+    "execution_run_id",
+    "correlation_id",
+    "expected_execution_receipt_id",
+    "idempotency_key",
+)
+_COMMON_RECONCILIATION_OUTCOMES = (
+    "success",
+    "failure",
+    "missing",
+    "stale",
+    "mismatched",
+    "duplicated",
+    "wrong_correlation",
+    "manual_review",
+)
+
+
 PHASE62_ACTION_POLICIES: Mapping[str, ActionPolicy] = {
     "enrichment_only_lookup": ActionPolicy(
         catalog_action="enrichment_only_lookup",
@@ -87,6 +126,10 @@ PHASE62_ACTION_POLICIES: Mapping[str, ActionPolicy] = {
         allowed_target_scope="single_lookup_subject",
         idempotency_required=True,
         protected_target_posture="mutation_forbidden",
+        expected_receipt_fields=_COMMON_RECEIPT_FIELDS
+        + ("lookup_subject_ref", "lookup_evidence_ref"),
+        correlation_fields=_COMMON_CORRELATION_FIELDS + ("lookup_subject_ref",),
+        reconciliation_outcomes=_COMMON_RECONCILIATION_OUTCOMES,
         registry_id="phase62.2:enrichment_only_lookup",
     ),
     "operator_notification": ActionPolicy(
@@ -98,6 +141,10 @@ PHASE62_ACTION_POLICIES: Mapping[str, ActionPolicy] = {
         allowed_target_scope="single_recipient",
         idempotency_required=True,
         protected_target_posture="mutation_forbidden",
+        expected_receipt_fields=_COMMON_RECEIPT_FIELDS
+        + ("recipient_ref", "delivery_attempt_status", "normalized_receipt_ref"),
+        correlation_fields=_COMMON_CORRELATION_FIELDS + ("recipient_ref",),
+        reconciliation_outcomes=_COMMON_RECONCILIATION_OUTCOMES,
         registry_id="phase62.2:operator_notification",
     ),
     "manual_escalation_request": ActionPolicy(
@@ -109,6 +156,10 @@ PHASE62_ACTION_POLICIES: Mapping[str, ActionPolicy] = {
         allowed_target_scope="single_escalation_owner",
         idempotency_required=True,
         protected_target_posture="approval_required_for_follow_up",
+        expected_receipt_fields=_COMMON_RECEIPT_FIELDS
+        + ("escalation_owner_ref", "delivery_attempt_status", "fallback_needed"),
+        correlation_fields=_COMMON_CORRELATION_FIELDS + ("escalation_owner_ref",),
+        reconciliation_outcomes=_COMMON_RECONCILIATION_OUTCOMES,
         registry_id="phase62.2:manual_escalation_request",
     ),
     "create_tracking_ticket": ActionPolicy(
@@ -120,6 +171,18 @@ PHASE62_ACTION_POLICIES: Mapping[str, ActionPolicy] = {
         allowed_target_scope="single_external_ticket",
         idempotency_required=True,
         protected_target_posture="mutation_forbidden",
+        expected_receipt_fields=_COMMON_RECEIPT_FIELDS
+        + (
+            "approval_decision_id",
+            "ticket_pointer_id",
+            "ticket_system_id",
+            "ticket_pointer_custody",
+            "delivery_status",
+            "normalized_receipt_ref",
+        ),
+        correlation_fields=_COMMON_CORRELATION_FIELDS
+        + ("coordination_reference_id", "coordination_target_type"),
+        reconciliation_outcomes=_COMMON_RECONCILIATION_OUTCOMES,
         registry_id="phase62.2:create_tracking_ticket",
     ),
 }
@@ -161,6 +224,9 @@ def evaluate_phase62_action_policy(
             allowed_target_scope="none",
             idempotency_required=True,
             protected_target_posture="denied",
+            expected_receipt_fields=(),
+            correlation_fields=(),
+            reconciliation_outcomes=("manual_review",),
             registry_id=f"phase62.2:{catalog_action}:missing",
             denied_by_default=True,
         )

--- a/control-plane/aegisops/control_plane/actions/action_policy_registry.py
+++ b/control-plane/aegisops/control_plane/actions/action_policy_registry.py
@@ -110,7 +110,7 @@ _COMMON_RECONCILIATION_OUTCOMES = (
     "missing",
     "stale",
     "mismatched",
-    "duplicated",
+    "duplicate",
     "wrong_correlation",
     "manual_review",
 )

--- a/control-plane/aegisops/control_plane/actions/execution_coordinator_delegation.py
+++ b/control-plane/aegisops/control_plane/actions/execution_coordinator_delegation.py
@@ -533,6 +533,28 @@ class ApprovedActionDelegationCoordinator:
                         "requested_scope": dict(delegation_binding["requested_scope"]),
                     }
                 )
+            else:
+                provenance["downstream_binding"].update(
+                    {
+                        "action_request_id": execution.action_request_id,
+                        "workflow_id": self._require_receipt_string_attribute(
+                            receipt,
+                            "workflow_id",
+                        ),
+                        "workflow_version_id": self._require_receipt_string_attribute(
+                            receipt,
+                            "workflow_version_id",
+                        ),
+                        "correlation_id": self._require_receipt_string_attribute(
+                            receipt,
+                            "correlation_id",
+                        ),
+                        "expected_execution_receipt_id": self._require_receipt_string_attribute(
+                            receipt,
+                            "expected_execution_receipt_id",
+                        ),
+                    }
+                )
             if execution.approved_payload.get("action_type") == "create_tracking_ticket":
                 provenance["downstream_binding"].update(
                     {

--- a/control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py
+++ b/control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py
@@ -547,8 +547,6 @@ class ActionExecutionReconciliationCoordinator:
         for field_name, observed_value in expected_fields:
             if not isinstance(downstream_binding.get(field_name), str):
                 continue
-            if action_type == "create_tracking_ticket" and observed_value is None:
-                continue
             if observed_value != downstream_binding[field_name]:
                 return True
         return False

--- a/control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py
+++ b/control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py
@@ -235,6 +235,9 @@ class ActionExecutionReconciliationCoordinator:
                     observed_expected_execution_receipt_id=(
                         observed_expected_execution_receipt_id
                     ),
+                    action_type=authoritative_execution.approved_payload.get(
+                        "action_type"
+                    ),
                 )
             ):
                 ingest_disposition = "mismatch"
@@ -522,6 +525,7 @@ class ActionExecutionReconciliationCoordinator:
         observed_workflow_version_id: object,
         observed_correlation_id: object,
         observed_expected_execution_receipt_id: object,
+        action_type: object,
     ) -> bool:
         downstream_binding = authoritative_execution.provenance.get(
             "downstream_binding",
@@ -540,11 +544,14 @@ class ActionExecutionReconciliationCoordinator:
                 observed_expected_execution_receipt_id,
             ),
         )
-        return any(
-            isinstance(downstream_binding.get(field_name), str)
-            and observed_value != downstream_binding[field_name]
-            for field_name, observed_value in expected_fields
-        )
+        for field_name, observed_value in expected_fields:
+            if not isinstance(downstream_binding.get(field_name), str):
+                continue
+            if action_type == "create_tracking_ticket" and observed_value is None:
+                continue
+            if observed_value != downstream_binding[field_name]:
+                return True
+        return False
 
     def _normalize_observed_executions(
         self,

--- a/control-plane/aegisops/control_plane/adapters/shuffle.py
+++ b/control-plane/aegisops/control_plane/adapters/shuffle.py
@@ -64,10 +64,10 @@ class ShuffleActionAdapter:
                     "shuffle delegation binding requested_scope is malformed"
                 )
         else:
-            external_receipt_id = None
-            workflow_id = None
-            workflow_version_id = None
-            correlation_id = None
+            workflow_id = self._default_workflow_id(action_type)
+            workflow_version_id = self._default_workflow_version_id(workflow_id)
+            correlation_id = f"shuffle-correlation-{action_request_id}"
+            external_receipt_id = f"shuffle-receipt-{delegation_id}"
             requested_scope = None
         if action_type == "notify_identity_owner":
             self._require_reviewed_phase20_notify_payload(approved_payload)
@@ -121,6 +121,26 @@ class ShuffleActionAdapter:
                     f"{coordination_target_id}"
                 ),
             )
+        raise ValueError(
+            "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
+        )
+
+    @staticmethod
+    def _default_workflow_id(action_type: object) -> str:
+        if action_type == "notify_identity_owner":
+            return "notify_identity_owner"
+        if action_type == "create_tracking_ticket":
+            return "create_tracking_ticket"
+        raise ValueError(
+            "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
+        )
+
+    @staticmethod
+    def _default_workflow_version_id(workflow_id: str) -> str:
+        if workflow_id == "notify_identity_owner":
+            return "notify_identity_owner-v1-reviewed-2026-05-03"
+        if workflow_id == "create_tracking_ticket":
+            return "create_tracking_ticket-v1-reviewed-2026-05-03"
         raise ValueError(
             "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
         )

--- a/control-plane/tests/test_cli_inspection_action_reviews.py
+++ b/control-plane/tests/test_cli_inspection_action_reviews.py
@@ -1013,6 +1013,13 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
                     "approval_decision_id": approval.approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],
@@ -1101,6 +1108,13 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
                     "approval_decision_id": seeded["approval"].approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": seeded["payload_hash"],
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],
@@ -1176,6 +1190,13 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
                     "approval_decision_id": seeded["approval"].approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": seeded["payload_hash"],
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],
@@ -1576,6 +1597,13 @@ class CliInspectionActionReviewTests(ControlPlaneCliInspectionTestBase):
                     "approval_decision_id": seeded["approval"].approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": seeded["payload_hash"],
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],

--- a/control-plane/tests/test_cli_inspection_restore_readiness.py
+++ b/control-plane/tests/test_cli_inspection_restore_readiness.py
@@ -58,6 +58,7 @@ class CliInspectionRestoreReadinessTests(ControlPlaneCliInspectionTestBase):
             delegation_issuer="control-plane-service",
             evidence_ids=(evidence_id,),
         )
+        downstream_binding = execution.provenance["downstream_binding"]
         service.reconcile_action_execution(
             action_request_id=approved_request.action_request_id,
             execution_surface_type="automation_substrate",
@@ -71,6 +72,13 @@ class CliInspectionRestoreReadinessTests(ControlPlaneCliInspectionTestBase):
                     "approval_decision_id": execution.approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "observed_at": action_request.requested_at + timedelta(minutes=15),
                     "status": "success",
                 },
@@ -489,6 +497,7 @@ class CliInspectionRestoreReadinessTests(ControlPlaneCliInspectionTestBase):
             delegation_issuer="control-plane-service",
             evidence_ids=(evidence_id,),
         )
+        downstream_binding = execution.provenance["downstream_binding"]
         reconciliation = service.reconcile_action_execution(
             action_request_id=approved_request.action_request_id,
             execution_surface_type="automation_substrate",
@@ -502,6 +511,13 @@ class CliInspectionRestoreReadinessTests(ControlPlaneCliInspectionTestBase):
                     "approval_decision_id": execution.approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "observed_at": base_now + timedelta(minutes=15),
                     "status": "success",
                 },

--- a/control-plane/tests/test_cli_inspection_runtime_surface.py
+++ b/control-plane/tests/test_cli_inspection_runtime_surface.py
@@ -324,6 +324,7 @@ class CliInspectionRuntimeSurfaceTests(ControlPlaneCliInspectionTestBase):
                 delegation_issuer="control-plane-service",
                 evidence_ids=(evidence_id,),
             )
+            downstream_binding = execution.provenance["downstream_binding"]
             service.reconcile_action_execution(
                 action_request_id=approved_request.action_request_id,
                 execution_surface_type="automation_substrate",
@@ -337,6 +338,13 @@ class CliInspectionRuntimeSurfaceTests(ControlPlaneCliInspectionTestBase):
                         "approval_decision_id": execution.approval_decision_id,
                         "delegation_id": execution.delegation_id,
                         "payload_hash": execution.payload_hash,
+                        "action_request_id": execution.action_request_id,
+                        "workflow_id": downstream_binding["workflow_id"],
+                        "workflow_version_id": downstream_binding["workflow_version_id"],
+                        "correlation_id": downstream_binding["correlation_id"],
+                        "expected_execution_receipt_id": downstream_binding[
+                            "expected_execution_receipt_id"
+                        ],
                         "observed_at": base_now + timedelta(minutes=15),
                         "status": "success",
                     },

--- a/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
+++ b/control-plane/tests/test_cross_boundary_negative_e2e_validation.py
@@ -211,7 +211,14 @@ class CrossBoundaryNegativeE2EValidationTests(unittest.TestCase):
                     "idempotency_key": seeded["action_request"].idempotency_key,
                     "approval_decision_id": seeded["approval"].approval_decision_id,
                     "delegation_id": execution.delegation_id,
-                    "payload_hash": seeded["payload_hash"],
+                    "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],
@@ -643,7 +650,14 @@ class CrossBoundaryNegativeE2EValidationTests(unittest.TestCase):
                     "idempotency_key": seeded["action_request"].idempotency_key,
                     "approval_decision_id": seeded["approval"].approval_decision_id,
                     "delegation_id": execution.delegation_id,
-                    "payload_hash": seeded["payload_hash"],
+                    "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],

--- a/control-plane/tests/test_phase21_end_to_end_validation.py
+++ b/control-plane/tests/test_phase21_end_to_end_validation.py
@@ -149,6 +149,7 @@ class Phase21EndToEndValidationTests(unittest.TestCase):
             delegation_issuer="control-plane-service",
             evidence_ids=(evidence_id,),
         )
+        downstream_binding = execution.provenance["downstream_binding"]
         reconciliation = service.reconcile_action_execution(
             action_request_id=approved_request.action_request_id,
             execution_surface_type="automation_substrate",
@@ -162,6 +163,13 @@ class Phase21EndToEndValidationTests(unittest.TestCase):
                     "approval_decision_id": execution.approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "observed_at": action_request.requested_at + timedelta(minutes=15),
                     "status": "success",
                 },

--- a/control-plane/tests/test_phase26_end_to_end_validation.py
+++ b/control-plane/tests/test_phase26_end_to_end_validation.py
@@ -129,6 +129,13 @@ class Phase26EndToEndValidationTests(unittest.TestCase):
                     "approval_decision_id": seeded["approval"].approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": seeded["payload_hash"],
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],
@@ -260,6 +267,13 @@ class Phase26EndToEndValidationTests(unittest.TestCase):
                     "approval_decision_id": seeded["approval"].approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": seeded["payload_hash"],
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],
@@ -282,6 +296,13 @@ class Phase26EndToEndValidationTests(unittest.TestCase):
                     "approval_decision_id": seeded["approval"].approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": seeded["payload_hash"],
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],
@@ -348,6 +369,13 @@ class Phase26EndToEndValidationTests(unittest.TestCase):
                     "approval_decision_id": seeded["approval"].approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": seeded["payload_hash"],
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],

--- a/control-plane/tests/test_phase27_day2_runtime_contract.py
+++ b/control-plane/tests/test_phase27_day2_runtime_contract.py
@@ -162,6 +162,13 @@ class Phase27Day2RuntimeContractTests(ServicePersistenceTestBase):
                     "approval_decision_id": approval.approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],

--- a/control-plane/tests/test_phase37_reviewed_record_chain_rehearsal.py
+++ b/control-plane/tests/test_phase37_reviewed_record_chain_rehearsal.py
@@ -309,6 +309,7 @@ class Phase37ReviewedRecordChainRehearsalTests(ServicePersistenceTestBase):
             ),
             evidence_ids=(evidence.evidence_id,),
         )
+        downstream_binding = execution.provenance["downstream_binding"]
         observed_at = action_request.requested_at + timedelta(
             minutes=_require_number(
                 reconciliation_fixture.get("observed_offset_minutes"),
@@ -328,6 +329,13 @@ class Phase37ReviewedRecordChainRehearsalTests(ServicePersistenceTestBase):
                     "approval_decision_id": execution.approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "observed_at": observed_at,
                     "status": _require_string(
                         reconciliation_fixture.get("status"),

--- a/control-plane/tests/test_phase62_action_policy_registry.py
+++ b/control-plane/tests/test_phase62_action_policy_registry.py
@@ -38,6 +38,22 @@ class Phase62ActionPolicyRegistryTests(unittest.TestCase):
             PHASE62_ACTION_POLICIES["create_tracking_ticket"].allowed_reviewer_roles,
             ("approver",),
         )
+        for policy in PHASE62_ACTION_POLICIES.values():
+            self.assertIn("correlation_id", policy.expected_receipt_fields)
+            self.assertIn("expected_execution_receipt_id", policy.correlation_fields)
+            self.assertEqual(
+                policy.reconciliation_outcomes,
+                (
+                    "success",
+                    "failure",
+                    "missing",
+                    "stale",
+                    "mismatched",
+                    "duplicated",
+                    "wrong_correlation",
+                    "manual_review",
+                ),
+            )
 
     def test_validation_allows_reviewed_tracking_ticket_policy(self) -> None:
         decision = evaluate_phase62_action_policy(

--- a/control-plane/tests/test_phase62_action_policy_registry.py
+++ b/control-plane/tests/test_phase62_action_policy_registry.py
@@ -49,7 +49,7 @@ class Phase62ActionPolicyRegistryTests(unittest.TestCase):
                     "missing",
                     "stale",
                     "mismatched",
-                    "duplicated",
+                    "duplicate",
                     "wrong_correlation",
                     "manual_review",
                 ),

--- a/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
@@ -1046,6 +1046,101 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
             reconciliation.subject_linkage["ticket_reference_urls"],
             (downstream_binding["ticket_reference_url"],),
         )
+
+    def test_service_fail_closes_when_create_tracking_ticket_receipt_omits_bound_fields(
+        self,
+    ) -> None:
+        _, service, approved_payload, delegated_at = (
+            self._build_phase54_create_tracking_ticket_context(
+                suffix="missing-bound-fields-001",
+                binding={
+                    "workflow_id": "create_tracking_ticket",
+                    "workflow_version_id": (
+                        "create_tracking_ticket-v1-reviewed-2026-05-03"
+                    ),
+                    "correlation_id": "shuffle-correlation-missing-bound-fields-001",
+                    "expected_execution_receipt_id": (
+                        "shuffle-receipt-missing-bound-fields-001"
+                    ),
+                    "requested_scope": {
+                        "case_id": "case-tracking-missing-bound-fields-001",
+                        "alert_id": "alert-tracking-missing-bound-fields-001",
+                        "finding_id": "finding-tracking-missing-bound-fields-001",
+                        "coordination_reference_id": (
+                            "coord-ref-missing-bound-fields-001"
+                        ),
+                        "coordination_target_type": "zammad",
+                    },
+                },
+            )
+        )
+        compared_at = support.datetime(
+            2026, 5, 3, 4, 10, tzinfo=support.timezone.utc
+        )
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id="action-request-create-ticket-missing-bound-fields-001",
+            approved_payload=approved_payload,
+            delegated_at=delegated_at,
+            delegation_issuer="control-plane-service",
+            evidence_ids=("evidence-create-ticket-missing-bound-fields-001",),
+        )
+        downstream_binding = execution.provenance["downstream_binding"]
+
+        reconciliation = service.reconcile_action_execution(
+            action_request_id="action-request-create-ticket-missing-bound-fields-001",
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": (
+                        "idempotency-create-ticket-missing-bound-fields-001"
+                    ),
+                    "approval_decision_id": execution.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
+                    "coordination_reference_id": downstream_binding[
+                        "coordination_reference_id"
+                    ],
+                    "coordination_target_type": downstream_binding[
+                        "coordination_target_type"
+                    ],
+                    "external_receipt_id": downstream_binding["external_receipt_id"],
+                    "coordination_target_id": downstream_binding[
+                        "coordination_target_id"
+                    ],
+                    "ticket_reference_url": downstream_binding["ticket_reference_url"],
+                    "observed_at": compared_at,
+                    "status": "success",
+                },
+            ),
+            compared_at=compared_at,
+            stale_after=support.datetime(
+                2026,
+                5,
+                3,
+                4,
+                30,
+                tzinfo=support.timezone.utc,
+            ),
+        )
+
+        stored_execution = service.get_record(
+            support.ActionExecutionRecord,
+            execution.action_execution_id,
+        )
+        self.assertEqual(reconciliation.ingest_disposition, "mismatch")
+        self.assertEqual(reconciliation.lifecycle_state, "mismatched")
+        self.assertEqual(
+            reconciliation.mismatch_summary,
+            "execution receipt binding mismatch between authoritative action execution "
+            "and observed downstream execution",
+        )
+        self.assertEqual(stored_execution.lifecycle_state, "queued")
+
     def test_service_fail_closes_when_create_tracking_ticket_reconciliation_receipt_drifts(
         self,
     ) -> None:

--- a/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_create_tracking_ticket.py
@@ -986,6 +986,13 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
                     "approval_decision_id": execution.approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],
@@ -1125,6 +1132,13 @@ class CreateTrackingTicketActionReconciliationPersistenceTests(ServicePersistenc
                     "approval_decision_id": execution.approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],

--- a/control-plane/tests/test_service_persistence_action_reconciliation_delegation.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_delegation.py
@@ -374,6 +374,17 @@ class ActionDelegationPolicyPersistenceTests(ServicePersistenceTestBase):
                     "approval_decision_id": "approval-routine-001",
                     "delegation_id": execution.delegation_id,
                     "payload_hash": payload_hash,
+                    "action_request_id": "action-request-routine-001",
+                    "workflow_id": "notify_identity_owner",
+                    "workflow_version_id": (
+                        "notify_identity_owner-v1-reviewed-2026-05-03"
+                    ),
+                    "correlation_id": (
+                        "shuffle-correlation-action-request-routine-001"
+                    ),
+                    "expected_execution_receipt_id": (
+                        f"shuffle-receipt-{execution.delegation_id}"
+                    ),
                 },
             },
         )

--- a/control-plane/tests/test_service_persistence_action_reconciliation_reviewed_requests.py
+++ b/control-plane/tests/test_service_persistence_action_reconciliation_reviewed_requests.py
@@ -329,6 +329,7 @@ class ReviewedActionRequestPersistenceTests(ServicePersistenceTestBase):
             delegation_issuer="control-plane-service",
             evidence_ids=(evidence_id,),
         )
+        downstream_binding = execution.provenance["downstream_binding"]
         reconciliation = service.reconcile_action_execution(
             action_request_id=approved_request.action_request_id,
             execution_surface_type="automation_substrate",
@@ -342,6 +343,13 @@ class ReviewedActionRequestPersistenceTests(ServicePersistenceTestBase):
                     "approval_decision_id": execution.approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "observed_at": observed_at,
                     "status": "success",
                 },
@@ -386,6 +394,81 @@ class ReviewedActionRequestPersistenceTests(ServicePersistenceTestBase):
             reconciliation.subject_linkage["evidence_ids"],
             (evidence_id,),
         )
+
+    def test_service_rejects_phase62_notification_success_without_bound_receipt(
+        self,
+    ) -> None:
+        _store, service, promoted_case, evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        recommendation = service.record_case_recommendation(
+            case_id=promoted_case.case_id,
+            review_owner="analyst-001",
+            intended_outcome="Prepare a reviewed owner notification request.",
+        )
+        action_request = service.create_reviewed_action_request_from_advisory(
+            record_family="recommendation",
+            record_id=recommendation.recommendation_id,
+            requester_identity="analyst-001",
+            recipient_identity="repo-owner-001",
+            message_intent="Notify the accountable repository owner about the reviewed permission change.",
+            escalation_reason="Reviewed GitHub audit evidence requires bounded owner notification.",
+            expires_at=reviewed_at + timedelta(hours=4),
+        )
+        approval_decision = service.record_action_approval_decision(
+            action_request_id=action_request.action_request_id,
+            approver_identity="approver-001",
+            authenticated_approver_identity="approver-001",
+            decision="grant",
+            decision_rationale="Reviewed notification remains bounded to one recipient.",
+            decided_at=action_request.requested_at + timedelta(minutes=5),
+        )
+        approved_request = service.get_record(
+            ActionRequestRecord,
+            action_request.action_request_id,
+        )
+        self.assertIsNotNone(approved_request)
+        assert approved_request is not None
+
+        execution = service.delegate_approved_action_to_shuffle(
+            action_request_id=approved_request.action_request_id,
+            approved_payload=dict(approved_request.requested_payload),
+            delegated_at=action_request.requested_at + timedelta(minutes=10),
+            delegation_issuer="control-plane-service",
+            evidence_ids=(evidence_id,),
+        )
+
+        reconciliation = service.reconcile_action_execution(
+            action_request_id=approved_request.action_request_id,
+            execution_surface_type="automation_substrate",
+            execution_surface_id="shuffle",
+            observed_executions=(
+                {
+                    "execution_run_id": execution.execution_run_id,
+                    "execution_surface_type": "automation_substrate",
+                    "execution_surface_id": "shuffle",
+                    "idempotency_key": approved_request.idempotency_key,
+                    "approval_decision_id": approval_decision.approval_decision_id,
+                    "delegation_id": execution.delegation_id,
+                    "payload_hash": execution.payload_hash,
+                    "observed_at": action_request.requested_at + timedelta(minutes=15),
+                    "status": "success",
+                },
+            ),
+            compared_at=action_request.requested_at + timedelta(minutes=16),
+            stale_after=action_request.requested_at + timedelta(hours=1),
+        )
+
+        stored_execution = service.get_record(
+            ActionExecutionRecord,
+            execution.action_execution_id,
+        )
+        self.assertIsNotNone(stored_execution)
+        assert stored_execution is not None
+        self.assertEqual(reconciliation.ingest_disposition, "mismatch")
+        self.assertEqual(reconciliation.lifecycle_state, "mismatched")
+        self.assertIn("receipt binding", reconciliation.mismatch_summary)
+        self.assertEqual(stored_execution.lifecycle_state, "queued")
 
     def test_service_executes_second_low_risk_tracking_ticket_action_from_reviewed_recommendation(
         self,
@@ -547,6 +630,13 @@ class ReviewedActionRequestPersistenceTests(ServicePersistenceTestBase):
                     "approval_decision_id": execution.approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "coordination_reference_id": downstream_binding[
                         "coordination_reference_id"
                     ],
@@ -914,6 +1004,7 @@ class ReviewedActionRequestPersistenceTests(ServicePersistenceTestBase):
             delegation_issuer="control-plane-service",
             evidence_ids=(evidence_id,),
         )
+        downstream_binding = execution.provenance["downstream_binding"]
         service.persist_record(replace(execution, lifecycle_state="running"))
 
         reconciliation = service.reconcile_action_execution(
@@ -929,6 +1020,13 @@ class ReviewedActionRequestPersistenceTests(ServicePersistenceTestBase):
                     "approval_decision_id": execution.approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "observed_at": observed_at,
                     "status": "queued",
                 },

--- a/control-plane/tests/test_service_restore_backup_codec.py
+++ b/control-plane/tests/test_service_restore_backup_codec.py
@@ -549,6 +549,7 @@ class RestoreBackupCodecTests(ServicePersistenceTestBase):
             delegation_issuer="control-plane-service",
             evidence_ids=(evidence_id,),
         )
+        downstream_binding = execution.provenance["downstream_binding"]
         reconciliation = service.reconcile_action_execution(
             action_request_id=approved_request.action_request_id,
             execution_surface_type="automation_substrate",
@@ -562,6 +563,13 @@ class RestoreBackupCodecTests(ServicePersistenceTestBase):
                     "approval_decision_id": execution.approval_decision_id,
                     "delegation_id": execution.delegation_id,
                     "payload_hash": execution.payload_hash,
+                    "action_request_id": execution.action_request_id,
+                    "workflow_id": downstream_binding["workflow_id"],
+                    "workflow_version_id": downstream_binding["workflow_version_id"],
+                    "correlation_id": downstream_binding["correlation_id"],
+                    "expected_execution_receipt_id": downstream_binding[
+                        "expected_execution_receipt_id"
+                    ],
                     "observed_at": observed_at,
                     "status": "success",
                 },

--- a/docs/phase-62-3-per-action-reconciliation-contract.md
+++ b/docs/phase-62-3-per-action-reconciliation-contract.md
@@ -1,0 +1,28 @@
+# AegisOps Phase 62.3 Per-Action Reconciliation Contract
+
+This contract defines the reviewed receipt and reconciliation boundary for the Phase 62 default Read, Notify, and Soft Write catalog actions. It does not add new actions, launch Shuffle directly, widen SOAR marketplace scope, or treat downstream workflow success as AegisOps truth.
+
+## Contract
+
+Every reviewed Phase 62 action must carry expected receipt fields, correlation fields, and reconciliation outcomes in the action policy registry. The required outcomes are success, failure, missing, stale, mismatched, duplicated, wrong-correlation, and manual review.
+
+The common receipt fields are `action_request_id`, `catalog_action`, `family`, `reviewed_template_version`, `correlation_id`, `idempotency_key`, `execution_run_id`, `started_at`, `finished_at`, and `status`. The common correlation fields are `action_request_id`, `approval_decision_id`, `delegation_id`, `execution_run_id`, `correlation_id`, `expected_execution_receipt_id`, and `idempotency_key`.
+
+`enrichment_only_lookup` adds `lookup_subject_ref` and `lookup_evidence_ref` receipt metadata. `operator_notification` adds `recipient_ref`, `delivery_attempt_status`, and `normalized_receipt_ref`. `manual_escalation_request` adds `escalation_owner_ref`, `delivery_attempt_status`, and `fallback_needed`. `create_tracking_ticket` adds approval, ticket pointer, ticket system, ticket pointer custody, delivery status, normalized receipt, coordination reference, and coordination target correlation metadata.
+
+## Enforcement Boundary
+
+Shuffle receipts are subordinate evidence. A Shuffle `success` status can only update AegisOps action execution state when the observed receipt is bound to the authoritative AegisOps action request, approval decision, delegation, payload hash, workflow, workflow version, correlation identifier, expected receipt identifier, execution run, and idempotency key.
+
+Missing receipt metadata, stale observations, mismatched surface/idempotency/binding values, duplicated unsafe observations, and wrong-correlation receipts reconcile as non-matched AegisOps reconciliation records. They do not mutate authoritative action execution records to succeeded, close cases, approve actions, or make downstream ticket or workflow state authoritative.
+
+## Validation
+
+Run `bash scripts/verify-phase-62-3-per-action-reconciliation-contract.sh`.
+
+The focused validation covers:
+
+- Per-action receipt metadata and correlation metadata in the Phase 62 registry.
+- Notification reconciliation rejecting downstream success without a bound AegisOps receipt.
+- Existing receipt normalization and tracking-ticket reconciliation behavior.
+- Publishable path hygiene.

--- a/docs/phase-62-3-per-action-reconciliation-contract.md
+++ b/docs/phase-62-3-per-action-reconciliation-contract.md
@@ -4,7 +4,7 @@ This contract defines the reviewed receipt and reconciliation boundary for the P
 
 ## Contract
 
-Every reviewed Phase 62 action must carry expected receipt fields, correlation fields, and reconciliation outcomes in the action policy registry. The required outcomes are success, failure, missing, stale, mismatched, duplicated, wrong-correlation, and manual review.
+Every reviewed Phase 62 action must carry expected receipt fields, correlation fields, and reconciliation outcomes in the action policy registry. The required outcomes are success, failure, missing, stale, mismatched, duplicate, wrong-correlation, and manual review.
 
 The common receipt fields are `action_request_id`, `catalog_action`, `family`, `reviewed_template_version`, `correlation_id`, `idempotency_key`, `execution_run_id`, `started_at`, `finished_at`, and `status`. The common correlation fields are `action_request_id`, `approval_decision_id`, `delegation_id`, `execution_run_id`, `correlation_id`, `expected_execution_receipt_id`, and `idempotency_key`.
 
@@ -14,7 +14,7 @@ The common receipt fields are `action_request_id`, `catalog_action`, `family`, `
 
 Shuffle receipts are subordinate evidence. A Shuffle `success` status can only update AegisOps action execution state when the observed receipt is bound to the authoritative AegisOps action request, approval decision, delegation, payload hash, workflow, workflow version, correlation identifier, expected receipt identifier, execution run, and idempotency key.
 
-Missing receipt metadata, stale observations, mismatched surface/idempotency/binding values, duplicated unsafe observations, and wrong-correlation receipts reconcile as non-matched AegisOps reconciliation records. They do not mutate authoritative action execution records to succeeded, close cases, approve actions, or make downstream ticket or workflow state authoritative.
+Missing receipt metadata, stale observations, mismatched surface/idempotency/binding values, duplicate unsafe observations, and wrong-correlation receipts reconcile as non-matched AegisOps reconciliation records. They do not mutate authoritative action execution records to succeeded, close cases, approve actions, or make downstream ticket or workflow state authoritative.
 
 ## Validation
 

--- a/docs/phase-62-3-per-action-reconciliation-validation.md
+++ b/docs/phase-62-3-per-action-reconciliation-validation.md
@@ -1,0 +1,16 @@
+# Phase 62.3 Per-Action Reconciliation Contract Validation
+
+Validation date: 2026-05-17
+
+Validation status: PASS
+
+## Evidence
+
+- Phase 62 action policy registry records expected receipt fields, correlation fields, and reconciliation outcomes for `enrichment_only_lookup`, `operator_notification`, `manual_escalation_request`, and `create_tracking_ticket`.
+- Notification reconciliation rejects downstream success without an AegisOps-bound receipt and keeps the authoritative execution record queued.
+- Tracking-ticket receipt normalization and coordination receipt mismatch handling remain preserved.
+- Downstream workflow status remains subordinate to AegisOps action request, approval, execution receipt, and reconciliation records.
+
+## Deviations
+
+- No deviations.

--- a/scripts/verify-phase-62-3-per-action-reconciliation-contract.sh
+++ b/scripts/verify-phase-62-3-per-action-reconciliation-contract.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+required_paths=(
+  "${repo_root}/docs/phase-62-3-per-action-reconciliation-contract.md"
+  "${repo_root}/docs/phase-62-3-per-action-reconciliation-validation.md"
+  "${repo_root}/control-plane/aegisops/control_plane/actions/action_policy_registry.py"
+  "${repo_root}/control-plane/aegisops/control_plane/actions/execution_coordinator_reconciliation.py"
+  "${repo_root}/control-plane/tests/test_phase62_action_policy_registry.py"
+  "${repo_root}/control-plane/tests/test_service_persistence_action_reconciliation_reviewed_requests.py"
+)
+
+for path in "${required_paths[@]}"; do
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing Phase 62.3 per-action reconciliation artifact: ${path}" >&2
+    exit 1
+  fi
+done
+
+require_phrase() {
+  local file_path="$1"
+  local expected="$2"
+  if ! grep -Fq -- "${expected}" "${file_path}"; then
+    echo "Missing Phase 62.3 reconciliation statement in ${file_path}: ${expected}" >&2
+    exit 1
+  fi
+}
+
+registry_path="${repo_root}/control-plane/aegisops/control_plane/actions/action_policy_registry.py"
+for phrase in \
+  'expected_receipt_fields' \
+  'correlation_fields' \
+  'reconciliation_outcomes' \
+  '"success"' \
+  '"failure"' \
+  '"missing"' \
+  '"stale"' \
+  '"mismatched"' \
+  '"duplicated"' \
+  '"wrong_correlation"' \
+  '"manual_review"' \
+  '"expected_execution_receipt_id"' \
+  '"coordination_reference_id"'; do
+  require_phrase "${registry_path}" "${phrase}"
+done
+
+contract_path="${repo_root}/docs/phase-62-3-per-action-reconciliation-contract.md"
+for phrase in \
+  '# AegisOps Phase 62.3 Per-Action Reconciliation Contract' \
+  'Every reviewed Phase 62 action must carry expected receipt fields' \
+  'Shuffle receipts are subordinate evidence.' \
+  'A Shuffle `success` status can only update AegisOps action execution state when the observed receipt is bound' \
+  'Run `bash scripts/verify-phase-62-3-per-action-reconciliation-contract.sh`.'; do
+  require_phrase "${contract_path}" "${phrase}"
+done
+
+(cd "${repo_root}" && PYTHONPATH="${repo_root}/control-plane:${repo_root}/control-plane/tests" python3 -m unittest \
+  control-plane.tests.test_phase62_action_policy_registry \
+  control-plane.tests.test_service_persistence_action_reconciliation_reviewed_requests.ReviewedActionRequestPersistenceTests.test_service_rejects_phase62_notification_success_without_bound_receipt \
+  control-plane.tests.test_service_persistence_action_reconciliation_reviewed_requests.ReviewedActionRequestPersistenceTests.test_service_executes_phase20_first_live_action_end_to_end_from_reviewed_recommendation \
+  control-plane.tests.test_service_persistence_action_reconciliation_create_tracking_ticket.CreateTrackingTicketActionReconciliationPersistenceTests.test_service_reconciles_create_tracking_ticket_receipt_into_authoritative_records \
+  control-plane.tests.test_service_persistence_action_reconciliation_create_tracking_ticket.CreateTrackingTicketActionReconciliationPersistenceTests.test_service_fail_closes_when_create_tracking_ticket_reconciliation_receipt_drifts \
+  control-plane.tests.test_action_receipt_validation)
+
+path_hygiene_stderr="${repo_root}/.tmp-phase62-3-reconciliation-path-hygiene.err"
+trap 'rm -f "${path_hygiene_stderr}"' EXIT
+if ! bash "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" >/dev/null 2>"${path_hygiene_stderr}"; then
+  cat "${path_hygiene_stderr}" >&2
+  echo "Forbidden Phase 62.3 reconciliation contract absolute path usage detected" >&2
+  exit 1
+fi
+
+echo "Phase 62.3 per-action reconciliation contract and focused tests pass."

--- a/scripts/verify-phase-62-3-per-action-reconciliation-contract.sh
+++ b/scripts/verify-phase-62-3-per-action-reconciliation-contract.sh
@@ -39,7 +39,7 @@ for phrase in \
   '"missing"' \
   '"stale"' \
   '"mismatched"' \
-  '"duplicated"' \
+  '"duplicate"' \
   '"wrong_correlation"' \
   '"manual_review"' \
   '"expected_execution_receipt_id"' \


### PR DESCRIPTION
## Summary
- add Phase 62 per-action receipt, correlation, and reconciliation outcome metadata to the action policy registry
- bind Shuffle receipts with workflow, version, correlation, and expected receipt identifiers even when explicit delegation binding is absent
- reject downstream success without an AegisOps-bound receipt and preserve existing tracking-ticket/authority-boundary behavior
- add Phase 62.3 contract, validation note, and verifier

## Verification
- bash scripts/verify-phase-62-3-per-action-reconciliation-contract.sh
- PYTHONPATH=control-plane:control-plane/tests python3 -m unittest control-plane.tests.test_service_persistence_action_reconciliation control-plane.tests.test_phase62_action_policy_registry control-plane.tests.test_action_receipt_validation
- bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh
- bash scripts/verify-phase-54-9-shuffle-authority-boundary-negative-tests.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1317 --config <supervisor-config-path>

Closes #1317
