### PR TITLE
Add reviewed action catalog UI

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.actionCatalog.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.actionCatalog.testSuite.tsx
@@ -1,0 +1,155 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createDefaultDependencies } from "./OperatorRoutes";
+import {
+  createAuthorizedFetch,
+  renderOperatorRoute,
+} from "./OperatorRoutes.testSupport";
+
+export function registerOperatorRoutesActionCatalogTests() {
+  describe("action catalog routes", () => {
+    it("renders reviewed action catalog posture from backend action records", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch(
+          {
+            "/inspect-records": {
+              read_only: true,
+              records: [
+                {
+                  action_request_id: "action-request-failed-001",
+                  action_type: "enrichment_only_lookup",
+                  catalog_action: "enrichment_only_lookup",
+                  action_request_state: "approved",
+                  approval_state: "policy_not_required",
+                  action_execution_state: "failed",
+                  reconciliation_state: "missing_reconciliation",
+                  fallback_state: "not_recorded",
+                  receipt_state: "missing_receipt",
+                  requested_at: "2026-05-18T01:03:00Z",
+                },
+                {
+                  action_request_id: "action-request-normal-001",
+                  action_type: "operator_notification",
+                  catalog_action: "operator_notification",
+                  action_request_state: "approved",
+                  approval_state: "policy_not_required",
+                  action_execution_state: "succeeded",
+                  reconciliation_state: "matched",
+                  fallback_state: "not_required",
+                  receipt_state: "present",
+                  simulation_mode: "production",
+                  requested_at: "2026-05-18T01:00:00Z",
+                },
+                {
+                  action_request_id: "action-request-fallback-001",
+                  action_type: "manual_escalation_request",
+                  catalog_action: "manual_escalation_request",
+                  action_request_state: "expired",
+                  approval_state: "expired",
+                  action_execution_state: "pending",
+                  reconciliation_state: "stale_receipt",
+                  fallback_state: "fallback_required",
+                  receipt_state: "stale_receipt",
+                  demo_test_label: "demo",
+                  requested_at: "2026-05-18T01:02:00Z",
+                },
+                {
+                  action_request_id: "action-request-mismatched-001",
+                  action_type: "create_tracking_ticket",
+                  catalog_action: "create_tracking_ticket",
+                  action_request_state: "rejected",
+                  approval_state: "rejected",
+                  action_execution_state: "rejected",
+                  reconciliation_state: "mismatched",
+                  fallback_state: "manual_review",
+                  receipt_state: "mismatched_receipt",
+                  requested_at: "2026-05-18T01:01:00Z",
+                },
+              ],
+              total_records: 4,
+            },
+          },
+          {
+            identity: "approver@example.com",
+            provider: "authentik",
+            roles: ["Approver"],
+            subject: "operator-8",
+          },
+        ),
+      });
+
+      renderOperatorRoute("/operator/actions", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Action Catalog" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("operator_notification")).toBeInTheDocument();
+      expect(
+        screen.getAllByText("Policy: policy_not_required").length,
+      ).toBeGreaterThan(0);
+      expect(screen.getAllByText("Request: approved").length).toBeGreaterThan(0);
+      expect(screen.getByText("Receipt: present")).toBeInTheDocument();
+      expect(screen.getByText("Reconciliation: matched")).toBeInTheDocument();
+      expect(screen.getAllByText("Request: rejected").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Approval: rejected").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Request: expired").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Execution: failed").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Fallback: fallback_required").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Receipt: missing_receipt").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Receipt: stale_receipt").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Receipt: mismatched_receipt").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Simulator: demo").length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText(/backend AegisOps records remain authoritative/i).length,
+      ).toBeGreaterThan(0);
+      expect(screen.queryByRole("button", { name: /execute/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /approve/i })).toBeNull();
+
+    });
+
+    it("keeps unavailable automation posture visible when no backend request record exists", async () => {
+      const fetchFn = createAuthorizedFetch(
+        {
+          "/inspect-records": {
+            read_only: true,
+            records: [],
+            total_records: 0,
+          },
+        },
+        {
+          identity: "approver@example.com",
+          provider: "authentik",
+          roles: ["Approver"],
+          subject: "operator-8",
+        },
+      );
+      const dependencies = createDefaultDependencies({ fetchFn });
+
+      renderOperatorRoute("/operator/automations", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Action Catalog" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getAllByText("Request: unavailable").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Receipt: unavailable").length).toBeGreaterThan(0);
+      expect(
+        screen.getAllByText(
+          "No backend-reviewed action request is currently visible for this catalog entry.",
+        ).length,
+      ).toBeGreaterThan(0);
+
+      const recordCall = fetchFn.mock.calls.find(([url]) =>
+        String(url).startsWith("/inspect-records"),
+      );
+      expect(recordCall).toBeDefined();
+      const parsedUrl = new URL(String(recordCall![0]), "http://operator-ui.local");
+      expect(parsedUrl.searchParams.get("family")).toBe("action_request");
+    });
+  });
+}

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe } from "vitest";
 import { resetOperatorQueryCacheForTests } from "./operatorQueryCache";
 import { registerOperatorRoutesActionReviewTests } from "./OperatorRoutes.actionReview.testSuite";
