### PR TITLE
Add Phase 62.4 Shuffle workflow mapping

### DIFF
--- a/control-plane/aegisops/control_plane/actions/action_policy_registry.py
+++ b/control-plane/aegisops/control_plane/actions/action_policy_registry.py
@@ -345,11 +345,11 @@ def validate_phase62_shuffle_workflow_mapping(
         errors.append("family_mismatch")
     if policy_registry_id != reviewed_policy.registry_id:
         errors.append("policy_incompatibility")
-    for field_name in ("action_request_id", "approval_decision_id"):
+    for field_name in reviewed_mapping.required_inputs:
         if field_name not in required_inputs:
             errors.append("missing_required_input")
             break
-    for field_name in ("execution_receipt_id", "normalized_receipt_ref"):
+    for field_name in reviewed_mapping.expected_outputs:
         if field_name not in expected_outputs:
             errors.append("missing_expected_output")
             break

--- a/control-plane/aegisops/control_plane/actions/action_policy_registry.py
+++ b/control-plane/aegisops/control_plane/actions/action_policy_registry.py
@@ -39,6 +39,20 @@ class ActionPolicy:
 
 
 @dataclass(frozen=True)
+class ShuffleWorkflowMapping:
+    catalog_action: str
+    workflow_template_id: str
+    reviewed_template_version: str
+    family: str
+    required_inputs: tuple[str, ...]
+    expected_outputs: tuple[str, ...]
+    correlation_fields: tuple[str, ...]
+    policy_registry_id: str
+    review_status: str = "reviewed"
+    import_eligible: bool = True
+
+
+@dataclass(frozen=True)
 class ActionPolicyDecision:
     policy: ActionPolicy
     requester_role: str
@@ -190,6 +204,160 @@ PHASE62_ACTION_POLICIES: Mapping[str, ActionPolicy] = {
 ACTION_TYPE_POLICY_ALIASES = {
     "notify_identity_owner": "operator_notification",
 }
+
+_COMMON_SHUFFLE_REQUIRED_INPUTS = (
+    "action_request_id",
+    "approval_decision_id",
+    "correlation_id",
+    "reviewed_template_version",
+    "requested_by",
+    "callback_url",
+    "callback_secret_ref",
+)
+_COMMON_SHUFFLE_EXPECTED_OUTPUTS = (
+    "action_request_id",
+    "approval_decision_id",
+    "correlation_id",
+    "execution_receipt_id",
+    "normalized_receipt_ref",
+    "reviewed_template_version",
+    "execution_status",
+    "execution_started_at",
+    "execution_finished_at",
+)
+
+PHASE62_SHUFFLE_WORKFLOW_MAPPINGS: Mapping[str, ShuffleWorkflowMapping] = {
+    "enrichment_only_lookup": ShuffleWorkflowMapping(
+        catalog_action="enrichment_only_lookup",
+        workflow_template_id="enrichment_only_lookup",
+        reviewed_template_version="enrichment_only_lookup-v1-reviewed-2026-05-03",
+        family="Read",
+        required_inputs=_COMMON_SHUFFLE_REQUIRED_INPUTS
+        + ("lookup_subject_id", "enrichment_scope"),
+        expected_outputs=_COMMON_SHUFFLE_EXPECTED_OUTPUTS + ("lookup_result_ref",),
+        correlation_fields=PHASE62_ACTION_POLICIES[
+            "enrichment_only_lookup"
+        ].correlation_fields,
+        policy_registry_id="phase62.2:enrichment_only_lookup",
+    ),
+    "operator_notification": ShuffleWorkflowMapping(
+        catalog_action="operator_notification",
+        workflow_template_id="operator_notification",
+        reviewed_template_version="operator_notification-v1-reviewed-2026-05-03",
+        family="Notify",
+        required_inputs=_COMMON_SHUFFLE_REQUIRED_INPUTS
+        + ("operator_recipient_id", "notification_scope"),
+        expected_outputs=_COMMON_SHUFFLE_EXPECTED_OUTPUTS
+        + ("notification_delivery_ref",),
+        correlation_fields=PHASE62_ACTION_POLICIES[
+            "operator_notification"
+        ].correlation_fields,
+        policy_registry_id="phase62.2:operator_notification",
+    ),
+    "manual_escalation_request": ShuffleWorkflowMapping(
+        catalog_action="manual_escalation_request",
+        workflow_template_id="manual_escalation_request",
+        reviewed_template_version="manual_escalation_request-v1-reviewed-2026-05-03",
+        family="Notify",
+        required_inputs=_COMMON_SHUFFLE_REQUIRED_INPUTS
+        + ("escalation_subject_id", "escalation_owner_id", "escalation_scope"),
+        expected_outputs=_COMMON_SHUFFLE_EXPECTED_OUTPUTS
+        + ("manual_escalation_request_ref",),
+        correlation_fields=PHASE62_ACTION_POLICIES[
+            "manual_escalation_request"
+        ].correlation_fields,
+        policy_registry_id="phase62.2:manual_escalation_request",
+    ),
+    "create_tracking_ticket": ShuffleWorkflowMapping(
+        catalog_action="create_tracking_ticket",
+        workflow_template_id="create_tracking_ticket",
+        reviewed_template_version="create_tracking_ticket-v1-reviewed-2026-05-03",
+        family="Soft Write",
+        required_inputs=_COMMON_SHUFFLE_REQUIRED_INPUTS
+        + (
+            "ticket_pointer_id",
+            "ticket_system_id",
+            "ticket_pointer_custody",
+            "ticket_coordination_scope",
+        ),
+        expected_outputs=_COMMON_SHUFFLE_EXPECTED_OUTPUTS
+        + ("ticket_pointer_id", "ticket_system_id", "ticket_pointer_custody"),
+        correlation_fields=PHASE62_ACTION_POLICIES[
+            "create_tracking_ticket"
+        ].correlation_fields,
+        policy_registry_id="phase62.2:create_tracking_ticket",
+    ),
+}
+
+_LEGACY_ACTION_TYPE_SHUFFLE_MAPPINGS: Mapping[str, ShuffleWorkflowMapping] = {
+    "notify_identity_owner": ShuffleWorkflowMapping(
+        catalog_action="operator_notification",
+        workflow_template_id="notify_identity_owner",
+        reviewed_template_version="notify_identity_owner-v1-reviewed-2026-05-03",
+        family="Notify",
+        required_inputs=_COMMON_SHUFFLE_REQUIRED_INPUTS
+        + ("recipient_identity_owner_id", "message_scope"),
+        expected_outputs=_COMMON_SHUFFLE_EXPECTED_OUTPUTS,
+        correlation_fields=PHASE62_ACTION_POLICIES[
+            "operator_notification"
+        ].correlation_fields,
+        policy_registry_id="phase62.2:operator_notification",
+    ),
+}
+
+
+def reviewed_shuffle_workflow_mapping_for_action_type(
+    action_type: str,
+) -> ShuffleWorkflowMapping | None:
+    if action_type in _LEGACY_ACTION_TYPE_SHUFFLE_MAPPINGS:
+        return _LEGACY_ACTION_TYPE_SHUFFLE_MAPPINGS[action_type]
+    catalog_action = ACTION_TYPE_POLICY_ALIASES.get(action_type, action_type)
+    return PHASE62_SHUFFLE_WORKFLOW_MAPPINGS.get(catalog_action)
+
+
+def validate_phase62_shuffle_workflow_mapping(
+    *,
+    catalog_action: str,
+    workflow_template_id: str,
+    reviewed_template_version: str,
+    family: str,
+    required_inputs: tuple[str, ...],
+    expected_outputs: tuple[str, ...],
+    correlation_fields: tuple[str, ...],
+    policy_registry_id: str,
+    review_status: str,
+    import_eligible: bool,
+) -> tuple[str, ...]:
+    reviewed_mapping = PHASE62_SHUFFLE_WORKFLOW_MAPPINGS.get(catalog_action)
+    reviewed_policy = PHASE62_ACTION_POLICIES.get(catalog_action)
+    errors: list[str] = []
+    if reviewed_mapping is None or reviewed_policy is None:
+        return ("unsupported_action",)
+    if not workflow_template_id:
+        errors.append("missing_template")
+    elif workflow_template_id != reviewed_mapping.workflow_template_id:
+        errors.append("template_mismatch")
+    if reviewed_template_version != reviewed_mapping.reviewed_template_version:
+        errors.append("version_mismatch")
+    if review_status != "reviewed" or not import_eligible:
+        errors.append("unreviewed_template")
+    if family != reviewed_policy.family:
+        errors.append("family_mismatch")
+    if policy_registry_id != reviewed_policy.registry_id:
+        errors.append("policy_incompatibility")
+    for field_name in ("action_request_id", "approval_decision_id"):
+        if field_name not in required_inputs:
+            errors.append("missing_required_input")
+            break
+    for field_name in ("execution_receipt_id", "normalized_receipt_ref"):
+        if field_name not in expected_outputs:
+            errors.append("missing_expected_output")
+            break
+    for field_name in reviewed_policy.correlation_fields:
+        if field_name not in correlation_fields:
+            errors.append("missing_correlation")
+            break
+    return tuple(dict.fromkeys(errors))
 
 
 def requester_role_from_identity(identity: str) -> str:

--- a/control-plane/aegisops/control_plane/actions/action_policy_registry.py
+++ b/control-plane/aegisops/control_plane/actions/action_policy_registry.py
@@ -345,18 +345,24 @@ def validate_phase62_shuffle_workflow_mapping(
         errors.append("family_mismatch")
     if policy_registry_id != reviewed_policy.registry_id:
         errors.append("policy_incompatibility")
-    for field_name in reviewed_mapping.required_inputs:
-        if field_name not in required_inputs:
-            errors.append("missing_required_input")
-            break
-    for field_name in reviewed_mapping.expected_outputs:
-        if field_name not in expected_outputs:
-            errors.append("missing_expected_output")
-            break
-    for field_name in reviewed_policy.correlation_fields:
-        if field_name not in correlation_fields:
-            errors.append("missing_correlation")
-            break
+    reviewed_required_inputs = set(reviewed_mapping.required_inputs)
+    candidate_required_inputs = set(required_inputs)
+    if reviewed_required_inputs - candidate_required_inputs:
+        errors.append("missing_required_input")
+    if candidate_required_inputs - reviewed_required_inputs:
+        errors.append("unexpected_required_input")
+    reviewed_expected_outputs = set(reviewed_mapping.expected_outputs)
+    candidate_expected_outputs = set(expected_outputs)
+    if reviewed_expected_outputs - candidate_expected_outputs:
+        errors.append("missing_expected_output")
+    if candidate_expected_outputs - reviewed_expected_outputs:
+        errors.append("unexpected_expected_output")
+    reviewed_correlation_fields = set(reviewed_policy.correlation_fields)
+    candidate_correlation_fields = set(correlation_fields)
+    if reviewed_correlation_fields - candidate_correlation_fields:
+        errors.append("missing_correlation")
+    if candidate_correlation_fields - reviewed_correlation_fields:
+        errors.append("unexpected_correlation")
     return tuple(dict.fromkeys(errors))
 
 

--- a/control-plane/aegisops/control_plane/actions/execution_coordinator_delegation.py
+++ b/control-plane/aegisops/control_plane/actions/execution_coordinator_delegation.py
@@ -9,6 +9,7 @@ from .action_receipt_validation import (
     require_receipt_https_url_value,
     require_receipt_string_value,
 )
+from .action_policy_registry import reviewed_shuffle_workflow_mapping_for_action_type
 from .execution_coordinator import (
     ExecutionCoordinatorServiceDependencies,
     _PHASE26_REVIEWED_COORDINATION_TARGET_TYPES,
@@ -19,12 +20,6 @@ from ..models import (
     ActionRequestRecord,
     ApprovalDecisionRecord,
 )
-
-
-_REVIEWED_SHUFFLE_WORKFLOW_VERSIONS = {
-    "create_tracking_ticket": "create_tracking_ticket-v1-reviewed-2026-05-03",
-    "notify_identity_owner": "notify_identity_owner-v1-reviewed-2026-05-03",
-}
 
 
 class ApprovedActionDelegationCoordinator:
@@ -281,6 +276,18 @@ class ApprovedActionDelegationCoordinator:
         approved_payload: Mapping[str, object],
     ) -> None:
         action_type = approved_payload.get("action_type")
+        action_type_value = (
+            action_type.strip()
+            if isinstance(action_type, str) and action_type.strip()
+            else ""
+        )
+        reviewed_mapping = reviewed_shuffle_workflow_mapping_for_action_type(
+            action_type_value,
+        )
+        if reviewed_mapping is None:
+            raise ValueError(
+                "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
+            )
         if action_type == "notify_identity_owner":
             for field_name in (
                 "recipient_identity",
@@ -340,6 +347,13 @@ class ApprovedActionDelegationCoordinator:
             approved_payload.get("action_type"),
             "approved_payload.action_type",
         )
+        reviewed_mapping = reviewed_shuffle_workflow_mapping_for_action_type(
+            action_type,
+        )
+        if reviewed_mapping is None:
+            raise ValueError(
+                "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
+            )
         workflow_id = self._service._require_non_empty_string(
             binding.get("workflow_id"),
             "shuffle_delegation_binding.workflow_id",
@@ -360,14 +374,11 @@ class ApprovedActionDelegationCoordinator:
         if not isinstance(requested_scope, Mapping):
             raise ValueError("shuffle delegation binding requested_scope is malformed")
 
-        if workflow_id != action_type:
+        if workflow_id != reviewed_mapping.workflow_template_id:
             raise ValueError(
                 "shuffle delegation binding does not match approved action request scope"
             )
-        if (
-            _REVIEWED_SHUFFLE_WORKFLOW_VERSIONS.get(workflow_id)
-            != workflow_version_id
-        ):
+        if reviewed_mapping.reviewed_template_version != workflow_version_id:
             raise ValueError(
                 "shuffle delegation binding uses an unknown reviewed workflow template version"
             )

--- a/control-plane/aegisops/control_plane/adapters/shuffle.py
+++ b/control-plane/aegisops/control_plane/adapters/shuffle.py
@@ -4,6 +4,10 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Mapping
 
+from ..actions.action_policy_registry import (
+    reviewed_shuffle_workflow_mapping_for_action_type,
+)
+
 
 @dataclass(frozen=True)
 class ShuffleDelegationReceipt:
@@ -127,20 +131,26 @@ class ShuffleActionAdapter:
 
     @staticmethod
     def _default_workflow_id(action_type: object) -> str:
-        if action_type == "notify_identity_owner":
-            return "notify_identity_owner"
-        if action_type == "create_tracking_ticket":
-            return "create_tracking_ticket"
+        if isinstance(action_type, str):
+            mapping = reviewed_shuffle_workflow_mapping_for_action_type(action_type)
+            if mapping is not None:
+                return mapping.workflow_template_id
         raise ValueError(
             "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
         )
 
     @staticmethod
     def _default_workflow_version_id(workflow_id: str) -> str:
-        if workflow_id == "notify_identity_owner":
-            return "notify_identity_owner-v1-reviewed-2026-05-03"
-        if workflow_id == "create_tracking_ticket":
-            return "create_tracking_ticket-v1-reviewed-2026-05-03"
+        for action_type in (
+            "enrichment_only_lookup",
+            "operator_notification",
+            "manual_escalation_request",
+            "create_tracking_ticket",
+            "notify_identity_owner",
+        ):
+            mapping = reviewed_shuffle_workflow_mapping_for_action_type(action_type)
+            if mapping is not None and mapping.workflow_template_id == workflow_id:
+                return mapping.reviewed_template_version
         raise ValueError(
             "approved action is outside the reviewed Phase 20 Shuffle delegation scope"
         )

--- a/control-plane/tests/test_phase62_action_policy_registry.py
+++ b/control-plane/tests/test_phase62_action_policy_registry.py
@@ -156,6 +156,21 @@ class Phase62ActionPolicyRegistryTests(unittest.TestCase):
             review_status=reviewed_mapping.review_status,
             import_eligible=reviewed_mapping.import_eligible,
         )
+        unexpected_contract_fields = validate_phase62_shuffle_workflow_mapping(
+            catalog_action="operator_notification",
+            workflow_template_id="operator_notification",
+            reviewed_template_version=reviewed_mapping.reviewed_template_version,
+            family=reviewed_mapping.family,
+            required_inputs=reviewed_mapping.required_inputs
+            + ("unreviewed_operator_hint",),
+            expected_outputs=reviewed_mapping.expected_outputs
+            + ("unreviewed_delivery_receipt",),
+            correlation_fields=reviewed_mapping.correlation_fields
+            + ("unreviewed_correlation_hint",),
+            policy_registry_id="phase62.2:operator_notification",
+            review_status=reviewed_mapping.review_status,
+            import_eligible=reviewed_mapping.import_eligible,
+        )
         policy_incompatibility = validate_phase62_shuffle_workflow_mapping(
             catalog_action="operator_notification",
             workflow_template_id="operator_notification",
@@ -186,6 +201,9 @@ class Phase62ActionPolicyRegistryTests(unittest.TestCase):
         self.assertIn("unreviewed_template", unreviewed_template)
         self.assertIn("family_mismatch", family_mismatch)
         self.assertIn("missing_correlation", missing_correlation)
+        self.assertIn("unexpected_required_input", unexpected_contract_fields)
+        self.assertIn("unexpected_expected_output", unexpected_contract_fields)
+        self.assertIn("unexpected_correlation", unexpected_contract_fields)
         self.assertIn("policy_incompatibility", policy_incompatibility)
         self.assertIn("unsupported_action", unsupported_action)
 
@@ -217,6 +235,24 @@ class Phase62ActionPolicyRegistryTests(unittest.TestCase):
 
         self.assertIn("missing_required_input", validation)
         self.assertIn("missing_expected_output", validation)
+
+        unexpected_validation = validate_phase62_shuffle_workflow_mapping(
+            catalog_action="create_tracking_ticket",
+            workflow_template_id=reviewed_mapping.workflow_template_id,
+            reviewed_template_version=reviewed_mapping.reviewed_template_version,
+            family=reviewed_mapping.family,
+            required_inputs=reviewed_mapping.required_inputs
+            + ("unreviewed_ticket_priority",),
+            expected_outputs=reviewed_mapping.expected_outputs
+            + ("unreviewed_ticket_url",),
+            correlation_fields=reviewed_mapping.correlation_fields,
+            policy_registry_id=reviewed_mapping.policy_registry_id,
+            review_status=reviewed_mapping.review_status,
+            import_eligible=reviewed_mapping.import_eligible,
+        )
+
+        self.assertIn("unexpected_required_input", unexpected_validation)
+        self.assertIn("unexpected_expected_output", unexpected_validation)
 
     def test_validation_allows_reviewed_tracking_ticket_policy(self) -> None:
         decision = evaluate_phase62_action_policy(

--- a/control-plane/tests/test_phase62_action_policy_registry.py
+++ b/control-plane/tests/test_phase62_action_policy_registry.py
@@ -12,7 +12,9 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
 
 from aegisops.control_plane.actions.action_policy_registry import (  # noqa: E402
     PHASE62_ACTION_POLICIES,
+    PHASE62_SHUFFLE_WORKFLOW_MAPPINGS,
     evaluate_phase62_action_policy,
+    validate_phase62_shuffle_workflow_mapping,
 )
 
 
@@ -54,6 +56,138 @@ class Phase62ActionPolicyRegistryTests(unittest.TestCase):
                     "manual_review",
                 ),
             )
+
+    def test_shuffle_mapping_contains_reviewed_catalog_actions(self) -> None:
+        self.assertEqual(
+            set(PHASE62_SHUFFLE_WORKFLOW_MAPPINGS),
+            set(PHASE62_ACTION_POLICIES),
+        )
+
+        tracking_ticket = PHASE62_SHUFFLE_WORKFLOW_MAPPINGS[
+            "create_tracking_ticket"
+        ]
+        self.assertEqual(tracking_ticket.workflow_template_id, "create_tracking_ticket")
+        self.assertEqual(
+            tracking_ticket.reviewed_template_version,
+            "create_tracking_ticket-v1-reviewed-2026-05-03",
+        )
+        self.assertEqual(tracking_ticket.family, "Soft Write")
+        self.assertIn("correlation_id", tracking_ticket.correlation_fields)
+        self.assertIn(
+            "expected_execution_receipt_id",
+            tracking_ticket.correlation_fields,
+        )
+
+        validation = validate_phase62_shuffle_workflow_mapping(
+            catalog_action="create_tracking_ticket",
+            workflow_template_id="create_tracking_ticket",
+            reviewed_template_version="create_tracking_ticket-v1-reviewed-2026-05-03",
+            family="Soft Write",
+            required_inputs=tracking_ticket.required_inputs,
+            expected_outputs=tracking_ticket.expected_outputs,
+            correlation_fields=tracking_ticket.correlation_fields,
+            policy_registry_id="phase62.2:create_tracking_ticket",
+            review_status=tracking_ticket.review_status,
+            import_eligible=tracking_ticket.import_eligible,
+        )
+
+        self.assertEqual(validation, ())
+
+    def test_shuffle_mapping_validation_fails_closed_for_drift(self) -> None:
+        reviewed_mapping = PHASE62_SHUFFLE_WORKFLOW_MAPPINGS["operator_notification"]
+
+        missing_template = validate_phase62_shuffle_workflow_mapping(
+            catalog_action="operator_notification",
+            workflow_template_id="",
+            reviewed_template_version=reviewed_mapping.reviewed_template_version,
+            family=reviewed_mapping.family,
+            required_inputs=reviewed_mapping.required_inputs,
+            expected_outputs=reviewed_mapping.expected_outputs,
+            correlation_fields=reviewed_mapping.correlation_fields,
+            policy_registry_id="phase62.2:operator_notification",
+            review_status=reviewed_mapping.review_status,
+            import_eligible=reviewed_mapping.import_eligible,
+        )
+        version_mismatch = validate_phase62_shuffle_workflow_mapping(
+            catalog_action="operator_notification",
+            workflow_template_id="operator_notification",
+            reviewed_template_version="operator_notification-v2-unreviewed",
+            family=reviewed_mapping.family,
+            required_inputs=reviewed_mapping.required_inputs,
+            expected_outputs=reviewed_mapping.expected_outputs,
+            correlation_fields=reviewed_mapping.correlation_fields,
+            policy_registry_id="phase62.2:operator_notification",
+            review_status=reviewed_mapping.review_status,
+            import_eligible=reviewed_mapping.import_eligible,
+        )
+        unreviewed_template = validate_phase62_shuffle_workflow_mapping(
+            catalog_action="operator_notification",
+            workflow_template_id="operator_notification",
+            reviewed_template_version=reviewed_mapping.reviewed_template_version,
+            family=reviewed_mapping.family,
+            required_inputs=reviewed_mapping.required_inputs,
+            expected_outputs=reviewed_mapping.expected_outputs,
+            correlation_fields=reviewed_mapping.correlation_fields,
+            policy_registry_id="phase62.2:operator_notification",
+            review_status="draft",
+            import_eligible=False,
+        )
+        family_mismatch = validate_phase62_shuffle_workflow_mapping(
+            catalog_action="operator_notification",
+            workflow_template_id="operator_notification",
+            reviewed_template_version=reviewed_mapping.reviewed_template_version,
+            family="Hard Write",
+            required_inputs=reviewed_mapping.required_inputs,
+            expected_outputs=reviewed_mapping.expected_outputs,
+            correlation_fields=reviewed_mapping.correlation_fields,
+            policy_registry_id="phase62.2:operator_notification",
+            review_status=reviewed_mapping.review_status,
+            import_eligible=reviewed_mapping.import_eligible,
+        )
+        missing_correlation = validate_phase62_shuffle_workflow_mapping(
+            catalog_action="operator_notification",
+            workflow_template_id="operator_notification",
+            reviewed_template_version=reviewed_mapping.reviewed_template_version,
+            family=reviewed_mapping.family,
+            required_inputs=reviewed_mapping.required_inputs,
+            expected_outputs=reviewed_mapping.expected_outputs,
+            correlation_fields=("action_request_id",),
+            policy_registry_id="phase62.2:operator_notification",
+            review_status=reviewed_mapping.review_status,
+            import_eligible=reviewed_mapping.import_eligible,
+        )
+        policy_incompatibility = validate_phase62_shuffle_workflow_mapping(
+            catalog_action="operator_notification",
+            workflow_template_id="operator_notification",
+            reviewed_template_version=reviewed_mapping.reviewed_template_version,
+            family=reviewed_mapping.family,
+            required_inputs=reviewed_mapping.required_inputs,
+            expected_outputs=reviewed_mapping.expected_outputs,
+            correlation_fields=reviewed_mapping.correlation_fields,
+            policy_registry_id="phase62.2:create_tracking_ticket",
+            review_status=reviewed_mapping.review_status,
+            import_eligible=reviewed_mapping.import_eligible,
+        )
+        unsupported_action = validate_phase62_shuffle_workflow_mapping(
+            catalog_action="disable_account",
+            workflow_template_id="disable_account",
+            reviewed_template_version="disable_account-v1-reviewed",
+            family="Hard Write",
+            required_inputs=("action_request_id",),
+            expected_outputs=("execution_receipt_id",),
+            correlation_fields=("correlation_id",),
+            policy_registry_id="phase62.2:disable_account",
+            review_status="reviewed",
+            import_eligible=True,
+        )
+
+        self.assertIn("missing_template", missing_template)
+        self.assertIn("version_mismatch", version_mismatch)
+        self.assertIn("unreviewed_template", unreviewed_template)
+        self.assertIn("family_mismatch", family_mismatch)
+        self.assertIn("missing_correlation", missing_correlation)
+        self.assertIn("policy_incompatibility", policy_incompatibility)
+        self.assertIn("unsupported_action", unsupported_action)
 
     def test_validation_allows_reviewed_tracking_ticket_policy(self) -> None:
         decision = evaluate_phase62_action_policy(

--- a/control-plane/tests/test_phase62_action_policy_registry.py
+++ b/control-plane/tests/test_phase62_action_policy_registry.py
@@ -189,6 +189,35 @@ class Phase62ActionPolicyRegistryTests(unittest.TestCase):
         self.assertIn("policy_incompatibility", policy_incompatibility)
         self.assertIn("unsupported_action", unsupported_action)
 
+    def test_shuffle_mapping_validation_rejects_action_specific_contract_drift(
+        self,
+    ) -> None:
+        reviewed_mapping = PHASE62_SHUFFLE_WORKFLOW_MAPPINGS["create_tracking_ticket"]
+
+        validation = validate_phase62_shuffle_workflow_mapping(
+            catalog_action="create_tracking_ticket",
+            workflow_template_id=reviewed_mapping.workflow_template_id,
+            reviewed_template_version=reviewed_mapping.reviewed_template_version,
+            family=reviewed_mapping.family,
+            required_inputs=tuple(
+                field
+                for field in reviewed_mapping.required_inputs
+                if field not in {"ticket_pointer_id", "ticket_system_id"}
+            ),
+            expected_outputs=tuple(
+                field
+                for field in reviewed_mapping.expected_outputs
+                if field not in {"ticket_pointer_id", "ticket_system_id"}
+            ),
+            correlation_fields=reviewed_mapping.correlation_fields,
+            policy_registry_id=reviewed_mapping.policy_registry_id,
+            review_status=reviewed_mapping.review_status,
+            import_eligible=reviewed_mapping.import_eligible,
+        )
+
+        self.assertIn("missing_required_input", validation)
+        self.assertIn("missing_expected_output", validation)
+
     def test_validation_allows_reviewed_tracking_ticket_policy(self) -> None:
         decision = evaluate_phase62_action_policy(
             action_type="create_tracking_ticket",

--- a/scripts/verify-phase-62-4-shuffle-workflow-mapping.sh
+++ b/scripts/verify-phase-62-4-shuffle-workflow-mapping.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+required_files=(
+  "${repo_root}/control-plane/aegisops/control_plane/actions/action_policy_registry.py"
+  "${repo_root}/control-plane/aegisops/control_plane/actions/execution_coordinator_delegation.py"
+  "${repo_root}/control-plane/aegisops/control_plane/adapters/shuffle.py"
+  "${repo_root}/control-plane/tests/test_phase62_action_policy_registry.py"
+)
+
+for path in "${required_files[@]}"; do
+  if [[ ! -f "${path}" ]]; then
+    echo "Missing Phase 62.4 Shuffle workflow mapping artifact: ${path}" >&2
+    exit 1
+  fi
+done
+
+(cd "${repo_root}" && python3 -m unittest \
+  control-plane.tests.test_phase62_action_policy_registry \
+  control-plane.tests.test_service_persistence_action_reconciliation_delegation \
+  control-plane.tests.test_service_persistence_action_reconciliation_reviewed_requests \
+  control-plane.tests.test_service_persistence_action_reconciliation_create_tracking_ticket)
+
+path_hygiene_stderr="${repo_root}/.tmp-phase62-4-shuffle-mapping-path-hygiene.err"
+trap 'rm -f "${path_hygiene_stderr}"' EXIT
+if ! bash "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" >/dev/null 2>"${path_hygiene_stderr}"; then
+  cat "${path_hygiene_stderr}" >&2
+  echo "Forbidden Phase 62.4 Shuffle workflow mapping absolute path usage detected" >&2
+  exit 1
+fi
+
+echo "Phase 62.4 Shuffle workflow mapping verifier passes."


### PR DESCRIPTION
## Summary
- add Phase 62.4 reviewed Shuffle workflow mappings for the reviewed automation catalog
- validate template identity, reviewed version, action family, required inputs, expected outputs, correlation fields, review status, import eligibility, and policy compatibility
- route Shuffle delegation and adapter defaults through the reviewed mapping registry while preserving legacy notify_identity_owner compatibility
- add a Phase 62.4 focused verifier

## Verification
- `scripts/verify-phase-62-4-shuffle-workflow-mapping.sh`
- `bash scripts/verify-phase-62-2-action-policy-registry.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1318 --config <supervisor-config-path>`

Part of #1314.
Closes #1318.