+import { registerOperatorRoutesActionCatalogTests } from "./OperatorRoutes.actionCatalog.testSuite";
 import { registerOperatorRoutesAssistantTests } from "./OperatorRoutes.assistant.testSuite";
 import { registerOperatorRoutesAuthAndShellTests } from "./OperatorRoutes.authAndShell.testSuite";
 import { registerOperatorRoutesBusinessHoursHandoffTests } from "./OperatorRoutes.businessHoursHandoff.testSuite";
@@ -18,6 +19,7 @@ describe("OperatorRoutes", () => {
   });
 
   registerOperatorRoutesAuthAndShellTests();
+  registerOperatorRoutesActionCatalogTests();
   registerOperatorRoutesActionReviewTests();
   registerOperatorRoutesCaseworkTests();
   registerOperatorRoutesAssistantTests();

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -76,6 +76,8 @@ function lazyOperatorConsolePage<T extends keyof Awaited<ReturnType<typeof loadO
 
 const ActionReviewPage =
   lazyOperatorConsolePage("ActionReviewPage") as unknown as typeof import("./operatorConsolePages").ActionReviewPage;
+const ActionCatalogPage =
+  lazyOperatorConsolePage("ActionCatalogPage") as unknown as typeof import("./operatorConsolePages").ActionCatalogPage;
 const AITraceReviewQueuePage =
   lazyOperatorConsolePage("AITraceReviewQueuePage") as unknown as typeof import("./operatorConsolePages").AITraceReviewQueuePage;
 const AssistantAdvisoryPage =
@@ -576,7 +578,7 @@ function OperatorShellContent({
           <Route
             element={
               canViewActionReview ? (
-                <ReadinessPage />
+                <ActionCatalogPage />
               ) : (
                 <Navigate
                   replace
@@ -633,10 +635,7 @@ function OperatorShellContent({
           <Route
             element={
               canViewActionReview ? (
-                <ActionReviewPage
-                  operatorIdentity={operatorIdentity}
-                  operatorRoles={operatorRoles}
-                />
+                <ActionCatalogPage />
               ) : (
                 <Navigate
                   replace

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -13,6 +13,7 @@ export {
 export { RecordSearchPage } from "./operatorConsolePages/recordSearchPages";
 export { DetectorActivationReviewPage } from "./operatorConsolePages/detectorActivationReviewPages";
 export { SourceHealthDashboardPage } from "./operatorConsolePages/sourceHealthDashboardPages";
+export { ActionCatalogPage } from "./operatorConsolePages/actionCatalogPages";
 export { ActionReviewPage } from "./operatorConsolePages/actionReviewPages";
 export {
   AITraceReviewQueuePage,

--- a/apps/operator-ui/src/app/operatorConsolePages/actionCatalogPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/actionCatalogPages.tsx
@@ -1,0 +1,335 @@
+import {
+  Alert,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { Link as ReactRouterLink } from "react-router-dom";
+import {
+  EmptyState,
+  ErrorState,
+  LoadingState,
+  PageFrame,
+  QueryStateNotice,
+  StatusStrip,
+  ValueList,
+  asRecord,
+  asString,
+  formatValue,
+  getPath,
+  statusTone,
+  useOperatorList,
+  type UnknownRecord,
+} from "./shared";
+
+const ACTION_CATALOG_FILTER = {};
+const ACTION_CATALOG_SORT = {
+  field: "requested_at",
+  order: "DESC",
+} as const;
+
+const REVIEWED_ACTION_CATALOG = [
+  {
+    catalogAction: "enrichment_only_lookup",
+    family: "Read",
+    policy: "policy_not_required",
+    receipt: "AegisOps execution receipt with lookup evidence reference",
+    reconciliation: "Subordinate lookup context only",
+  },
+  {
+    catalogAction: "operator_notification",
+    family: "Notify",
+    policy: "policy_not_required",
+    receipt: "AegisOps execution receipt with normalized delivery reference",
+    reconciliation: "Notification attempted, delivered, failed, or fallback-needed",
+  },
+  {
+    catalogAction: "manual_escalation_request",
+    family: "Notify",
+    policy: "human_required_for_protected_follow_up",
+    receipt: "AegisOps execution receipt with escalation owner and fallback flag",
+    reconciliation: "Manual escalation requested; no automatic approval or closure",
+  },
+  {
+    catalogAction: "create_tracking_ticket",
+    family: "Soft Write",
+    policy: "human_required",
+    receipt: "AegisOps execution receipt with non-authoritative ticket pointer",
+    reconciliation: "Ticket coordination context cannot become workflow truth",
+  },
+] as const;
+
+const ACTION_TYPE_ALIASES: Record<string, string> = {
+  notify_identity_owner: "operator_notification",
+};
+
+function recordCatalogAction(record: UnknownRecord): string | null {
+  const direct =
+    asString(record.catalog_action) ??
+    asString(getPath(record, "policy_basis.catalog_action")) ??
+    asString(getPath(record, "policy_evaluation.catalog_action")) ??
+    asString(getPath(record, "requested_payload.catalog_action")) ??
+    asString(record.action_type) ??
+    asString(getPath(record, "requested_payload.action_type"));
+
+  return direct ? (ACTION_TYPE_ALIASES[direct] ?? direct) : null;
+}
+
+function latestRecordByCatalogAction(records: UnknownRecord[] | null) {
+  const latest = new Map<string, UnknownRecord>();
+  for (const record of records ?? []) {
+    const catalogAction = recordCatalogAction(record);
+    if (catalogAction !== null && !latest.has(catalogAction)) {
+      latest.set(catalogAction, record);
+    }
+  }
+  return latest;
+}
+
+function policyPosture(record: UnknownRecord | null, fallback: string) {
+  return (
+    asString(record?.approval_requirement) ??
+    asString(getPath(record, "policy_evaluation.approval_requirement")) ??
+    asString(getPath(record, "policy_evaluation.approval_requirement_override")) ??
+    asString(getPath(record, "policy_basis.approval_requirement")) ??
+    fallback
+  );
+}
+
+function requestState(record: UnknownRecord | null) {
+  return (
+    asString(record?.action_request_state) ??
+    asString(record?.lifecycle_state) ??
+    "unavailable"
+  );
+}
+
+function approvalState(record: UnknownRecord | null) {
+  return (
+    asString(record?.approval_state) ??
+    asString(getPath(record, "approval.lifecycle_state")) ??
+    asString(record?.approval_decision_state) ??
+    (record ? "not_attached" : "unavailable")
+  );
+}
+
+function receiptState(record: UnknownRecord | null) {
+  if (record === null) {
+    return "unavailable";
+  }
+  return (
+    asString(record.receipt_state) ??
+    asString(record.action_execution_state) ??
+    asString(getPath(record, "shuffle_receipt.status")) ??
+    (asString(record.action_execution_id) ? "present" : "missing_receipt")
+  );
+}
+
+function reconciliationState(record: UnknownRecord | null) {
+  if (record === null) {
+    return "unavailable";
+  }
+  return (
+    asString(record.reconciliation_state) ??
+    asString(getPath(record, "reconciliation.lifecycle_state")) ??
+    (asString(record.reconciliation_id) ? "present" : "missing_reconciliation")
+  );
+}
+
+function fallbackState(record: UnknownRecord | null) {
+  if (record === null) {
+    return "unavailable";
+  }
+  return (
+    asString(record.fallback_state) ??
+    asString(record.manual_fallback_state) ??
+    asString(getPath(record, "fallback.fallback_state")) ??
+    "not_recorded"
+  );
+}
+
+function mismatchPosture(record: UnknownRecord | null) {
+  if (record === null) {
+    return "automation_unavailable";
+  }
+
+  const candidates = [
+    asString(record.mismatch_state),
+    asString(record.mismatch_posture),
+    asString(getPath(record, "mismatch_inspection.lifecycle_state")),
+    receiptState(record),
+    reconciliationState(record),
+    fallbackState(record),
+  ].filter((value): value is string => value !== null);
+  const degraded = candidates.find((value) =>
+    /(failed|failure|fallback|missing|mismatch|rejected|stale|unavailable)/i.test(value),
+  );
+
+  return degraded ?? "none";
+}
+
+function simulatorPosture(record: UnknownRecord | null) {
+  const simulator = asRecord(record?.simulator_output);
+  return (
+    asString(record?.demo_test_label) ??
+    asString(record?.simulation_mode) ??
+    asString(simulator?.demo_test_label) ??
+    asString(simulator?.production_exclusion) ??
+    "production_record_only"
+  );
+}
+
+function ActionCatalogEntryCard({
+  definition,
+  record,
+}: {
+  definition: (typeof REVIEWED_ACTION_CATALOG)[number];
+  record: UnknownRecord | null;
+}) {
+  const request = requestState(record);
+  const approval = approvalState(record);
+  const receipt = receiptState(record);
+  const reconciliation = reconciliationState(record);
+  const fallback = fallbackState(record);
+  const mismatch = mismatchPosture(record);
+  const simulator = simulatorPosture(record);
+  const actionRequestId = asString(record?.action_request_id);
+
+  return (
+    <Card elevation={0} sx={{ border: "1px solid", borderColor: "divider", height: "100%" }}>
+      <CardContent>
+        <Stack spacing={2}>
+          <Stack
+            alignItems={{ xs: "flex-start", sm: "center" }}
+            direction={{ xs: "column", sm: "row" }}
+            justifyContent="space-between"
+            spacing={1}
+          >
+            <Stack spacing={0.5}>
+              <Typography fontWeight={700}>{definition.catalogAction}</Typography>
+              <Typography color="text.secondary" variant="body2">
+                {definition.family}
+              </Typography>
+            </Stack>
+            <Chip
+              color={statusTone(request)}
+              label={request}
+              size="small"
+              variant={statusTone(request) === "default" ? "outlined" : "filled"}
+            />
+          </Stack>
+
+          <StatusStrip
+            values={[
+              ["Policy", policyPosture(record, definition.policy)],
+              ["Request", request],
+              ["Approval", approval],
+              ["Execution", asString(record?.action_execution_state)],
+              ["Receipt", receipt],
+              ["Reconciliation", reconciliation],
+              ["Fallback", fallback],
+              ["Mismatch", mismatch],
+              ["Simulator", simulator],
+            ]}
+          />
+
+          {record === null ? (
+            <Alert severity="warning" variant="outlined">
+              No backend-reviewed action request is currently visible for this catalog entry.
+            </Alert>
+          ) : null}
+          {mismatch !== "none" ? (
+            <Alert severity="warning" variant="outlined">
+              Failure, fallback, missing receipt, stale receipt, mismatched receipt, or unavailable automation posture remains review-visible and cannot be normalized into success by the UI.
+            </Alert>
+          ) : null}
+          {simulator !== "production_record_only" && simulator !== "production" ? (
+            <Alert severity="info" variant="outlined">
+              Simulator/demo output is subordinate context only; backend AegisOps records remain authoritative.
+            </Alert>
+          ) : null}
+
+          <ValueList
+            entries={[
+              ["Action request id", actionRequestId],
+              ["Reviewed receipt expectation", definition.receipt],
+              ["Reconciliation expectation", definition.reconciliation],
+              ["Requested at", asString(record?.requested_at)],
+              ["Expires at", asString(record?.expires_at)],
+              ["Execution surface", asString(record?.execution_surface_id)],
+              ["Action execution id", asString(record?.action_execution_id)],
+              ["Reconciliation id", asString(record?.reconciliation_id)],
+            ]}
+          />
+
+          {actionRequestId ? (
+            <Button
+              component={ReactRouterLink}
+              size="small"
+              to={`/operator/action-review/${actionRequestId}`}
+              variant="outlined"
+            >
+              Open action review
+            </Button>
+          ) : null}
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ActionCatalogPage() {
+  const actionRecords = useOperatorList(
+    "actionCatalog",
+    ACTION_CATALOG_FILTER,
+    ACTION_CATALOG_SORT,
+    null,
+  );
+  const latest = latestRecordByCatalogAction(actionRecords.data);
+
+  if (actionRecords.loading && actionRecords.data === null) {
+    return <LoadingState label="Loading action catalog" />;
+  }
+
+  return (
+    <PageFrame
+      subtitle="Reviewed Read, Notify, and Soft Write actions are visible here as a thin browser surface over AegisOps-owned request, approval, receipt, fallback, and reconciliation records."
+      title="Action Catalog"
+    >
+      {actionRecords.error && actionRecords.data === null ? (
+        <ErrorState error={actionRecords.error} />
+      ) : (
+        <Stack spacing={2}>
+          <QueryStateNotice
+            error={actionRecords.error}
+            refreshing={actionRecords.refreshing}
+          />
+          <Alert severity="info" variant="outlined">
+            UI cache, browser state, simulator output, downstream ticket state, and automation substrate status are subordinate context only; backend AegisOps records remain authoritative.
+          </Alert>
+          {actionRecords.data && actionRecords.data.length === 0 ? (
+            <EmptyState message="No action requests are currently visible; the reviewed catalog remains bounded to default Phase 62 actions." />
+          ) : null}
+          <Grid container spacing={2}>
+            {REVIEWED_ACTION_CATALOG.map((definition) => (
+              <Grid key={definition.catalogAction} size={{ xs: 12, lg: 6 }}>
+                <ActionCatalogEntryCard
+                  definition={definition}
+                  record={latest.get(definition.catalogAction) ?? null}
+                />
+              </Grid>
+            ))}
+          </Grid>
+          <Typography color="text.secondary" variant="body2">
+            Controlled Write and Hard Write actions are not default requestable controls in this reviewed catalog.
+            Current visible records: {formatValue(actionRecords.data?.length ?? 0)}.
+          </Typography>
+        </Stack>
+      )}
+    </PageFrame>
+  );
+}

--- a/apps/operator-ui/src/dataProvider.test.ts
+++ b/apps/operator-ui/src/dataProvider.test.ts
@@ -416,6 +416,49 @@ describe("createOperatorDataProvider", () => {
     );
   });
 
+  it("lists action catalog posture from backend action-request records", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        records: [
+          {
+            action_request_id: "action-request-catalog-001",
+            catalog_action: "operator_notification",
+            lifecycle_state: "approved",
+          },
+        ],
+        total_records: 1,
+      }),
+    );
+    const dataProvider = createOperatorDataProvider({ fetchFn });
+
+    await expect(
+      dataProvider.getList("actionCatalog", {
+        filter: {},
+        pagination: { page: 1, perPage: 25 },
+        sort: { field: "requested_at", order: "DESC" },
+      }),
+    ).resolves.toEqual({
+      data: [
+        expect.objectContaining({
+          id: "action-request-catalog-001",
+          action_request_id: "action-request-catalog-001",
+          catalog_action: "operator_notification",
+        }),
+      ],
+      total: 1,
+    });
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "/inspect-records?family=action_request&order=DESC&page=1&per_page=25&sort=requested_at",
+      {
+        credentials: "include",
+        headers: {
+          Accept: "application/json",
+        },
+      },
+    );
+  });
+
   it("rejects action-review detail payloads whose selected review is missing or mismatched", async () => {
     const missingSelectedReviewId = createOperatorDataProvider({
       fetchFn: vi.fn<typeof fetch>().mockResolvedValue(

--- a/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
+++ b/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
@@ -16,6 +16,12 @@ export const RESOURCE_BINDINGS: Record<
     listSemantics: "client",
     recordFamily: "alert",
   },
+  actionCatalog: {
+    idField: "action_request_id",
+    listPath: "/inspect-records",
+    listSemantics: "client",
+    recordFamily: "action_request",
+  },
   aiTraceReviewQueue: {
     idField: "ai_trace_id",
     listPath: "/inspect-ai-trace-review-queue",

--- a/apps/operator-ui/src/operatorDataProvider/types.ts
+++ b/apps/operator-ui/src/operatorDataProvider/types.ts
@@ -14,6 +14,7 @@ export type OperatorResourceName =
   | "todayView"
   | "businessHoursHandoff"
   | "advisoryOutput"
+  | "actionCatalog"
   | "actionReview";
 
 export interface OperatorDataProviderConfig {


### PR DESCRIPTION
## Summary
- Add a reviewed Phase 62 action catalog page for Read, Notify, and Soft Write actions.
- Route `/operator/actions` and `/operator/automations` to the catalog while keeping action-review detail on existing reviewed routes.
- Add action catalog data-provider mapping over backend `action_request` records and focused UI/provider coverage for normal, rejected, expired, failed, fallback, missing/stale/mismatched receipt, demo, and unavailable postures.

## Verification
- `npm test -- --run src/app/OperatorRoutes.test.tsx src/dataProvider.test.ts`
- `npm run typecheck`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node <codex-supervisor-root>/dist/index.js issue-lint 1321 --config <supervisor-config-path>`

Closes #1321