### PR TITLE
63.6: Add evidence pack UI in case detail

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -198,6 +198,7 @@ describe("case detail evidence pack UI", () => {
     ["hidden conflict label", createEvidencePack({ conflict_state: "" })],
     ["unsupported conflict label", createEvidencePack({ conflict_state: "ready_to_close" })],
     ["unsupported consumer", createEvidencePack({ consumer: "workflow_gate" })],
+    ["AI grounding consumer", createEvidencePack({ consumer: "ai_grounding" })],
     ["unsupported source", createEvidencePackWithSource("workflow_gate")],
     [
       "unsupported degraded reason",
@@ -237,6 +238,45 @@ describe("case detail evidence pack UI", () => {
         provenance: {
           ...createEvidencePack().provenance,
           target_binding: "c".repeat(64),
+        },
+      }),
+    ],
+    [
+      "invalid reviewed file hash",
+      createEvidencePack({
+        custody: {
+          ...createEvidencePack().custody,
+          reviewed_file_hash: "not-a-hash",
+        },
+        provenance: {
+          ...createEvidencePack().provenance,
+          target_binding: "not-a-hash",
+        },
+      }),
+    ],
+    [
+      "invalid response digest",
+      createEvidencePack({
+        custody: {
+          ...createEvidencePack().custody,
+          response_digest: "not-a-digest",
+        },
+        provenance: {
+          ...createEvidencePack().provenance,
+          response_digest: "not-a-digest",
+        },
+      }),
+    ],
+    [
+      "non-aware collection timestamp",
+      createEvidencePack({
+        custody: {
+          ...createEvidencePack().custody,
+          collection_timestamp: "2026-05-30T00:00:00",
+        },
+        provenance: {
+          ...createEvidencePack().provenance,
+          collection_timestamp: "2026-05-30T00:00:00",
         },
       }),
     ],

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -213,6 +213,39 @@ describe("case detail evidence pack UI", () => {
     );
   }, fullRouteTestTimeout);
 
+  it("renders supported non-SHA256 reviewed hash bindings", async () => {
+    const md5Hash = "c".repeat(32);
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({
+        "/inspect-case-detail": createCaseDetailPayload({
+          linked_evidence_packs: [
+            createEvidencePack({
+              custody: {
+                ...createEvidencePack().custody,
+                reviewed_file_hash: md5Hash,
+              },
+              provenance: {
+                ...createEvidencePack().provenance,
+                target_binding: md5Hash,
+              },
+            }),
+          ],
+        }),
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/cases/case-456"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole("table", { name: "Linked evidence packs" }, fullRouteWait),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Reviewed operator data could not be verified.")).not.toBeInTheDocument();
+  }, fullRouteTestTimeout);
+
   it("keeps empty and degraded evidence-pack states explicit", async () => {
     const dependencies = createDefaultDependencies({
       fetchFn: createAuthorizedFetch({

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -77,6 +77,23 @@ function createEvidencePackWithSource(sourceId: string) {
   };
 }
 
+function createUnavailableEvidencePack() {
+  return createEvidencePack({
+    confidence: {
+      ...createEvidencePack().confidence,
+      ambiguity_badge: "related-entity",
+      freshness: "fresh",
+    },
+    conflict_state: "none",
+    degraded_reasons: [],
+    freshness_state: "fresh",
+    source_state: "unavailable",
+    status: "unavailable",
+    uncertainty_label: "source_unavailable",
+    unavailable_reasons: ["source_unavailable"],
+  });
+}
+
 function createCaseDetailPayload(overrides: Record<string, unknown> = {}) {
   return {
     case_id: "case-456",
@@ -147,6 +164,11 @@ describe("case detail evidence pack UI", () => {
       within(rows[0] as HTMLElement).getByText("conflicting"),
     ).toBeInTheDocument();
     expect(
+      within(rows[0] as HTMLElement)
+        .getByText("conflicting")
+        .closest(".MuiChip-root"),
+    ).toHaveClass("MuiChip-colorWarning");
+    expect(
       within(rows[0] as HTMLElement).getByText("present"),
     ).toBeInTheDocument();
     expect(
@@ -164,6 +186,31 @@ describe("case detail evidence pack UI", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("Evidence pack can close case")).not.toBeInTheDocument();
     expect(screen.queryByText("Evidence pack proves RC readiness")).not.toBeInTheDocument();
+  }, fullRouteTestTimeout);
+
+  it("flags unavailable evidence sources as an error state", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({
+        "/inspect-case-detail": createCaseDetailPayload({
+          linked_evidence_packs: [createUnavailableEvidencePack()],
+        }),
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/cases/case-456"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    const evidencePackTable = await screen.findByRole("table", {
+      name: "Linked evidence packs",
+    }, fullRouteWait);
+    const row = within(evidencePackTable).getAllByRole("row")[1] as HTMLElement;
+
+    expect(within(row).getByText("unavailable").closest(".MuiChip-root")).toHaveClass(
+      "MuiChip-colorError",
+    );
   }, fullRouteTestTimeout);
 
   it("keeps empty and degraded evidence-pack states explicit", async () => {

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -64,6 +64,17 @@ function createEvidencePack(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createEvidencePackWithSource(sourceId: string) {
+  const pack = createEvidencePack({ source_id: sourceId });
+  return {
+    ...pack,
+    provenance: {
+      ...pack.provenance,
+      source_id: sourceId,
+    },
+  };
+}
+
 function createCaseDetailPayload(overrides: Record<string, unknown> = {}) {
   return {
     case_id: "case-456",
@@ -181,9 +192,47 @@ describe("case detail evidence pack UI", () => {
     ["UI-cache source", createEvidencePack({ cache_sourced: true })],
     ["browser-state source", createEvidencePack({ projection_source: "browser_state" })],
     ["hidden stale label", createEvidencePack({ freshness_state: "" })],
+    ["unsupported stale label", createEvidencePack({ freshness_state: "rc_ready" })],
     ["hidden conflict label", createEvidencePack({ conflict_state: "" })],
+    ["unsupported conflict label", createEvidencePack({ conflict_state: "ready_to_close" })],
+    ["unsupported consumer", createEvidencePack({ consumer: "workflow_gate" })],
+    ["unsupported source", createEvidencePackWithSource("workflow_gate")],
+    [
+      "unsupported degraded reason",
+      createEvidencePack({ degraded_reasons: ["case_truth"] }),
+    ],
+    [
+      "unsupported unavailable reason",
+      createEvidencePack({ unavailable_reasons: ["approval_truth"] }),
+    ],
     ["missing custody display", createEvidencePack({ custody: null })],
+    [
+      "incomplete custody display",
+      createEvidencePack({
+        custody: {
+          aegisops_evidence_record_id: "evidence-enrichment-001",
+        },
+      }),
+    ],
     ["missing provenance display", createEvidencePack({ provenance: null })],
+    [
+      "incomplete provenance display",
+      createEvidencePack({
+        provenance: {
+          request_binding: "evidence-request-001",
+          case_binding: "case-456",
+          source_id: "malwarebazaar_hash_reputation",
+        },
+      }),
+    ],
+    [
+      "incomplete confidence display",
+      createEvidencePack({
+        confidence: {
+          source_native_score_authority: "none",
+        },
+      }),
+    ],
     ["evidence truth", createEvidencePack({ authoritative_workflow_truth: true })],
     [
       "authoritative posture",

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -360,6 +360,51 @@ describe("case detail evidence pack UI", () => {
         },
       }),
     ],
+    [
+      "invalid calendar collection timestamp",
+      createEvidencePack({
+        custody: {
+          ...createEvidencePack().custody,
+          collection_timestamp: "2026-02-30T00:00:00Z",
+        },
+        provenance: {
+          ...createEvidencePack().provenance,
+          collection_timestamp: "2026-02-30T00:00:00Z",
+        },
+      }),
+    ],
+    [
+      "enabled source stale reason",
+      createEvidencePack({
+        confidence: {
+          ...createEvidencePack().confidence,
+          ambiguity_badge: "related-entity",
+          freshness: "fresh",
+        },
+        conflict_state: "none",
+        degraded_reasons: ["source_stale"],
+        freshness_state: "fresh",
+        source_state: "degraded",
+        uncertainty_label: "stale_review_required",
+      }),
+    ],
+    [
+      "enabled source denied reason",
+      createEvidencePack({
+        confidence: {
+          ...createEvidencePack().confidence,
+          ambiguity_badge: "related-entity",
+          freshness: "fresh",
+        },
+        conflict_state: "none",
+        degraded_reasons: [],
+        freshness_state: "fresh",
+        source_state: "unavailable",
+        status: "unavailable",
+        uncertainty_label: "source_unavailable",
+        unavailable_reasons: ["source_denied"],
+      }),
+    ],
     ["missing custody display", createEvidencePack({ custody: null })],
     [
       "incomplete custody display",

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -10,21 +10,55 @@ import {
 } from "./OperatorRoutes.testSupport";
 
 function createEvidencePack(overrides: Record<string, unknown> = {}) {
+  const caseId = typeof overrides.case_id === "string" ? overrides.case_id : "case-456";
+  const evidenceRequestId =
+    typeof overrides.evidence_request_id === "string"
+      ? overrides.evidence_request_id
+      : "evidence-request-001";
+  const sourceId =
+    typeof overrides.source_id === "string"
+      ? overrides.source_id
+      : "malwarebazaar_hash_reputation";
+
   return {
     authoritative_workflow_truth: false,
-    case_id: "case-456",
-    confidence_state: "related_entity_not_authoritative",
-    conflict_state: "unresolved_conflict",
-    custody_reference: "custody://case-456/evidence-pack-001",
+    case_id: caseId,
+    confidence: {
+      ambiguity_badge: "related-entity",
+      freshness: "stale",
+      posture: "subordinate",
+      source_native_score_authority: "none",
+    },
+    confidence_state: "present",
+    conflict_state: "conflicting",
+    consumer: "case_workbench",
+    custody: {
+      aegisops_evidence_record_id: "evidence-enrichment-001",
+      collection_timestamp: "2026-05-30T00:00:00+00:00",
+      enrichment_request_id: "enrichment-request-001",
+      response_digest: "sha256:" + "a".repeat(64),
+      reviewed_file_hash: "b".repeat(64),
+    },
     custody_state: "complete",
-    evidence_pack_id: "evidence-pack-001",
-    freshness_state: "stale_review_required",
-    operator_visible: true,
-    provenance_reference: "provenance://case-456/enrichment-001",
+    evidence_request_id: evidenceRequestId,
+    freshness_state: "stale",
+    provenance: {
+      authority_posture: "subordinate_evidence_context_only",
+      case_binding: caseId,
+      collection_timestamp: "2026-05-30T00:00:00+00:00",
+      custody_reference: "custody-ref-enrichment-001",
+      enrichment_request_id: "enrichment-request-001",
+      request_binding: evidenceRequestId,
+      response_digest: "sha256:" + "a".repeat(64),
+      source_id: sourceId,
+      target_binding: "b".repeat(64),
+    },
     provenance_state: "bound",
-    source_id: "malwarebazaar_hash_reputation",
+    source_id: sourceId,
     source_state: "degraded",
-    uncertainty_label: "review_required",
+    status: "degraded",
+    uncertainty_label: "stale_review_required",
+    authority_posture: "subordinate_evidence_context_only",
     workflow_authority: "none",
     ...overrides,
   };
@@ -88,29 +122,29 @@ describe("case detail evidence pack UI", () => {
 
     expect(rows).toHaveLength(1);
     expect(
-      within(rows[0] as HTMLElement).getByText("evidence-pack-001"),
+      within(rows[0] as HTMLElement).getByText("evidence-request-001"),
     ).toBeInTheDocument();
     expect(
       within(rows[0] as HTMLElement).getByText("malwarebazaar_hash_reputation"),
     ).toBeInTheDocument();
     expect(
+      within(rows[0] as HTMLElement).getByText("stale"),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[0] as HTMLElement).getByText("conflicting"),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[0] as HTMLElement).getByText("present"),
+    ).toBeInTheDocument();
+    expect(
       within(rows[0] as HTMLElement).getByText("stale_review_required"),
-    ).toBeInTheDocument();
-    expect(
-      within(rows[0] as HTMLElement).getByText("unresolved_conflict"),
-    ).toBeInTheDocument();
-    expect(
-      within(rows[0] as HTMLElement).getByText("related_entity_not_authoritative"),
-    ).toBeInTheDocument();
-    expect(
-      within(rows[0] as HTMLElement).getByText("review_required"),
     ).toBeInTheDocument();
     expect(within(rows[0] as HTMLElement).getByText("degraded")).toBeInTheDocument();
     expect(
-      within(rows[0] as HTMLElement).getByText("custody://case-456/evidence-pack-001"),
+      within(rows[0] as HTMLElement).getByText("evidence-enrichment-001"),
     ).toBeInTheDocument();
     expect(
-      within(rows[0] as HTMLElement).getByText("provenance://case-456/enrichment-001"),
+      within(rows[0] as HTMLElement).getByText("custody-ref-enrichment-001"),
     ).toBeInTheDocument();
     expect(
       within(rows[0] as HTMLElement).getByText("Subordinate evidence context only"),
@@ -148,8 +182,8 @@ describe("case detail evidence pack UI", () => {
     ["browser-state source", createEvidencePack({ projection_source: "browser_state" })],
     ["hidden stale label", createEvidencePack({ freshness_state: "" })],
     ["hidden conflict label", createEvidencePack({ conflict_state: "" })],
-    ["missing custody display", createEvidencePack({ custody_reference: null })],
-    ["missing provenance display", createEvidencePack({ provenance_reference: null })],
+    ["missing custody display", createEvidencePack({ custody: null })],
+    ["missing provenance display", createEvidencePack({ provenance: null })],
     ["evidence truth", createEvidencePack({ authoritative_workflow_truth: true })],
     ["workflow authority", createEvidencePack({ workflow_authority: "close_case" })],
     ["RC readiness claim", createEvidencePack({ release_readiness_claim: "rc_ready" })],
@@ -236,7 +270,7 @@ describe("case detail evidence pack UI", () => {
                 ? [createEvidencePack()]
                 : [
                     createEvidencePack({
-                      evidence_pack_id: "evidence-pack-reread",
+                      evidence_request_id: "evidence-request-reread",
                       freshness_state: "fresh",
                     }),
                   ],
@@ -266,7 +300,7 @@ describe("case detail evidence pack UI", () => {
     );
 
     expect(
-      await screen.findByText("evidence-pack-001", undefined, fullRouteWait),
+      await screen.findByText("evidence-request-001", undefined, fullRouteWait),
     ).toBeInTheDocument();
     const user = userEvent.setup();
     await user.type(
@@ -292,7 +326,7 @@ describe("case detail evidence pack UI", () => {
     await user.click(screen.getByRole("button", { name: "Record observation" }));
 
     expect(
-      await screen.findByText("evidence-pack-reread", undefined, fullRouteWait),
+      await screen.findByText("evidence-request-reread", undefined, fullRouteWait),
     ).toBeInTheDocument();
     expect(screen.queryByText("stale-evidence")).not.toBeInTheDocument();
   }, fullRouteTestTimeout);

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -9,6 +9,11 @@ import {
   jsonResponse,
 } from "./OperatorRoutes.testSupport";
 
+const freshCollectionTimestamp = new Date().toISOString();
+const staleCollectionTimestamp = new Date(
+  Date.now() - 7 * 60 * 60 * 1000,
+).toISOString();
+
 function createEvidencePack(overrides: Record<string, unknown> = {}) {
   const caseId = typeof overrides.case_id === "string" ? overrides.case_id : "case-456";
   const evidenceRequestId =
@@ -19,6 +24,10 @@ function createEvidencePack(overrides: Record<string, unknown> = {}) {
     typeof overrides.source_id === "string"
       ? overrides.source_id
       : "malwarebazaar_hash_reputation";
+  const collectionTimestamp =
+    overrides.freshness_state === "fresh"
+      ? freshCollectionTimestamp
+      : staleCollectionTimestamp;
 
   return {
     authoritative_workflow_truth: false,
@@ -34,7 +43,7 @@ function createEvidencePack(overrides: Record<string, unknown> = {}) {
     consumer: "case_workbench",
     custody: {
       aegisops_evidence_record_id: "evidence-enrichment-001",
-      collection_timestamp: "2026-05-30T00:00:00+00:00",
+      collection_timestamp: collectionTimestamp,
       enrichment_request_id: "enrichment-request-001",
       response_digest: "sha256:" + "a".repeat(64),
       reviewed_file_hash: "b".repeat(64),
@@ -46,7 +55,7 @@ function createEvidencePack(overrides: Record<string, unknown> = {}) {
     provenance: {
       authority_posture: "subordinate_evidence_context_only",
       case_binding: caseId,
-      collection_timestamp: "2026-05-30T00:00:00+00:00",
+      collection_timestamp: collectionTimestamp,
       custody_reference: "custody-ref-enrichment-001",
       enrichment_request_id: "enrichment-request-001",
       request_binding: evidenceRequestId,
@@ -289,6 +298,19 @@ describe("case detail evidence pack UI", () => {
       createEvidencePack({ unavailable_reasons: ["approval_truth"] }),
     ],
     [
+      "stale pack inside source freshness window",
+      createEvidencePack({
+        custody: {
+          ...createEvidencePack().custody,
+          collection_timestamp: freshCollectionTimestamp,
+        },
+        provenance: {
+          ...createEvidencePack().provenance,
+          collection_timestamp: freshCollectionTimestamp,
+        },
+      }),
+    ],
+    [
       "available status with degraded reason",
       createEvidencePack({ status: "available" }),
     ],
@@ -451,6 +473,15 @@ describe("case detail evidence pack UI", () => {
         },
       }),
     ],
+    [
+      "unexpected confidence posture",
+      createEvidencePack({
+        confidence: {
+          ...createEvidencePack().confidence,
+          posture: "authoritative_aegisops_record",
+        },
+      }),
+    ],
     ["evidence truth", createEvidencePack({ authoritative_workflow_truth: true })],
     [
       "authoritative posture",
@@ -458,6 +489,7 @@ describe("case detail evidence pack UI", () => {
     ],
     ["workflow authority", createEvidencePack({ workflow_authority: "close_case" })],
     ["RC readiness claim", createEvidencePack({ release_readiness_claim: "rc_ready" })],
+    ["unexpected evidence-pack field", createEvidencePack({ workflow_truth: true })],
     ["role bypass", createEvidencePack({ operator_visible: false })],
   ])("fails closed on %s", async (_label, evidencePack) => {
     const dependencies = createDefaultDependencies({

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -60,6 +60,9 @@ function createCaseDetailPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
+const fullRouteWait = { timeout: 10_000 };
+const fullRouteTestTimeout = 15_000;
+
 describe("case detail evidence pack UI", () => {
   beforeEach(() => {
     resetOperatorQueryCacheForTests();
@@ -80,7 +83,7 @@ describe("case detail evidence pack UI", () => {
 
     const evidencePackTable = await screen.findByRole("table", {
       name: "Linked evidence packs",
-    });
+    }, fullRouteWait);
     const rows = within(evidencePackTable).getAllByRole("row").slice(1);
 
     expect(rows).toHaveLength(1);
@@ -114,7 +117,7 @@ describe("case detail evidence pack UI", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("Evidence pack can close case")).not.toBeInTheDocument();
     expect(screen.queryByText("Evidence pack proves RC readiness")).not.toBeInTheDocument();
-  });
+  }, fullRouteTestTimeout);
 
   it("keeps empty and degraded evidence-pack states explicit", async () => {
     const dependencies = createDefaultDependencies({
@@ -132,9 +135,13 @@ describe("case detail evidence pack UI", () => {
     );
 
     expect(
-      await screen.findByText("No linked evidence packs were returned for this case."),
+      await screen.findByText(
+        "No linked evidence packs were returned for this case.",
+        undefined,
+        fullRouteWait,
+      ),
     ).toBeInTheDocument();
-  });
+  }, fullRouteTestTimeout);
 
   it.each([
     ["UI-cache source", createEvidencePack({ cache_sourced: true })],
@@ -162,13 +169,16 @@ describe("case detail evidence pack UI", () => {
       </MemoryRouter>,
     );
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          "Reviewed operator data could not be verified. The browser stayed fail-closed instead of rendering an untrusted record.",
-        ),
-      ).toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText(
+            "Reviewed operator data could not be verified. The browser stayed fail-closed instead of rendering an untrusted record.",
+          ),
+        ).toBeInTheDocument();
+      },
+      fullRouteWait,
+    );
     expect(
       screen.queryByRole("table", { name: "Linked evidence packs" }),
     ).not.toBeInTheDocument();
@@ -196,12 +206,12 @@ describe("case detail evidence pack UI", () => {
     );
 
     expect(
-      await screen.findByRole("heading", { name: "Access denied" }),
+      await screen.findByRole("heading", { name: "Access denied" }, fullRouteWait),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("table", { name: "Linked evidence packs" }),
     ).not.toBeInTheDocument();
-  });
+  }, fullRouteTestTimeout);
 
   it("rereads backend case detail after case writes instead of treating edited evidence ids as evidence-pack truth", async () => {
     let caseDetailRequests = 0;
@@ -255,10 +265,12 @@ describe("case detail evidence pack UI", () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText("evidence-pack-001")).toBeInTheDocument();
+    expect(
+      await screen.findByText("evidence-pack-001", undefined, fullRouteWait),
+    ).toBeInTheDocument();
     const user = userEvent.setup();
     await user.type(
-      await screen.findByRole("textbox", { name: "Observed at" }),
+      await screen.findByRole("textbox", { name: "Observed at" }, fullRouteWait),
       "2026-05-30T12:00:00Z",
     );
     await user.type(
@@ -279,7 +291,9 @@ describe("case detail evidence pack UI", () => {
     );
     await user.click(screen.getByRole("button", { name: "Record observation" }));
 
-    expect(await screen.findByText("evidence-pack-reread")).toBeInTheDocument();
+    expect(
+      await screen.findByText("evidence-pack-reread", undefined, fullRouteWait),
+    ).toBeInTheDocument();
     expect(screen.queryByText("stale-evidence")).not.toBeInTheDocument();
-  });
+  }, fullRouteTestTimeout);
 });

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -115,7 +115,14 @@ function createCaseDetailPayload(overrides: Record<string, unknown> = {}) {
     linked_alert_records: [],
     linked_evidence_ids: ["evidence-123"],
     linked_evidence_packs: [createEvidencePack()],
-    linked_evidence_records: [],
+    linked_evidence_records: [
+      {
+        evidence_id: "evidence-enrichment-001",
+        provenance: {
+          custody_reference: "custody-ref-enrichment-001",
+        },
+      },
+    ],
     linked_lead_ids: [],
     linked_observation_ids: [],
     linked_recommendation_ids: [],
@@ -298,6 +305,14 @@ describe("case detail evidence pack UI", () => {
       createEvidencePack({ unavailable_reasons: ["approval_truth"] }),
     ],
     [
+      "missing degraded reason array",
+      createEvidencePack({ degraded_reasons: undefined }),
+    ],
+    [
+      "null unavailable reason array",
+      createEvidencePack({ unavailable_reasons: null }),
+    ],
+    [
       "stale pack inside source freshness window",
       createEvidencePack({
         custody: {
@@ -340,6 +355,15 @@ describe("case detail evidence pack UI", () => {
         provenance: {
           ...createEvidencePack().provenance,
           target_binding: "c".repeat(64),
+        },
+      }),
+    ],
+    [
+      "provenance custody reference mismatch",
+      createEvidencePack({
+        provenance: {
+          ...createEvidencePack().provenance,
+          custody_reference: "custody-ref-tampered",
         },
       }),
     ],

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -24,9 +24,9 @@ function createEvidencePack(overrides: Record<string, unknown> = {}) {
     authoritative_workflow_truth: false,
     case_id: caseId,
     confidence: {
-      ambiguity_badge: "related-entity",
+      ambiguity_badge: "unresolved",
       freshness: "stale",
-      posture: "subordinate",
+      posture: "external_hash_reputation_subordinate_context",
       source_native_score_authority: "none",
     },
     confidence_state: "present",
@@ -40,6 +40,7 @@ function createEvidencePack(overrides: Record<string, unknown> = {}) {
       reviewed_file_hash: "b".repeat(64),
     },
     custody_state: "complete",
+    degraded_reasons: ["stale_reputation", "conflicting_enrichment"],
     evidence_request_id: evidenceRequestId,
     freshness_state: "stale",
     provenance: {
@@ -55,9 +56,10 @@ function createEvidencePack(overrides: Record<string, unknown> = {}) {
     },
     provenance_state: "bound",
     source_id: sourceId,
-    source_state: "degraded",
+    source_state: "available",
     status: "degraded",
-    uncertainty_label: "stale_review_required",
+    uncertainty_label: "unresolved_conflict",
+    unavailable_reasons: [],
     authority_posture: "subordinate_evidence_context_only",
     workflow_authority: "none",
     ...overrides,
@@ -148,9 +150,9 @@ describe("case detail evidence pack UI", () => {
       within(rows[0] as HTMLElement).getByText("present"),
     ).toBeInTheDocument();
     expect(
-      within(rows[0] as HTMLElement).getByText("stale_review_required"),
+      within(rows[0] as HTMLElement).getByText("unresolved_conflict"),
     ).toBeInTheDocument();
-    expect(within(rows[0] as HTMLElement).getByText("degraded")).toBeInTheDocument();
+    expect(within(rows[0] as HTMLElement).getByText("available")).toBeInTheDocument();
     expect(
       within(rows[0] as HTMLElement).getByText("evidence-enrichment-001"),
     ).toBeInTheDocument();
@@ -204,6 +206,39 @@ describe("case detail evidence pack UI", () => {
     [
       "unsupported unavailable reason",
       createEvidencePack({ unavailable_reasons: ["approval_truth"] }),
+    ],
+    [
+      "available status with degraded reason",
+      createEvidencePack({ status: "available" }),
+    ],
+    [
+      "degraded status without degraded reason",
+      createEvidencePack({
+        degraded_reasons: [],
+        conflict_state: "none",
+        freshness_state: "fresh",
+        uncertainty_label: "related_entity_not_authoritative",
+        confidence: {
+          ...createEvidencePack().confidence,
+          ambiguity_badge: "related-entity",
+          freshness: "fresh",
+        },
+      }),
+    ],
+    [
+      "stale state without stale reason",
+      createEvidencePack({
+        degraded_reasons: ["conflicting_enrichment"],
+      }),
+    ],
+    [
+      "provenance target mismatch",
+      createEvidencePack({
+        provenance: {
+          ...createEvidencePack().provenance,
+          target_binding: "c".repeat(64),
+        },
+      }),
     ],
     ["missing custody display", createEvidencePack({ custody: null })],
     [
@@ -342,7 +377,16 @@ describe("case detail evidence pack UI", () => {
                 : [
                     createEvidencePack({
                       evidence_request_id: "evidence-request-reread",
+                      status: "available",
+                      degraded_reasons: [],
                       freshness_state: "fresh",
+                      conflict_state: "none",
+                      uncertainty_label: "related_entity_not_authoritative",
+                      confidence: {
+                        ...createEvidencePack().confidence,
+                        ambiguity_badge: "related-entity",
+                        freshness: "fresh",
+                      },
                     }),
                   ],
           }),

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -233,6 +233,24 @@ describe("case detail evidence pack UI", () => {
         },
       }),
     ],
+    [
+      "nested provenance authority",
+      createEvidencePack({
+        provenance: {
+          ...createEvidencePack().provenance,
+          authority_posture: "authoritative_aegisops_record",
+        },
+      }),
+    ],
+    [
+      "nested confidence authority",
+      createEvidencePack({
+        confidence: {
+          ...createEvidencePack().confidence,
+          source_native_score_authority: "workflow_truth",
+        },
+      }),
+    ],
     ["evidence truth", createEvidencePack({ authoritative_workflow_truth: true })],
     [
       "authoritative posture",

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -185,6 +185,10 @@ describe("case detail evidence pack UI", () => {
     ["missing custody display", createEvidencePack({ custody: null })],
     ["missing provenance display", createEvidencePack({ provenance: null })],
     ["evidence truth", createEvidencePack({ authoritative_workflow_truth: true })],
+    [
+      "authoritative posture",
+      createEvidencePack({ authority_posture: "authoritative_aegisops_record" }),
+    ],
     ["workflow authority", createEvidencePack({ workflow_authority: "close_case" })],
     ["RC readiness claim", createEvidencePack({ release_readiness_claim: "rc_ready" })],
     ["role bypass", createEvidencePack({ operator_visible: false })],

--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -1,0 +1,285 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { createDefaultDependencies, OperatorRoutes } from "./OperatorRoutes";
+import { resetOperatorQueryCacheForTests } from "./operatorQueryCache";
+import {
+  createAuthorizedFetch,
+  jsonResponse,
+} from "./OperatorRoutes.testSupport";
+
+function createEvidencePack(overrides: Record<string, unknown> = {}) {
+  return {
+    authoritative_workflow_truth: false,
+    case_id: "case-456",
+    confidence_state: "related_entity_not_authoritative",
+    conflict_state: "unresolved_conflict",
+    custody_reference: "custody://case-456/evidence-pack-001",
+    custody_state: "complete",
+    evidence_pack_id: "evidence-pack-001",
+    freshness_state: "stale_review_required",
+    operator_visible: true,
+    provenance_reference: "provenance://case-456/enrichment-001",
+    provenance_state: "bound",
+    source_id: "malwarebazaar_hash_reputation",
+    source_state: "degraded",
+    uncertainty_label: "review_required",
+    workflow_authority: "none",
+    ...overrides,
+  };
+}
+
+function createCaseDetailPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    case_id: "case-456",
+    case_record: {
+      case_id: "case-456",
+      lifecycle_state: "pending_action",
+    },
+    cross_source_timeline: [],
+    linked_alert_ids: ["alert-123"],
+    linked_alert_records: [],
+    linked_evidence_ids: ["evidence-123"],
+    linked_evidence_packs: [createEvidencePack()],
+    linked_evidence_records: [],
+    linked_lead_ids: [],
+    linked_observation_ids: [],
+    linked_recommendation_ids: [],
+    linked_reconciliation_ids: [],
+    linked_reconciliation_records: [],
+    provenance_summary: {
+      authoritative_anchor: {
+        provenance_classification: "authoritative",
+        record_family: "case",
+        record_id: "case-456",
+        source_family: "aegisops",
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("case detail evidence pack UI", () => {
+  beforeEach(() => {
+    resetOperatorQueryCacheForTests();
+  });
+
+  it("renders linked evidence pack custody, provenance, stale/conflict, freshness, confidence, uncertainty, and source state as subordinate context", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({
+        "/inspect-case-detail": createCaseDetailPayload(),
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/cases/case-456"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    const evidencePackTable = await screen.findByRole("table", {
+      name: "Linked evidence packs",
+    });
+    const rows = within(evidencePackTable).getAllByRole("row").slice(1);
+
+    expect(rows).toHaveLength(1);
+    expect(
+      within(rows[0] as HTMLElement).getByText("evidence-pack-001"),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[0] as HTMLElement).getByText("malwarebazaar_hash_reputation"),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[0] as HTMLElement).getByText("stale_review_required"),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[0] as HTMLElement).getByText("unresolved_conflict"),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[0] as HTMLElement).getByText("related_entity_not_authoritative"),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[0] as HTMLElement).getByText("review_required"),
+    ).toBeInTheDocument();
+    expect(within(rows[0] as HTMLElement).getByText("degraded")).toBeInTheDocument();
+    expect(
+      within(rows[0] as HTMLElement).getByText("custody://case-456/evidence-pack-001"),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[0] as HTMLElement).getByText("provenance://case-456/enrichment-001"),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[0] as HTMLElement).getByText("Subordinate evidence context only"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Evidence pack can close case")).not.toBeInTheDocument();
+    expect(screen.queryByText("Evidence pack proves RC readiness")).not.toBeInTheDocument();
+  });
+
+  it("keeps empty and degraded evidence-pack states explicit", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({
+        "/inspect-case-detail": createCaseDetailPayload({
+          linked_evidence_packs: [],
+        }),
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/cases/case-456"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText("No linked evidence packs were returned for this case."),
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    ["UI-cache source", createEvidencePack({ cache_sourced: true })],
+    ["browser-state source", createEvidencePack({ projection_source: "browser_state" })],
+    ["hidden stale label", createEvidencePack({ freshness_state: "" })],
+    ["hidden conflict label", createEvidencePack({ conflict_state: "" })],
+    ["missing custody display", createEvidencePack({ custody_reference: null })],
+    ["missing provenance display", createEvidencePack({ provenance_reference: null })],
+    ["evidence truth", createEvidencePack({ authoritative_workflow_truth: true })],
+    ["workflow authority", createEvidencePack({ workflow_authority: "close_case" })],
+    ["RC readiness claim", createEvidencePack({ release_readiness_claim: "rc_ready" })],
+    ["role bypass", createEvidencePack({ operator_visible: false })],
+  ])("fails closed on %s", async (_label, evidencePack) => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch({
+        "/inspect-case-detail": createCaseDetailPayload({
+          linked_evidence_packs: [evidencePack],
+        }),
+      }),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/cases/case-456"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Reviewed operator data could not be verified. The browser stayed fail-closed instead of rendering an untrusted record.",
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("table", { name: "Linked evidence packs" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("requires an approved operator session before evidence packs are visible", async () => {
+    const dependencies = createDefaultDependencies({
+      fetchFn: createAuthorizedFetch(
+        {
+          "/inspect-case-detail": createCaseDetailPayload(),
+        },
+        {
+          identity: "contractor@example.com",
+          provider: "authentik",
+          roles: ["unreviewed_contractor"],
+          subject: "operator-9",
+        },
+      ),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/cases/case-456"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Access denied" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("table", { name: "Linked evidence packs" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("rereads backend case detail after case writes instead of treating edited evidence ids as evidence-pack truth", async () => {
+    let caseDetailRequests = 0;
+    const fetchFn = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.startsWith("/api/operator/session")) {
+        return jsonResponse({
+          identity: "analyst@example.com",
+          provider: "authentik",
+          roles: ["Analyst"],
+          subject: "operator-7",
+        });
+      }
+
+      if (url.startsWith("/inspect-case-detail")) {
+        caseDetailRequests += 1;
+        return jsonResponse(
+          createCaseDetailPayload({
+            linked_evidence_packs:
+              caseDetailRequests === 1
+                ? [createEvidencePack()]
+                : [
+                    createEvidencePack({
+                      evidence_pack_id: "evidence-pack-reread",
+                      freshness_state: "fresh",
+                    }),
+                  ],
+          }),
+        );
+      }
+
+      if (
+        url.startsWith("/operator/record-case-observation") &&
+        init?.method === "POST"
+      ) {
+        return jsonResponse({ observation_id: "observation-1" }, 201);
+      }
+
+      if (url.startsWith("/diagnostics/readiness")) {
+        return jsonResponse({ metrics: {}, status: "ready" });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+    const dependencies = createDefaultDependencies({ fetchFn });
+
+    render(
+      <MemoryRouter initialEntries={["/operator/cases/case-456"]}>
+        <OperatorRoutes dependencies={dependencies} />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("evidence-pack-001")).toBeInTheDocument();
+    const user = userEvent.setup();
+    await user.type(
+      await screen.findByRole("textbox", { name: "Observed at" }),
+      "2026-05-30T12:00:00Z",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "Scope statement" }),
+      "Follow up stale evidence.",
+    );
+    await user.clear(
+      screen.getByRole("textbox", { name: "Supporting evidence ids" }),
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: "Supporting evidence ids" }),
+      "stale-evidence",
+    );
+    await user.click(
+      screen.getAllByRole("checkbox", {
+        name: "I confirm this reviewed task action should be submitted.",
+      })[0] as HTMLElement,
+    );
+    await user.click(screen.getByRole("button", { name: "Record observation" }));
+
+    expect(await screen.findByText("evidence-pack-reread")).toBeInTheDocument();
+    expect(screen.queryByText("stale-evidence")).not.toBeInTheDocument();
+  });
+});

--- a/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
@@ -72,7 +72,7 @@ export function CaseDetailPageBody({
   const reconciliationRecords = asRecordArray(data.linked_reconciliation_records);
   const alertRecords = asRecordArray(data.linked_alert_records);
   const evidenceRecords = asRecordArray(data.linked_evidence_records);
-  const evidencePacks = asRecordArray(data.linked_evidence_packs);
+  const evidencePacks = readBackendLinkedEvidencePacks(data);
   const timelineEntries = asRecordArray(data.cross_source_timeline);
   const caseTimelineProjection = asRecord(data.case_timeline_projection);
   const caseTimelineSegments = asRecordArray(caseTimelineProjection?.segments);
@@ -497,4 +497,8 @@ export function CaseDetailPageBody({
       ) : null}
     </Stack>
   );
+}
+
+function readBackendLinkedEvidencePacks(data: UnknownRecord) {
+  return asRecordArray(getPath(data, "linked_evidence_packs"));
 }

--- a/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
@@ -303,11 +303,13 @@ export function CaseDetailPageBody({
                 const freshnessState = asString(pack.freshness_state);
                 const conflictState = asString(pack.conflict_state);
                 const sourceState = asString(pack.source_state);
-                const packId = asString(pack.evidence_pack_id);
+                const custody = asRecord(pack.custody);
+                const provenance = asRecord(pack.provenance);
+                const packId = asString(pack.evidence_request_id);
 
                 return (
                   <TableRow key={`${packId ?? "evidence-pack"}-${index}`}>
-                    <TableCell>{formatValue(pack.evidence_pack_id)}</TableCell>
+                    <TableCell>{formatValue(pack.evidence_request_id)}</TableCell>
                     <TableCell>{formatValue(pack.source_id)}</TableCell>
                     <TableCell>
                       <Chip
@@ -347,7 +349,11 @@ export function CaseDetailPageBody({
                       <Stack spacing={0.5}>
                         <Typography variant="body2">{formatValue(pack.custody_state)}</Typography>
                         <Typography color="text.secondary" variant="caption">
-                          {formatValue(pack.custody_reference)}
+                          {formatValue(
+                            custody?.aegisops_evidence_record_id ??
+                              custody?.enrichment_request_id ??
+                              custody?.collection_timestamp,
+                          )}
                         </Typography>
                       </Stack>
                     </TableCell>
@@ -355,7 +361,11 @@ export function CaseDetailPageBody({
                       <Stack spacing={0.5}>
                         <Typography variant="body2">{formatValue(pack.provenance_state)}</Typography>
                         <Typography color="text.secondary" variant="caption">
-                          {formatValue(pack.provenance_reference)}
+                          {formatValue(
+                            provenance?.custody_reference ??
+                              provenance?.request_binding ??
+                              provenance?.source_id,
+                          )}
                         </Typography>
                       </Stack>
                     </TableCell>

--- a/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
@@ -326,11 +326,7 @@ export function CaseDetailPageBody({
                     <TableCell>{formatValue(pack.confidence_state)}</TableCell>
                     <TableCell>
                       <Chip
-                        color={
-                          conflictState === "unresolved_conflict"
-                            ? "warning"
-                            : statusTone(conflictState)
-                        }
+                        color={evidencePackConflictTone(conflictState)}
                         label={conflictState ?? "unknown"}
                         size="small"
                         variant="outlined"
@@ -339,7 +335,7 @@ export function CaseDetailPageBody({
                     <TableCell>{formatValue(pack.uncertainty_label)}</TableCell>
                     <TableCell>
                       <Chip
-                        color={sourceState === "degraded" ? "warning" : statusTone(sourceState)}
+                        color={evidencePackSourceTone(sourceState)}
                         label={sourceState ?? "unknown"}
                         size="small"
                         variant="outlined"
@@ -501,4 +497,23 @@ export function CaseDetailPageBody({
 
 function readBackendLinkedEvidencePacks(data: UnknownRecord) {
   return asRecordArray(getPath(data, "linked_evidence_packs"));
+}
+
+function evidencePackConflictTone(
+  conflictState: string | null,
+): ReturnType<typeof statusTone> {
+  if (conflictState === "conflicting") {
+    return "warning";
+  }
+  return statusTone(conflictState);
+}
+
+function evidencePackSourceTone(sourceState: string | null): ReturnType<typeof statusTone> {
+  if (sourceState === "unavailable") {
+    return "error";
+  }
+  if (sourceState === "degraded") {
+    return "warning";
+  }
+  return statusTone(sourceState);
 }

--- a/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
@@ -72,6 +72,7 @@ export function CaseDetailPageBody({
   const reconciliationRecords = asRecordArray(data.linked_reconciliation_records);
   const alertRecords = asRecordArray(data.linked_alert_records);
   const evidenceRecords = asRecordArray(data.linked_evidence_records);
+  const evidencePacks = asRecordArray(data.linked_evidence_packs);
   const timelineEntries = asRecordArray(data.cross_source_timeline);
   const caseTimelineProjection = asRecord(data.case_timeline_projection);
   const caseTimelineSegments = asRecordArray(caseTimelineProjection?.segments);
@@ -278,6 +279,102 @@ export function CaseDetailPageBody({
       </SectionCard>
 
       <SectionCard
+        subtitle="Evidence packs show backend-reviewed freshness, custody, confidence, provenance, conflict, uncertainty, and source posture as subordinate review context only."
+        title="Evidence pack review"
+      >
+        {evidencePacks.length > 0 ? (
+          <Table aria-label="Linked evidence packs" size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Evidence pack</TableCell>
+                <TableCell>Source</TableCell>
+                <TableCell>Freshness</TableCell>
+                <TableCell>Confidence</TableCell>
+                <TableCell>Conflict</TableCell>
+                <TableCell>Uncertainty</TableCell>
+                <TableCell>Source state</TableCell>
+                <TableCell>Custody</TableCell>
+                <TableCell>Provenance</TableCell>
+                <TableCell>Boundary</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {evidencePacks.map((pack, index) => {
+                const freshnessState = asString(pack.freshness_state);
+                const conflictState = asString(pack.conflict_state);
+                const sourceState = asString(pack.source_state);
+                const packId = asString(pack.evidence_pack_id);
+
+                return (
+                  <TableRow key={`${packId ?? "evidence-pack"}-${index}`}>
+                    <TableCell>{formatValue(pack.evidence_pack_id)}</TableCell>
+                    <TableCell>{formatValue(pack.source_id)}</TableCell>
+                    <TableCell>
+                      <Chip
+                        color={
+                          freshnessState === "stale_review_required"
+                            ? "warning"
+                            : statusTone(freshnessState)
+                        }
+                        label={freshnessState ?? "unknown"}
+                        size="small"
+                        variant="outlined"
+                      />
+                    </TableCell>
+                    <TableCell>{formatValue(pack.confidence_state)}</TableCell>
+                    <TableCell>
+                      <Chip
+                        color={
+                          conflictState === "unresolved_conflict"
+                            ? "warning"
+                            : statusTone(conflictState)
+                        }
+                        label={conflictState ?? "unknown"}
+                        size="small"
+                        variant="outlined"
+                      />
+                    </TableCell>
+                    <TableCell>{formatValue(pack.uncertainty_label)}</TableCell>
+                    <TableCell>
+                      <Chip
+                        color={sourceState === "degraded" ? "warning" : statusTone(sourceState)}
+                        label={sourceState ?? "unknown"}
+                        size="small"
+                        variant="outlined"
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Stack spacing={0.5}>
+                        <Typography variant="body2">{formatValue(pack.custody_state)}</Typography>
+                        <Typography color="text.secondary" variant="caption">
+                          {formatValue(pack.custody_reference)}
+                        </Typography>
+                      </Stack>
+                    </TableCell>
+                    <TableCell>
+                      <Stack spacing={0.5}>
+                        <Typography variant="body2">{formatValue(pack.provenance_state)}</Typography>
+                        <Typography color="text.secondary" variant="caption">
+                          {formatValue(pack.provenance_reference)}
+                        </Typography>
+                      </Stack>
+                    </TableCell>
+                    <TableCell>
+                      <Typography color="text.secondary" variant="body2">
+                        Subordinate evidence context only
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        ) : (
+          <EmptyState message="No linked evidence packs were returned for this case." />
+        )}
+      </SectionCard>
+
+      <SectionCard
         subtitle="Subordinate alert, evidence, and reconciliation context stays visible but secondary to the authoritative case state."
         title="Subordinate evidence context"
       >
@@ -285,6 +382,7 @@ export function CaseDetailPageBody({
           entries={[
             ["Alert records", alertRecords.length],
             ["Evidence records", evidenceRecords.length],
+            ["Evidence packs", evidencePacks.length],
             ["Reconciliation records", reconciliationRecords.length],
           ]}
         />

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -438,7 +438,9 @@ function validateEvidencePackReasons(
   allowedReasons: Set<string>,
 ) {
   if (value === undefined || value === null) {
-    return;
+    throw new OperatorDataProviderContractError(
+      "Resource cases linked_evidence_packs item has unsupported evidence-pack reasons.",
+    );
   }
   if (!Array.isArray(value)) {
     throw new OperatorDataProviderContractError(
@@ -589,12 +591,46 @@ function expectedEvidencePackUncertaintyLabel(
 }
 
 function evidencePackReasonList(value: unknown): string[] {
-  if (value === undefined || value === null) {
-    return [];
-  }
   return Array.isArray(value)
     ? value.map((reason) => asString(reason)).filter((reason): reason is string => reason !== null)
     : [];
+}
+
+function linkedEvidenceRecordCustodyReference(
+  response: Record<string, unknown>,
+  evidenceRecordId: string,
+  evidenceRequestId: string,
+) {
+  if (!Array.isArray(response.linked_evidence_records)) {
+    throw new OperatorDataProviderContractError(
+      `Resource cases linked_evidence_packs item ${evidenceRequestId} must be backed by linked evidence records.`,
+    );
+  }
+
+  for (const recordValue of response.linked_evidence_records) {
+    const record = asObject(
+      recordValue,
+      "Resource cases linked_evidence_records item must be an object.",
+    );
+    if (asString(record.evidence_id) !== evidenceRecordId) {
+      continue;
+    }
+    const provenance = asObject(
+      record.provenance,
+      `Resource cases linked_evidence_packs item ${evidenceRequestId} must be backed by linked evidence provenance.`,
+    );
+    const custodyReference = asString(provenance.custody_reference);
+    if (custodyReference === null) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases linked_evidence_packs item ${evidenceRequestId} must keep custody reference bound to the linked evidence record.`,
+      );
+    }
+    return custodyReference;
+  }
+
+  throw new OperatorDataProviderContractError(
+    `Resource cases linked_evidence_packs item ${evidenceRequestId} must be backed by linked evidence records.`,
+  );
 }
 
 function validateEvidencePackReasonConsistency(
@@ -797,7 +833,9 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
       freshnessState,
       evidenceRequestId,
     );
+    const evidenceRecordId = asString(custody.aegisops_evidence_record_id);
     if (
+      evidenceRecordId === null ||
       asString(provenance.request_binding) !== evidenceRequestId ||
       asString(provenance.case_binding) !== requestedCaseId ||
       asString(provenance.source_id) !== sourceId ||
@@ -806,7 +844,13 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
         asString(custody.enrichment_request_id) ||
       asString(provenance.collection_timestamp) !==
         asString(custody.collection_timestamp) ||
-      asString(provenance.response_digest) !== asString(custody.response_digest)
+      asString(provenance.response_digest) !== asString(custody.response_digest) ||
+      asString(provenance.custody_reference) !==
+        linkedEvidenceRecordCustodyReference(
+          response,
+          evidenceRecordId,
+          evidenceRequestId,
+        )
     ) {
       throw new OperatorDataProviderContractError(
         `Resource cases linked_evidence_packs item ${evidenceRequestId} must keep provenance bound to the evidence request and case.`,

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -436,6 +436,98 @@ function validateEvidencePackMetadataMap(
   }
 }
 
+function expectedEvidencePackUncertaintyLabel(
+  status: string,
+  freshnessState: string,
+  degradedReasons: string[],
+  unavailableReasons: string[],
+) {
+  if (status === "unavailable" || unavailableReasons.length > 0) {
+    return "source_unavailable";
+  }
+  if (degradedReasons.includes("conflicting_enrichment")) {
+    return "unresolved_conflict";
+  }
+  if (
+    freshnessState === "stale" ||
+    degradedReasons.includes("stale_reputation") ||
+    degradedReasons.includes("source_stale")
+  ) {
+    return "stale_review_required";
+  }
+  return "related_entity_not_authoritative";
+}
+
+function evidencePackReasonList(value: unknown): string[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  return Array.isArray(value)
+    ? value.map((reason) => asString(reason)).filter((reason): reason is string => reason !== null)
+    : [];
+}
+
+function validateEvidencePackReasonConsistency(
+  pack: Record<string, unknown>,
+  confidence: Record<string, unknown>,
+  labels: {
+    status: string;
+    freshnessState: string;
+    conflictState: string;
+    sourceState: string;
+    uncertaintyLabel: string;
+  },
+) {
+  const degradedReasons = evidencePackReasonList(pack.degraded_reasons);
+  const unavailableReasons = evidencePackReasonList(pack.unavailable_reasons);
+  const inconsistentMessage =
+    "Resource cases linked_evidence_packs item has inconsistent evidence-pack reasons.";
+
+  if (
+    (labels.status === "available" &&
+      (degradedReasons.length > 0 || unavailableReasons.length > 0)) ||
+    (labels.status === "degraded" &&
+      (degradedReasons.length === 0 || unavailableReasons.length > 0)) ||
+    (labels.status === "unavailable" && unavailableReasons.length === 0)
+  ) {
+    throw new OperatorDataProviderContractError(inconsistentMessage);
+  }
+  if (
+    degradedReasons.includes("stale_reputation") !==
+    (labels.freshnessState === "stale")
+  ) {
+    throw new OperatorDataProviderContractError(inconsistentMessage);
+  }
+  const expectedConflictState = degradedReasons.includes("conflicting_enrichment")
+    ? "conflicting"
+    : "none";
+  const expectedSourceState =
+    labels.status === "unavailable" || unavailableReasons.length > 0
+      ? "unavailable"
+      : degradedReasons.includes("source_stale")
+        ? "degraded"
+        : "available";
+
+  if (
+    labels.conflictState !== expectedConflictState ||
+    labels.sourceState !== expectedSourceState ||
+    labels.uncertaintyLabel !==
+      expectedEvidencePackUncertaintyLabel(
+        labels.status,
+        labels.freshnessState,
+        degradedReasons,
+        unavailableReasons,
+      ) ||
+    asString(confidence.freshness) !== labels.freshnessState ||
+    asString(confidence.ambiguity_badge) !==
+      (degradedReasons.includes("conflicting_enrichment")
+        ? "unresolved"
+        : "related-entity")
+  ) {
+    throw new OperatorDataProviderContractError(inconsistentMessage);
+  }
+}
+
 function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) {
   const response = asObject(
     payload,
@@ -565,7 +657,13 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
     if (
       asString(provenance.request_binding) !== evidenceRequestId ||
       asString(provenance.case_binding) !== requestedCaseId ||
-      asString(provenance.source_id) !== sourceId
+      asString(provenance.source_id) !== sourceId ||
+      asString(provenance.target_binding) !== asString(custody.reviewed_file_hash) ||
+      asString(provenance.enrichment_request_id) !==
+        asString(custody.enrichment_request_id) ||
+      asString(provenance.collection_timestamp) !==
+        asString(custody.collection_timestamp) ||
+      asString(provenance.response_digest) !== asString(custody.response_digest)
     ) {
       throw new OperatorDataProviderContractError(
         `Resource cases linked_evidence_packs item ${evidenceRequestId} must keep provenance bound to the evidence request and case.`,
@@ -584,6 +682,13 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
         `Resource cases linked_evidence_packs item ${evidenceRequestId} cannot carry workflow authority.`,
       );
     }
+    validateEvidencePackReasonConsistency(pack, confidence, {
+      status,
+      freshnessState,
+      conflictState,
+      sourceState,
+      uncertaintyLabel,
+    });
     if (
       pack.authoritative_workflow_truth !== false ||
       authorityPosture !== EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE ||

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -48,6 +48,12 @@ const CASE_TIMELINE_SUMMARY_DECISIONS = new Set([
   "fallback",
   "blocked",
 ]);
+const EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES = new Set([
+  "browser_state",
+  "browser_cache",
+  "ui_cache",
+  "cache",
+]);
 const BUSINESS_HOURS_HANDOFF_CONTRACT_VERSION = "phase-56-6";
 
 const BUSINESS_HOURS_HANDOFF_STATES = new Set([
@@ -76,6 +82,7 @@ export async function getOneForStandardResource(
   if (resource === "cases") {
     validateCaseTimelineProjection(payload, String(params.id).trim());
     validateCaseTimelineSummary(payload);
+    validateLinkedEvidencePacks(payload, String(params.id).trim());
   }
 
   return {
@@ -322,6 +329,99 @@ function validateCaseTimelineSummary(payload: unknown) {
     ) {
       throw new OperatorDataProviderContractError(
         `Resource cases case_timeline_summary segment ${segmentName} must stay cited by top-level advisory-only context.`,
+      );
+    }
+  });
+}
+
+function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) {
+  const response = asObject(
+    payload,
+    "Resource cases returned a malformed detail payload.",
+  );
+  const evidencePacks = response.linked_evidence_packs;
+
+  if (evidencePacks === undefined || evidencePacks === null) {
+    return;
+  }
+  if (!Array.isArray(evidencePacks)) {
+    throw new OperatorDataProviderContractError(
+      "Resource cases linked_evidence_packs must be an array.",
+    );
+  }
+
+  evidencePacks.forEach((packValue) => {
+    const pack = asObject(
+      packValue,
+      "Resource cases linked_evidence_packs item must be an object.",
+    );
+    const evidencePackId = asString(pack.evidence_pack_id);
+    const caseId = asString(pack.case_id);
+    const sourceId = asString(pack.source_id);
+    const freshnessState = asString(pack.freshness_state);
+    const custodyState = asString(pack.custody_state);
+    const custodyReference = asString(pack.custody_reference);
+    const confidenceState = asString(pack.confidence_state);
+    const provenanceState = asString(pack.provenance_state);
+    const provenanceReference = asString(pack.provenance_reference);
+    const conflictState = asString(pack.conflict_state);
+    const sourceState = asString(pack.source_state);
+    const uncertaintyLabel = asString(pack.uncertainty_label);
+    const workflowAuthority = asString(pack.workflow_authority);
+    const projectionSource = asString(pack.projection_source);
+
+    if (
+      evidencePackId === null ||
+      caseId === null ||
+      sourceId === null ||
+      freshnessState === null ||
+      custodyState === null ||
+      custodyReference === null ||
+      confidenceState === null ||
+      provenanceState === null ||
+      provenanceReference === null ||
+      conflictState === null ||
+      sourceState === null ||
+      uncertaintyLabel === null
+    ) {
+      throw new OperatorDataProviderContractError(
+        "Resource cases linked_evidence_packs item is missing required evidence-pack labels.",
+      );
+    }
+    if (caseId !== requestedCaseId) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases linked_evidence_packs item ${evidencePackId} must stay bound to case ${requestedCaseId}.`,
+      );
+    }
+    if (
+      pack.authoritative_workflow_truth !== false ||
+      workflowAuthority !== "none"
+    ) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases linked_evidence_packs item ${evidencePackId} cannot carry workflow authority.`,
+      );
+    }
+    if (pack.operator_visible !== true) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases linked_evidence_packs item ${evidencePackId} must stay operator visible.`,
+      );
+    }
+    if (
+      (pack.cache_sourced !== undefined && pack.cache_sourced !== false) ||
+      (pack.stale_cache !== undefined && pack.stale_cache !== false) ||
+      EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES.has(projectionSource ?? "")
+    ) {
+      throw new OperatorDataProviderContractError(
+        "Resource cases rejects cache or browser sourced evidence-pack truth.",
+      );
+    }
+    if (
+      pack.release_readiness_claim !== undefined ||
+      pack.rc_readiness_claim !== undefined ||
+      pack.gate_readiness_claim !== undefined
+    ) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases linked_evidence_packs item ${evidencePackId} cannot claim release readiness.`,
       );
     }
   });

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -57,6 +57,9 @@ const EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES = new Set([
 const EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE =
   "subordinate_evidence_context_only";
 const EVIDENCE_PACK_SUPPORTED_SOURCE_ID = "malwarebazaar_hash_reputation";
+const EVIDENCE_PACK_CONFIDENCE_POSTURE =
+  "external_hash_reputation_subordinate_context";
+const EVIDENCE_PACK_FRESHNESS_WINDOW_MS = 6 * 60 * 60 * 1000;
 const EVIDENCE_PACK_ALLOWED_LABELS = {
   consumer: new Set(["case_workbench"]),
   status: new Set(["available", "degraded", "unavailable"]),
@@ -105,6 +108,38 @@ const EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS = new Set([
   "freshness",
   "ambiguity_badge",
   "source_native_score_authority",
+]);
+const EVIDENCE_PACK_CONTRACT_FIELDS = new Set([
+  "evidence_request_id",
+  "case_id",
+  "source_id",
+  "consumer",
+  "status",
+  "freshness_state",
+  "custody_state",
+  "confidence_state",
+  "provenance_state",
+  "conflict_state",
+  "source_state",
+  "uncertainty_label",
+  "authority_posture",
+  "workflow_authority",
+  "degraded_reasons",
+  "unavailable_reasons",
+  "authoritative_workflow_truth",
+  "custody",
+  "provenance",
+  "confidence",
+]);
+const EVIDENCE_PACK_RECOGNIZED_FIELDS = new Set([
+  ...EVIDENCE_PACK_CONTRACT_FIELDS,
+  "cache_sourced",
+  "stale_cache",
+  "projection_source",
+  "operator_visible",
+  "release_readiness_claim",
+  "rc_readiness_claim",
+  "gate_readiness_claim",
 ]);
 const BUSINESS_HOURS_HANDOFF_CONTRACT_VERSION = "phase-56-6";
 
@@ -507,6 +542,30 @@ function validateEvidencePackMetadataFormats(
   }
 }
 
+function validateEvidencePackFreshnessWindow(
+  custody: Record<string, unknown>,
+  freshnessState: string,
+  evidenceRequestId: string,
+) {
+  const collectionTimestamp = asString(custody.collection_timestamp);
+  if (collectionTimestamp === null || !isAwareTimestamp(collectionTimestamp)) {
+    throw new OperatorDataProviderContractError(
+      `Resource cases linked_evidence_packs item ${evidenceRequestId} has invalid evidence-pack metadata.`,
+    );
+  }
+
+  const ageMs = Date.now() - Date.parse(collectionTimestamp);
+  if (
+    ageMs < 0 ||
+    (freshnessState === "fresh" && ageMs > EVIDENCE_PACK_FRESHNESS_WINDOW_MS) ||
+    (freshnessState === "stale" && ageMs <= EVIDENCE_PACK_FRESHNESS_WINDOW_MS)
+  ) {
+    throw new OperatorDataProviderContractError(
+      `Resource cases linked_evidence_packs item ${evidenceRequestId} has an invalid evidence-pack freshness window.`,
+    );
+  }
+}
+
 function expectedEvidencePackUncertaintyLabel(
   status: string,
   freshnessState: string,
@@ -733,6 +792,11 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
       evidenceRequestId,
     );
     validateEvidencePackMetadataFormats(custody, provenance, evidenceRequestId);
+    validateEvidencePackFreshnessWindow(
+      custody,
+      freshnessState,
+      evidenceRequestId,
+    );
     if (
       asString(provenance.request_binding) !== evidenceRequestId ||
       asString(provenance.case_binding) !== requestedCaseId ||
@@ -759,6 +823,11 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
     if (asString(confidence.source_native_score_authority) !== "none") {
       throw new OperatorDataProviderContractError(
         `Resource cases linked_evidence_packs item ${evidenceRequestId} cannot carry workflow authority.`,
+      );
+    }
+    if (asString(confidence.posture) !== EVIDENCE_PACK_CONFIDENCE_POSTURE) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases linked_evidence_packs item ${evidenceRequestId} has an unsupported confidence posture.`,
       );
     }
     validateEvidencePackReasonConsistency(pack, confidence, {
@@ -798,6 +867,15 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
     ) {
       throw new OperatorDataProviderContractError(
         `Resource cases linked_evidence_packs item ${evidenceRequestId} cannot claim release readiness.`,
+      );
+    }
+    if (
+      Object.keys(pack).some(
+        (fieldName) => !EVIDENCE_PACK_RECOGNIZED_FIELDS.has(fieldName),
+      )
+    ) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases linked_evidence_packs item ${evidenceRequestId} has unexpected evidence-pack fields.`,
       );
     }
   });

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -448,10 +448,45 @@ function isSha256Digest(value: string | null) {
 }
 
 function isAwareTimestamp(value: string | null) {
+  if (value === null) {
+    return false;
+  }
+  const match = value?.match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/,
+  );
+  if (!match || Number.isNaN(Date.parse(value))) {
+    return false;
+  }
+
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, zoneText] =
+    match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const offsetHour =
+    zoneText === "Z" ? 0 : Number(zoneText.slice(1, 3));
+  const offsetMinute =
+    zoneText === "Z" ? 0 : Number(zoneText.slice(4, 6));
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+
   return (
-    value !== null &&
-    !Number.isNaN(Date.parse(value)) &&
-    /(?:Z|[+-]\d{2}:\d{2})$/.test(value)
+    month >= 1 &&
+    month <= 12 &&
+    day >= 1 &&
+    day <= daysInMonth &&
+    hour >= 0 &&
+    hour <= 23 &&
+    minute >= 0 &&
+    minute <= 59 &&
+    second >= 0 &&
+    second <= 59 &&
+    offsetHour >= 0 &&
+    offsetHour <= 23 &&
+    offsetMinute >= 0 &&
+    offsetMinute <= 59
   );
 }
 
@@ -518,6 +553,13 @@ function validateEvidencePackReasonConsistency(
   const unavailableReasons = evidencePackReasonList(pack.unavailable_reasons);
   const inconsistentMessage =
     "Resource cases linked_evidence_packs item has inconsistent evidence-pack reasons.";
+
+  if (
+    degradedReasons.includes("source_stale") ||
+    unavailableReasons.includes("source_denied")
+  ) {
+    throw new OperatorDataProviderContractError(inconsistentMessage);
+  }
 
   if (
     (labels.status === "available" &&

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -436,8 +436,11 @@ function validateEvidencePackMetadataMap(
   }
 }
 
-function isSha256Hex(value: string | null) {
-  return value !== null && /^[0-9a-fA-F]{64}$/.test(value);
+function isSupportedReviewedHash(value: string | null) {
+  return (
+    value !== null &&
+    /^(?:[0-9a-fA-F]{32}|[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/.test(value)
+  );
 }
 
 function isSha256Digest(value: string | null) {
@@ -458,7 +461,7 @@ function validateEvidencePackMetadataFormats(
   evidenceRequestId: string,
 ) {
   if (
-    !isSha256Hex(asString(custody.reviewed_file_hash)) ||
+    !isSupportedReviewedHash(asString(custody.reviewed_file_hash)) ||
     !isSha256Digest(asString(custody.response_digest)) ||
     !isAwareTimestamp(asString(custody.collection_timestamp)) ||
     !isAwareTimestamp(asString(provenance.collection_timestamp))

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -572,6 +572,19 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
       );
     }
     if (
+      asString(provenance.authority_posture) !==
+      EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE
+    ) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases linked_evidence_packs item ${evidenceRequestId} must keep provenance subordinate.`,
+      );
+    }
+    if (asString(confidence.source_native_score_authority) !== "none") {
+      throw new OperatorDataProviderContractError(
+        `Resource cases linked_evidence_packs item ${evidenceRequestId} cannot carry workflow authority.`,
+      );
+    }
+    if (
       pack.authoritative_workflow_truth !== false ||
       authorityPosture !== EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE ||
       workflowAuthority !== "none"

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -54,6 +54,8 @@ const EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES = new Set([
   "ui_cache",
   "cache",
 ]);
+const EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE =
+  "subordinate_evidence_context_only";
 const BUSINESS_HOURS_HANDOFF_CONTRACT_VERSION = "phase-56-6";
 
 const BUSINESS_HOURS_HANDOFF_STATES = new Set([
@@ -418,6 +420,7 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
     }
     if (
       pack.authoritative_workflow_truth !== false ||
+      authorityPosture !== EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE ||
       workflowAuthority !== "none"
     ) {
       throw new OperatorDataProviderContractError(

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -58,7 +58,7 @@ const EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE =
   "subordinate_evidence_context_only";
 const EVIDENCE_PACK_SUPPORTED_SOURCE_ID = "malwarebazaar_hash_reputation";
 const EVIDENCE_PACK_ALLOWED_LABELS = {
-  consumer: new Set(["case_workbench", "ai_grounding"]),
+  consumer: new Set(["case_workbench"]),
   status: new Set(["available", "degraded", "unavailable"]),
   freshness_state: new Set(["fresh", "stale"]),
   custody_state: new Set(["complete"]),
@@ -436,6 +436,39 @@ function validateEvidencePackMetadataMap(
   }
 }
 
+function isSha256Hex(value: string | null) {
+  return value !== null && /^[0-9a-fA-F]{64}$/.test(value);
+}
+
+function isSha256Digest(value: string | null) {
+  return value !== null && /^sha256:[0-9a-fA-F]{64}$/.test(value);
+}
+
+function isAwareTimestamp(value: string | null) {
+  return (
+    value !== null &&
+    !Number.isNaN(Date.parse(value)) &&
+    /(?:Z|[+-]\d{2}:\d{2})$/.test(value)
+  );
+}
+
+function validateEvidencePackMetadataFormats(
+  custody: Record<string, unknown>,
+  provenance: Record<string, unknown>,
+  evidenceRequestId: string,
+) {
+  if (
+    !isSha256Hex(asString(custody.reviewed_file_hash)) ||
+    !isSha256Digest(asString(custody.response_digest)) ||
+    !isAwareTimestamp(asString(custody.collection_timestamp)) ||
+    !isAwareTimestamp(asString(provenance.collection_timestamp))
+  ) {
+    throw new OperatorDataProviderContractError(
+      `Resource cases linked_evidence_packs item ${evidenceRequestId} has invalid evidence-pack metadata.`,
+    );
+  }
+}
+
 function expectedEvidencePackUncertaintyLabel(
   status: string,
   freshnessState: string,
@@ -654,6 +687,7 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
       EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS,
       evidenceRequestId,
     );
+    validateEvidencePackMetadataFormats(custody, provenance, evidenceRequestId);
     if (
       asString(provenance.request_binding) !== evidenceRequestId ||
       asString(provenance.case_binding) !== requestedCaseId ||

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -56,6 +56,56 @@ const EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES = new Set([
 ]);
 const EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE =
   "subordinate_evidence_context_only";
+const EVIDENCE_PACK_SUPPORTED_SOURCE_ID = "malwarebazaar_hash_reputation";
+const EVIDENCE_PACK_ALLOWED_LABELS = {
+  consumer: new Set(["case_workbench", "ai_grounding"]),
+  status: new Set(["available", "degraded", "unavailable"]),
+  freshness_state: new Set(["fresh", "stale"]),
+  custody_state: new Set(["complete"]),
+  confidence_state: new Set(["present"]),
+  provenance_state: new Set(["bound"]),
+  conflict_state: new Set(["conflicting", "none"]),
+  source_state: new Set(["available", "degraded", "unavailable"]),
+  uncertainty_label: new Set([
+    "related_entity_not_authoritative",
+    "stale_review_required",
+    "unresolved_conflict",
+    "source_unavailable",
+  ]),
+};
+const EVIDENCE_PACK_ALLOWED_DEGRADED_REASONS = new Set([
+  "stale_reputation",
+  "conflicting_enrichment",
+  "source_stale",
+]);
+const EVIDENCE_PACK_ALLOWED_UNAVAILABLE_REASONS = new Set([
+  "source_denied",
+  "source_unavailable",
+]);
+const EVIDENCE_PACK_REQUIRED_CUSTODY_FIELDS = new Set([
+  "reviewed_file_hash",
+  "enrichment_request_id",
+  "collection_timestamp",
+  "response_digest",
+  "aegisops_evidence_record_id",
+]);
+const EVIDENCE_PACK_REQUIRED_PROVENANCE_FIELDS = new Set([
+  "request_binding",
+  "case_binding",
+  "target_binding",
+  "source_id",
+  "enrichment_request_id",
+  "collection_timestamp",
+  "response_digest",
+  "custody_reference",
+  "authority_posture",
+]);
+const EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS = new Set([
+  "posture",
+  "freshness",
+  "ambiguity_badge",
+  "source_native_score_authority",
+]);
 const BUSINESS_HOURS_HANDOFF_CONTRACT_VERSION = "phase-56-6";
 
 const BUSINESS_HOURS_HANDOFF_STATES = new Set([
@@ -336,6 +386,56 @@ function validateCaseTimelineSummary(payload: unknown) {
   });
 }
 
+function validateEvidencePackLabel(
+  fieldName: keyof typeof EVIDENCE_PACK_ALLOWED_LABELS,
+  value: string,
+  evidenceRequestId: string,
+) {
+  if (!EVIDENCE_PACK_ALLOWED_LABELS[fieldName].has(value)) {
+    throw new OperatorDataProviderContractError(
+      `Resource cases linked_evidence_packs item ${evidenceRequestId} has an unsupported evidence-pack label.`,
+    );
+  }
+}
+
+function validateEvidencePackReasons(
+  value: unknown,
+  allowedReasons: Set<string>,
+) {
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!Array.isArray(value)) {
+    throw new OperatorDataProviderContractError(
+      "Resource cases linked_evidence_packs item has unsupported evidence-pack reasons.",
+    );
+  }
+  value.forEach((reason) => {
+    if (!asString(reason) || !allowedReasons.has(asString(reason) ?? "")) {
+      throw new OperatorDataProviderContractError(
+        "Resource cases linked_evidence_packs item has unsupported evidence-pack reasons.",
+      );
+    }
+  });
+}
+
+function validateEvidencePackMetadataMap(
+  value: Record<string, unknown>,
+  requiredFields: Set<string>,
+  evidenceRequestId: string,
+) {
+  const fieldNames = Object.keys(value);
+  if (
+    fieldNames.length !== requiredFields.size ||
+    fieldNames.some((fieldName) => !requiredFields.has(fieldName)) ||
+    Array.from(requiredFields).some((fieldName) => asString(value[fieldName]) === null)
+  ) {
+    throw new OperatorDataProviderContractError(
+      `Resource cases linked_evidence_packs item ${evidenceRequestId} is missing required evidence-pack metadata.`,
+    );
+  }
+}
+
 function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) {
   const response = asObject(
     payload,
@@ -380,7 +480,7 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
       pack.provenance,
       "Resource cases linked_evidence_packs item provenance must be an object.",
     );
-    asObject(
+    const confidence = asObject(
       pack.confidence,
       "Resource cases linked_evidence_packs item confidence must be an object.",
     );
@@ -409,6 +509,59 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
         `Resource cases linked_evidence_packs item ${evidenceRequestId} must stay bound to case ${requestedCaseId}.`,
       );
     }
+    if (sourceId !== EVIDENCE_PACK_SUPPORTED_SOURCE_ID) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases linked_evidence_packs item ${evidenceRequestId} has an unsupported evidence-pack source.`,
+      );
+    }
+    validateEvidencePackLabel("consumer", consumer, evidenceRequestId);
+    validateEvidencePackLabel("status", status, evidenceRequestId);
+    validateEvidencePackLabel(
+      "freshness_state",
+      freshnessState,
+      evidenceRequestId,
+    );
+    validateEvidencePackLabel("custody_state", custodyState, evidenceRequestId);
+    validateEvidencePackLabel(
+      "confidence_state",
+      confidenceState,
+      evidenceRequestId,
+    );
+    validateEvidencePackLabel(
+      "provenance_state",
+      provenanceState,
+      evidenceRequestId,
+    );
+    validateEvidencePackLabel("conflict_state", conflictState, evidenceRequestId);
+    validateEvidencePackLabel("source_state", sourceState, evidenceRequestId);
+    validateEvidencePackLabel(
+      "uncertainty_label",
+      uncertaintyLabel,
+      evidenceRequestId,
+    );
+    validateEvidencePackReasons(
+      pack.degraded_reasons,
+      EVIDENCE_PACK_ALLOWED_DEGRADED_REASONS,
+    );
+    validateEvidencePackReasons(
+      pack.unavailable_reasons,
+      EVIDENCE_PACK_ALLOWED_UNAVAILABLE_REASONS,
+    );
+    validateEvidencePackMetadataMap(
+      custody,
+      EVIDENCE_PACK_REQUIRED_CUSTODY_FIELDS,
+      evidenceRequestId,
+    );
+    validateEvidencePackMetadataMap(
+      provenance,
+      EVIDENCE_PACK_REQUIRED_PROVENANCE_FIELDS,
+      evidenceRequestId,
+    );
+    validateEvidencePackMetadataMap(
+      confidence,
+      EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS,
+      evidenceRequestId,
+    );
     if (
       asString(provenance.request_binding) !== evidenceRequestId ||
       asString(provenance.case_binding) !== requestedCaseId ||

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -355,34 +355,48 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
       packValue,
       "Resource cases linked_evidence_packs item must be an object.",
     );
-    const evidencePackId = asString(pack.evidence_pack_id);
+    const evidenceRequestId = asString(pack.evidence_request_id);
     const caseId = asString(pack.case_id);
     const sourceId = asString(pack.source_id);
+    const consumer = asString(pack.consumer);
+    const status = asString(pack.status);
     const freshnessState = asString(pack.freshness_state);
     const custodyState = asString(pack.custody_state);
-    const custodyReference = asString(pack.custody_reference);
     const confidenceState = asString(pack.confidence_state);
     const provenanceState = asString(pack.provenance_state);
-    const provenanceReference = asString(pack.provenance_reference);
     const conflictState = asString(pack.conflict_state);
     const sourceState = asString(pack.source_state);
     const uncertaintyLabel = asString(pack.uncertainty_label);
+    const authorityPosture = asString(pack.authority_posture);
     const workflowAuthority = asString(pack.workflow_authority);
     const projectionSource = asString(pack.projection_source);
+    const custody = asObject(
+      pack.custody,
+      "Resource cases linked_evidence_packs item custody must be an object.",
+    );
+    const provenance = asObject(
+      pack.provenance,
+      "Resource cases linked_evidence_packs item provenance must be an object.",
+    );
+    asObject(
+      pack.confidence,
+      "Resource cases linked_evidence_packs item confidence must be an object.",
+    );
 
     if (
-      evidencePackId === null ||
+      evidenceRequestId === null ||
       caseId === null ||
       sourceId === null ||
+      consumer === null ||
+      status === null ||
       freshnessState === null ||
       custodyState === null ||
-      custodyReference === null ||
       confidenceState === null ||
       provenanceState === null ||
-      provenanceReference === null ||
       conflictState === null ||
       sourceState === null ||
-      uncertaintyLabel === null
+      uncertaintyLabel === null ||
+      authorityPosture === null
     ) {
       throw new OperatorDataProviderContractError(
         "Resource cases linked_evidence_packs item is missing required evidence-pack labels.",
@@ -390,7 +404,16 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
     }
     if (caseId !== requestedCaseId) {
       throw new OperatorDataProviderContractError(
-        `Resource cases linked_evidence_packs item ${evidencePackId} must stay bound to case ${requestedCaseId}.`,
+        `Resource cases linked_evidence_packs item ${evidenceRequestId} must stay bound to case ${requestedCaseId}.`,
+      );
+    }
+    if (
+      asString(provenance.request_binding) !== evidenceRequestId ||
+      asString(provenance.case_binding) !== requestedCaseId ||
+      asString(provenance.source_id) !== sourceId
+    ) {
+      throw new OperatorDataProviderContractError(
+        `Resource cases linked_evidence_packs item ${evidenceRequestId} must keep provenance bound to the evidence request and case.`,
       );
     }
     if (
@@ -398,12 +421,12 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
       workflowAuthority !== "none"
     ) {
       throw new OperatorDataProviderContractError(
-        `Resource cases linked_evidence_packs item ${evidencePackId} cannot carry workflow authority.`,
+        `Resource cases linked_evidence_packs item ${evidenceRequestId} cannot carry workflow authority.`,
       );
     }
-    if (pack.operator_visible !== true) {
+    if (pack.operator_visible !== undefined && pack.operator_visible !== true) {
       throw new OperatorDataProviderContractError(
-        `Resource cases linked_evidence_packs item ${evidencePackId} must stay operator visible.`,
+        `Resource cases linked_evidence_packs item ${evidenceRequestId} must stay operator visible.`,
       );
     }
     if (
@@ -421,7 +444,7 @@ function validateLinkedEvidencePacks(payload: unknown, requestedCaseId: string) 
       pack.gate_readiness_claim !== undefined
     ) {
       throw new OperatorDataProviderContractError(
-        `Resource cases linked_evidence_packs item ${evidencePackId} cannot claim release readiness.`,
+        `Resource cases linked_evidence_packs item ${evidenceRequestId} cannot claim release readiness.`,
       );
     }
   });

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -4,6 +4,11 @@ from collections import Counter
 from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, Protocol, Type, TypeVar
 
+from .evidence.bounded_enrichment_adapter import BoundedEnrichmentEvidencePack
+from .evidence.evidence_freshness_provenance_projection import (
+    EvidenceFreshnessProvenanceProjectionInput,
+    project_evidence_freshness_provenance,
+)
 from .models import (
     ActionExecutionRecord,
     ActionRequestRecord,
@@ -42,6 +47,11 @@ _EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES = {
     "browser_cache",
     "ui_cache",
     "cache",
+}
+_EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS = {
+    "release_readiness_claim",
+    "rc_readiness_claim",
+    "gate_readiness_claim",
 }
 _EVIDENCE_PACK_PROJECTION_REQUIRED_STRINGS = (
     "evidence_request_id",
@@ -1205,7 +1215,14 @@ class OperatorInspectionReadSurface:
             content = evidence_record.get("content")
             if not isinstance(content, Mapping):
                 continue
-            projection = content.get(_EVIDENCE_PACK_PROJECTION_CONTENT_KEY)
+            evidence_record_id = self._optional_string_from_mapping(
+                evidence_record,
+                "evidence_id",
+            )
+            projection = self._linked_evidence_pack_projection_from_content(
+                content=content,
+                evidence_record_id=evidence_record_id,
+            )
             if projection is None:
                 continue
             if not isinstance(projection, Mapping):
@@ -1214,13 +1231,155 @@ class OperatorInspectionReadSurface:
                 self._validated_linked_evidence_pack_projection(
                     projection=projection,
                     case_id=case_id,
-                    evidence_record_id=self._optional_string_from_mapping(
-                        evidence_record,
-                        "evidence_id",
-                    ),
+                    evidence_record_id=evidence_record_id,
                 )
             )
         return tuple(projections)
+
+    def _linked_evidence_pack_projection_from_content(
+        self,
+        *,
+        content: Mapping[str, object],
+        evidence_record_id: str | None,
+    ) -> Mapping[str, object] | None:
+        projection = content.get(_EVIDENCE_PACK_PROJECTION_CONTENT_KEY)
+        if projection is not None:
+            if not isinstance(projection, Mapping):
+                raise ValueError("linked evidence-pack projection must be a mapping")
+            return projection
+        if not self._looks_like_bounded_enrichment_pack(content):
+            return None
+        return self._project_bounded_enrichment_evidence_pack(
+            content=content,
+            evidence_record_id=evidence_record_id,
+        )
+
+    def _project_bounded_enrichment_evidence_pack(
+        self,
+        *,
+        content: Mapping[str, object],
+        evidence_record_id: str | None,
+    ) -> Mapping[str, object]:
+        if evidence_record_id is None:
+            raise ValueError("linked evidence-pack projection custody binding mismatch")
+        looked_up_at = self._datetime_from_evidence_pack_content(
+            content,
+            "looked_up_at",
+        )
+        provenance = content.get("provenance")
+        if not isinstance(provenance, Mapping):
+            raise ValueError("linked evidence-pack projection requires provenance map")
+        expected_custody_reference = self._optional_string_from_mapping(
+            provenance,
+            "custody_reference",
+        )
+        if expected_custody_reference is None:
+            raise ValueError("linked evidence-pack projection provenance binding mismatch")
+        pack = BoundedEnrichmentEvidencePack(
+            evidence_request_id=self._required_string_from_mapping(
+                content,
+                "evidence_request_id",
+            ),
+            case_id=self._required_string_from_mapping(content, "case_id"),
+            source_id=self._required_string_from_mapping(content, "source_id"),
+            file_hash=self._required_string_from_mapping(content, "file_hash"),
+            status=self._required_string_from_mapping(content, "status"),
+            freshness=self._required_string_from_mapping(content, "freshness"),
+            looked_up_at=looked_up_at,
+            custody=self._required_mapping_from_mapping(content, "custody"),
+            provenance=provenance,
+            confidence=self._required_mapping_from_mapping(content, "confidence"),
+            content=self._required_mapping_from_mapping(content, "content"),
+            authority_posture=self._required_string_from_mapping(
+                content,
+                "authority_posture",
+            ),
+            degraded_reasons=self._string_tuple_from_object(
+                content.get("degraded_reasons")
+            ),
+            unavailable_reasons=self._string_tuple_from_object(
+                content.get("unavailable_reasons")
+            ),
+            workflow_authority=self._required_string_from_mapping(
+                content,
+                "workflow_authority",
+            ),
+        )
+        projection = project_evidence_freshness_provenance(
+            EvidenceFreshnessProvenanceProjectionInput(
+                evidence_pack=pack,
+                consumer="case_workbench",
+                expected_source_id=pack.source_id,
+                expected_case_id=pack.case_id,
+                expected_custody_reference=expected_custody_reference,
+                projected_at=datetime.now(timezone.utc),
+            )
+        ).as_dict()
+        return projection
+
+    @staticmethod
+    def _looks_like_bounded_enrichment_pack(content: Mapping[str, object]) -> bool:
+        return all(
+            field_name in content
+            for field_name in (
+                "evidence_request_id",
+                "case_id",
+                "source_id",
+                "file_hash",
+                "looked_up_at",
+                "custody",
+                "provenance",
+                "confidence",
+                "content",
+            )
+        )
+
+    @staticmethod
+    def _required_string_from_mapping(
+        mapping: Mapping[str, object],
+        key: str,
+    ) -> str:
+        value = mapping.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("linked evidence-pack projection is missing required fields")
+        return value.strip()
+
+    @staticmethod
+    def _required_mapping_from_mapping(
+        mapping: Mapping[str, object],
+        key: str,
+    ) -> Mapping[str, object]:
+        value = mapping.get(key)
+        if not isinstance(value, Mapping):
+            raise ValueError(
+                "linked evidence-pack projection requires custody, provenance, and confidence maps"
+            )
+        return value
+
+    @staticmethod
+    def _datetime_from_evidence_pack_content(
+        mapping: Mapping[str, object],
+        key: str,
+    ) -> datetime:
+        value = mapping.get(key)
+        if isinstance(value, datetime):
+            parsed = value
+        elif isinstance(value, str):
+            try:
+                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError as exc:
+                raise ValueError(
+                    "linked evidence-pack projection requires timezone-aware timestamps"
+                ) from exc
+        else:
+            raise ValueError(
+                "linked evidence-pack projection requires timezone-aware timestamps"
+            )
+        if parsed.tzinfo is None or parsed.utcoffset() is None:
+            raise ValueError(
+                "linked evidence-pack projection requires timezone-aware timestamps"
+            )
+        return parsed
 
     def _validated_linked_evidence_pack_projection(
         self,
@@ -1243,6 +1402,17 @@ class OperatorInspectionReadSurface:
             raise ValueError("linked evidence-pack projection cannot carry workflow authority")
         if values["authority_posture"] != _EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE:
             raise ValueError("linked evidence-pack projection must stay subordinate")
+        if projection.get("operator_visible") is not None and projection.get(
+            "operator_visible"
+        ) is not True:
+            raise ValueError("linked evidence-pack projection must stay operator visible")
+        if any(
+            claim_name in projection
+            for claim_name in _EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS
+        ):
+            raise ValueError(
+                "linked evidence-pack projection cannot claim release readiness"
+            )
         projection_source = self._optional_string_from_mapping(
             projection,
             "projection_source",
@@ -1283,6 +1453,16 @@ class OperatorInspectionReadSurface:
             "source_id",
         ) != values["source_id"]:
             raise ValueError("linked evidence-pack projection provenance binding mismatch")
+        if self._optional_string_from_mapping(
+            provenance,
+            "authority_posture",
+        ) != _EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE:
+            raise ValueError("linked evidence-pack projection must stay subordinate")
+        if self._optional_string_from_mapping(
+            confidence,
+            "source_native_score_authority",
+        ) != "none":
+            raise ValueError("linked evidence-pack projection cannot carry workflow authority")
 
         return dict(projection)
 

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -59,7 +59,7 @@ _EVIDENCE_PACK_BOUNDED_ENRICHMENT_SOURCE_SYSTEM = "phase63_bounded_enrichment_ad
 _EVIDENCE_PACK_BOUNDED_ENRICHMENT_DERIVATION = "bounded_enrichment_projection"
 _EVIDENCE_PACK_BOUNDED_ENRICHMENT_ADAPTER = "phase63_bounded_enrichment_adapter"
 _EVIDENCE_PACK_ALLOWED_PROJECTION_LABELS = {
-    "consumer": frozenset({"case_workbench", "ai_grounding"}),
+    "consumer": frozenset({"case_workbench"}),
     "status": frozenset({"available", "degraded", "unavailable"}),
     "freshness_state": frozenset({"fresh", "stale"}),
     "custody_state": frozenset({"complete"}),
@@ -1306,6 +1306,15 @@ class OperatorInspectionReadSurface:
                 evidence_record,
                 "evidence_id",
             )
+            record_provenance = evidence_record.get("provenance")
+            record_custody_reference = (
+                self._optional_string_from_mapping(
+                    record_provenance,
+                    "custody_reference",
+                )
+                if isinstance(record_provenance, Mapping)
+                else None
+            )
             projection = self._linked_evidence_pack_projection_from_record(
                 evidence_record=evidence_record,
                 content=content,
@@ -1319,6 +1328,7 @@ class OperatorInspectionReadSurface:
                     projection=projection,
                     case_id=case_id,
                     evidence_record_id=evidence_record_id,
+                    record_custody_reference=record_custody_reference,
                 )
             )
         return tuple(projections)
@@ -1646,6 +1656,7 @@ class OperatorInspectionReadSurface:
         *,
         provenance: Mapping[str, object],
         custody: Mapping[str, object],
+        record_custody_reference: str | None,
     ) -> None:
         expected_values = {
             "target_binding": self._optional_string_from_mapping(
@@ -1664,6 +1675,7 @@ class OperatorInspectionReadSurface:
                 custody,
                 "response_digest",
             ),
+            "custody_reference": record_custody_reference,
         }
         if any(
             expected_value is None
@@ -1673,12 +1685,42 @@ class OperatorInspectionReadSurface:
         ):
             raise ValueError("linked evidence-pack projection provenance binding mismatch")
 
+    @staticmethod
+    def _is_sha256_hex(value: str | None) -> bool:
+        if value is None or len(value) != 64:
+            return False
+        return all(character in "0123456789abcdefABCDEF" for character in value)
+
+    @classmethod
+    def _is_sha256_digest(cls, value: str | None) -> bool:
+        if value is None or not value.startswith("sha256:"):
+            return False
+        return cls._is_sha256_hex(value.removeprefix("sha256:"))
+
+    def _validate_linked_evidence_pack_metadata_formats(
+        self,
+        *,
+        custody: Mapping[str, object],
+        provenance: Mapping[str, object],
+    ) -> None:
+        if not self._is_sha256_hex(
+            self._optional_string_from_mapping(custody, "reviewed_file_hash")
+        ) or not self._is_sha256_digest(
+            self._optional_string_from_mapping(custody, "response_digest")
+        ):
+            raise ValueError(
+                "linked evidence-pack projection has invalid evidence-pack metadata"
+            )
+        self._datetime_from_evidence_pack_content(custody, "collection_timestamp")
+        self._datetime_from_evidence_pack_content(provenance, "collection_timestamp")
+
     def _validated_linked_evidence_pack_projection(
         self,
         *,
         projection: Mapping[str, object],
         case_id: str,
         evidence_record_id: str | None,
+        record_custody_reference: str | None,
     ) -> dict[str, object]:
         values = {
             field_name: self._optional_string_from_mapping(projection, field_name)
@@ -1790,6 +1832,11 @@ class OperatorInspectionReadSurface:
         self._validate_linked_evidence_pack_provenance_bindings(
             provenance=provenance,
             custody=custody,
+            record_custody_reference=record_custody_reference,
+        )
+        self._validate_linked_evidence_pack_metadata_formats(
+            custody=custody,
+            provenance=provenance,
         )
         if self._optional_string_from_mapping(
             provenance,

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -35,6 +35,24 @@ _QUEUE_LANES = (
     "clean",
 )
 
+_EVIDENCE_PACK_PROJECTION_CONTENT_KEY = "evidence_pack_projection"
+_EVIDENCE_PACK_PROJECTION_REQUIRED_STRINGS = (
+    "evidence_request_id",
+    "case_id",
+    "source_id",
+    "consumer",
+    "status",
+    "freshness_state",
+    "custody_state",
+    "confidence_state",
+    "provenance_state",
+    "conflict_state",
+    "source_state",
+    "uncertainty_label",
+    "authority_posture",
+    "workflow_authority",
+)
+
 
 class InspectionStore(Protocol):
     def get(self, record_type: Type[RecordT], record_id: str) -> RecordT | None:
@@ -1132,6 +1150,10 @@ class OperatorInspectionReadSurface:
             linked_alert_records=context_snapshot.linked_alert_records,
             linked_evidence_records=context_snapshot.linked_evidence_records,
         )
+        linked_evidence_packs = self._build_linked_evidence_pack_projections(
+            case_id=case_id,
+            linked_evidence_records=context_snapshot.linked_evidence_records,
+        )
         return self._case_detail_snapshot_factory(
             read_only=True,
             case_id=case_id,
@@ -1150,6 +1172,7 @@ class OperatorInspectionReadSurface:
             linked_observation_records=observation_records,
             linked_lead_records=lead_records,
             linked_evidence_records=context_snapshot.linked_evidence_records,
+            linked_evidence_packs=linked_evidence_packs,
             linked_recommendation_records=context_snapshot.linked_recommendation_records,
             linked_reconciliation_records=context_snapshot.linked_reconciliation_records,
             lifecycle_transitions=context_snapshot.lifecycle_transitions,
@@ -1163,6 +1186,74 @@ class OperatorInspectionReadSurface:
                 linked_alert_records=context_snapshot.linked_alert_records,
             ),
         )
+
+    def _build_linked_evidence_pack_projections(
+        self,
+        *,
+        case_id: str,
+        linked_evidence_records: tuple[dict[str, object], ...],
+    ) -> tuple[dict[str, object], ...]:
+        projections: list[dict[str, object]] = []
+        for evidence_record in linked_evidence_records:
+            content = evidence_record.get("content")
+            if not isinstance(content, Mapping):
+                continue
+            projection = content.get(_EVIDENCE_PACK_PROJECTION_CONTENT_KEY)
+            if projection is None:
+                continue
+            if not isinstance(projection, Mapping):
+                raise ValueError("linked evidence-pack projection must be a mapping")
+            projections.append(
+                self._validated_linked_evidence_pack_projection(
+                    projection=projection,
+                    case_id=case_id,
+                )
+            )
+        return tuple(projections)
+
+    def _validated_linked_evidence_pack_projection(
+        self,
+        *,
+        projection: Mapping[str, object],
+        case_id: str,
+    ) -> dict[str, object]:
+        values = {
+            field_name: self._optional_string_from_mapping(projection, field_name)
+            for field_name in _EVIDENCE_PACK_PROJECTION_REQUIRED_STRINGS
+        }
+        if any(value is None for value in values.values()):
+            raise ValueError("linked evidence-pack projection is missing required fields")
+        if values["case_id"] != case_id:
+            raise ValueError("linked evidence-pack projection case binding mismatch")
+        if projection.get("authoritative_workflow_truth") is not False:
+            raise ValueError("linked evidence-pack projection cannot carry workflow truth")
+        if values["workflow_authority"] != "none":
+            raise ValueError("linked evidence-pack projection cannot carry workflow authority")
+
+        custody = projection.get("custody")
+        provenance = projection.get("provenance")
+        confidence = projection.get("confidence")
+        if (
+            not isinstance(custody, Mapping)
+            or not isinstance(provenance, Mapping)
+            or not isinstance(confidence, Mapping)
+        ):
+            raise ValueError(
+                "linked evidence-pack projection requires custody, provenance, and confidence maps"
+            )
+        if self._optional_string_from_mapping(
+            provenance,
+            "request_binding",
+        ) != values["evidence_request_id"] or self._optional_string_from_mapping(
+            provenance,
+            "case_binding",
+        ) != case_id or self._optional_string_from_mapping(
+            provenance,
+            "source_id",
+        ) != values["source_id"]:
+            raise ValueError("linked evidence-pack projection provenance binding mismatch")
+
+        return dict(projection)
 
     def _build_case_timeline_projection(
         self,

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -53,6 +53,24 @@ _EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS = {
     "rc_readiness_claim",
     "gate_readiness_claim",
 }
+_EVIDENCE_PACK_ALLOWED_PROJECTION_LABELS = {
+    "consumer": frozenset({"case_workbench", "ai_grounding"}),
+    "status": frozenset({"available", "degraded", "unavailable"}),
+    "freshness_state": frozenset({"fresh", "stale"}),
+    "custody_state": frozenset({"complete"}),
+    "confidence_state": frozenset({"present"}),
+    "provenance_state": frozenset({"bound"}),
+    "conflict_state": frozenset({"conflicting", "none"}),
+    "source_state": frozenset({"available", "degraded", "unavailable"}),
+    "uncertainty_label": frozenset(
+        {
+            "related_entity_not_authoritative",
+            "stale_review_required",
+            "unresolved_conflict",
+            "source_unavailable",
+        }
+    ),
+}
 _EVIDENCE_PACK_PROJECTION_REQUIRED_STRINGS = (
     "evidence_request_id",
     "case_id",
@@ -1394,6 +1412,11 @@ class OperatorInspectionReadSurface:
         }
         if any(value is None for value in values.values()):
             raise ValueError("linked evidence-pack projection is missing required fields")
+        for field_name, allowed_values in _EVIDENCE_PACK_ALLOWED_PROJECTION_LABELS.items():
+            if values[field_name] not in allowed_values:
+                raise ValueError(
+                    "linked evidence-pack projection has unsupported evidence-pack projection label"
+                )
         if values["case_id"] != case_id:
             raise ValueError("linked evidence-pack projection case binding mismatch")
         if projection.get("authoritative_workflow_truth") is not False:

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Mapping, Protocol, Type, TypeVar
 from .evidence.bounded_enrichment_adapter import BoundedEnrichmentEvidencePack
 from .evidence.evidence_freshness_provenance_projection import (
     EvidenceFreshnessProvenanceProjectionInput,
+    _parse_duration_seconds,
     project_evidence_freshness_provenance,
 )
 from .evidence.evidence_source_registry import PHASE63_EVIDENCE_SOURCE_REGISTRY
@@ -1714,6 +1715,32 @@ class OperatorInspectionReadSurface:
         self._datetime_from_evidence_pack_content(custody, "collection_timestamp")
         self._datetime_from_evidence_pack_content(provenance, "collection_timestamp")
 
+    def _validate_linked_evidence_pack_freshness_window(
+        self,
+        *,
+        values: Mapping[str, str],
+        custody: Mapping[str, object],
+    ) -> None:
+        registry_entry = PHASE63_EVIDENCE_SOURCE_REGISTRY.get(values["source_id"])
+        if registry_entry is None:
+            raise ValueError(
+                "linked evidence-pack projection has unsupported evidence-pack projection source"
+            )
+        collection_timestamp = self._datetime_from_evidence_pack_content(
+            custody,
+            "collection_timestamp",
+        )
+        age_seconds = (
+            datetime.now(timezone.utc) - collection_timestamp.astimezone(timezone.utc)
+        ).total_seconds()
+        if age_seconds < 0:
+            raise ValueError("linked evidence-pack projection freshness window mismatch")
+        if (
+            values["freshness_state"] == "fresh"
+            and age_seconds > _parse_duration_seconds(registry_entry.freshness_window)
+        ):
+            raise ValueError("linked evidence-pack projection freshness window mismatch")
+
     def _validated_linked_evidence_pack_projection(
         self,
         *,
@@ -1837,6 +1864,10 @@ class OperatorInspectionReadSurface:
         self._validate_linked_evidence_pack_metadata_formats(
             custody=custody,
             provenance=provenance,
+        )
+        self._validate_linked_evidence_pack_freshness_window(
+            values=typed_values,
+            custody=custody,
         )
         if self._optional_string_from_mapping(
             provenance,

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -53,6 +53,7 @@ _EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS = {
     "rc_readiness_claim",
     "gate_readiness_claim",
 }
+_EVIDENCE_PACK_SUPPORTED_SOURCE_ID = "malwarebazaar_hash_reputation"
 _EVIDENCE_PACK_ALLOWED_PROJECTION_LABELS = {
     "consumer": frozenset({"case_workbench", "ai_grounding"}),
     "status": frozenset({"available", "degraded", "unavailable"}),
@@ -71,6 +72,19 @@ _EVIDENCE_PACK_ALLOWED_PROJECTION_LABELS = {
         }
     ),
 }
+_EVIDENCE_PACK_ALLOWED_DEGRADED_REASONS = frozenset(
+    {
+        "stale_reputation",
+        "conflicting_enrichment",
+        "source_stale",
+    }
+)
+_EVIDENCE_PACK_ALLOWED_UNAVAILABLE_REASONS = frozenset(
+    {
+        "source_denied",
+        "source_unavailable",
+    }
+)
 _EVIDENCE_PACK_PROJECTION_REQUIRED_STRINGS = (
     "evidence_request_id",
     "case_id",
@@ -86,6 +100,36 @@ _EVIDENCE_PACK_PROJECTION_REQUIRED_STRINGS = (
     "uncertainty_label",
     "authority_posture",
     "workflow_authority",
+)
+_EVIDENCE_PACK_REQUIRED_CUSTODY_FIELDS = frozenset(
+    {
+        "reviewed_file_hash",
+        "enrichment_request_id",
+        "collection_timestamp",
+        "response_digest",
+        "aegisops_evidence_record_id",
+    }
+)
+_EVIDENCE_PACK_REQUIRED_PROVENANCE_FIELDS = frozenset(
+    {
+        "request_binding",
+        "case_binding",
+        "target_binding",
+        "source_id",
+        "enrichment_request_id",
+        "collection_timestamp",
+        "response_digest",
+        "custody_reference",
+        "authority_posture",
+    }
+)
+_EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS = frozenset(
+    {
+        "posture",
+        "freshness",
+        "ambiguity_badge",
+        "source_native_score_authority",
+    }
 )
 
 
@@ -1399,6 +1443,44 @@ class OperatorInspectionReadSurface:
             )
         return parsed
 
+    def _required_metadata_map_fields(
+        self,
+        metadata: Mapping[str, object],
+        required_fields: frozenset[str],
+    ) -> None:
+        if frozenset(metadata) != required_fields:
+            raise ValueError(
+                "linked evidence-pack projection is missing required metadata fields"
+            )
+        if any(
+            self._optional_string_from_mapping(metadata, field_name) is None
+            for field_name in required_fields
+        ):
+            raise ValueError(
+                "linked evidence-pack projection is missing required metadata fields"
+            )
+
+    @staticmethod
+    def _projection_reason_tuple(
+        projection: Mapping[str, object],
+        key: str,
+    ) -> tuple[str, ...]:
+        value = projection.get(key)
+        if value is None:
+            return ()
+        if not isinstance(value, (tuple, list)):
+            raise ValueError(
+                "linked evidence-pack projection has unsupported evidence-pack projection reason"
+            )
+        reasons: list[str] = []
+        for item in value:
+            if not isinstance(item, str) or not item.strip():
+                raise ValueError(
+                    "linked evidence-pack projection has unsupported evidence-pack projection reason"
+                )
+            reasons.append(item.strip())
+        return tuple(reasons)
+
     def _validated_linked_evidence_pack_projection(
         self,
         *,
@@ -1417,12 +1499,36 @@ class OperatorInspectionReadSurface:
                 raise ValueError(
                     "linked evidence-pack projection has unsupported evidence-pack projection label"
                 )
+        if values["source_id"] != _EVIDENCE_PACK_SUPPORTED_SOURCE_ID:
+            raise ValueError(
+                "linked evidence-pack projection has unsupported evidence-pack projection source"
+            )
+        degraded_reasons = self._projection_reason_tuple(
+            projection,
+            "degraded_reasons",
+        )
+        unavailable_reasons = self._projection_reason_tuple(
+            projection,
+            "unavailable_reasons",
+        )
+        if any(
+            reason not in _EVIDENCE_PACK_ALLOWED_DEGRADED_REASONS
+            for reason in degraded_reasons
+        ) or any(
+            reason not in _EVIDENCE_PACK_ALLOWED_UNAVAILABLE_REASONS
+            for reason in unavailable_reasons
+        ):
+            raise ValueError(
+                "linked evidence-pack projection has unsupported evidence-pack projection reason"
+            )
         if values["case_id"] != case_id:
             raise ValueError("linked evidence-pack projection case binding mismatch")
         if projection.get("authoritative_workflow_truth") is not False:
             raise ValueError("linked evidence-pack projection cannot carry workflow truth")
         if values["workflow_authority"] != "none":
-            raise ValueError("linked evidence-pack projection cannot carry workflow authority")
+            raise ValueError(
+                "linked evidence-pack projection cannot carry workflow authority"
+            )
         if values["authority_posture"] != _EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE:
             raise ValueError("linked evidence-pack projection must stay subordinate")
         if projection.get("operator_visible") is not None and projection.get(
@@ -1460,6 +1566,18 @@ class OperatorInspectionReadSurface:
             raise ValueError(
                 "linked evidence-pack projection requires custody, provenance, and confidence maps"
             )
+        self._required_metadata_map_fields(
+            custody,
+            _EVIDENCE_PACK_REQUIRED_CUSTODY_FIELDS,
+        )
+        self._required_metadata_map_fields(
+            provenance,
+            _EVIDENCE_PACK_REQUIRED_PROVENANCE_FIELDS,
+        )
+        self._required_metadata_map_fields(
+            confidence,
+            _EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS,
+        )
         if evidence_record_id is None or self._optional_string_from_mapping(
             custody,
             "aegisops_evidence_record_id",

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -1481,6 +1481,130 @@ class OperatorInspectionReadSurface:
             reasons.append(item.strip())
         return tuple(reasons)
 
+    @staticmethod
+    def _linked_evidence_pack_expected_uncertainty_label(
+        *,
+        values: Mapping[str, str],
+        degraded_reasons: tuple[str, ...],
+        unavailable_reasons: tuple[str, ...],
+    ) -> str:
+        if values["status"] == "unavailable" or unavailable_reasons:
+            return "source_unavailable"
+        if "conflicting_enrichment" in degraded_reasons:
+            return "unresolved_conflict"
+        if (
+            values["freshness_state"] == "stale"
+            or "stale_reputation" in degraded_reasons
+            or "source_stale" in degraded_reasons
+        ):
+            return "stale_review_required"
+        return "related_entity_not_authoritative"
+
+    def _validate_linked_evidence_pack_reason_consistency(
+        self,
+        *,
+        values: Mapping[str, str],
+        degraded_reasons: tuple[str, ...],
+        unavailable_reasons: tuple[str, ...],
+        confidence: Mapping[str, object],
+    ) -> None:
+        if values["status"] == "available" and (
+            degraded_reasons or unavailable_reasons
+        ):
+            raise ValueError(
+                "linked evidence-pack projection has inconsistent evidence-pack projection reason"
+            )
+        if values["status"] == "degraded" and (
+            not degraded_reasons or unavailable_reasons
+        ):
+            raise ValueError(
+                "linked evidence-pack projection has inconsistent evidence-pack projection reason"
+            )
+        if values["status"] == "unavailable" and not unavailable_reasons:
+            raise ValueError(
+                "linked evidence-pack projection has inconsistent evidence-pack projection reason"
+            )
+        if (
+            "stale_reputation" in degraded_reasons
+        ) != (values["freshness_state"] == "stale"):
+            raise ValueError(
+                "linked evidence-pack projection has inconsistent evidence-pack projection reason"
+            )
+        expected_conflict_state = (
+            "conflicting" if "conflicting_enrichment" in degraded_reasons else "none"
+        )
+        if values["conflict_state"] != expected_conflict_state:
+            raise ValueError(
+                "linked evidence-pack projection has inconsistent evidence-pack projection reason"
+            )
+        expected_source_state = (
+            "unavailable"
+            if values["status"] == "unavailable" or unavailable_reasons
+            else "degraded"
+            if "source_stale" in degraded_reasons
+            else "available"
+        )
+        if values["source_state"] != expected_source_state:
+            raise ValueError(
+                "linked evidence-pack projection has inconsistent evidence-pack projection reason"
+            )
+        if values[
+            "uncertainty_label"
+        ] != self._linked_evidence_pack_expected_uncertainty_label(
+            values=values,
+            degraded_reasons=degraded_reasons,
+            unavailable_reasons=unavailable_reasons,
+        ):
+            raise ValueError(
+                "linked evidence-pack projection has inconsistent evidence-pack projection reason"
+            )
+        if self._optional_string_from_mapping(
+            confidence,
+            "freshness",
+        ) != values["freshness_state"] or self._optional_string_from_mapping(
+            confidence,
+            "ambiguity_badge",
+        ) != (
+            "unresolved"
+            if "conflicting_enrichment" in degraded_reasons
+            else "related-entity"
+        ):
+            raise ValueError(
+                "linked evidence-pack projection has inconsistent evidence-pack projection reason"
+            )
+
+    def _validate_linked_evidence_pack_provenance_bindings(
+        self,
+        *,
+        provenance: Mapping[str, object],
+        custody: Mapping[str, object],
+    ) -> None:
+        expected_values = {
+            "target_binding": self._optional_string_from_mapping(
+                custody,
+                "reviewed_file_hash",
+            ),
+            "enrichment_request_id": self._optional_string_from_mapping(
+                custody,
+                "enrichment_request_id",
+            ),
+            "collection_timestamp": self._optional_string_from_mapping(
+                custody,
+                "collection_timestamp",
+            ),
+            "response_digest": self._optional_string_from_mapping(
+                custody,
+                "response_digest",
+            ),
+        }
+        if any(
+            expected_value is None
+            or self._optional_string_from_mapping(provenance, field_name)
+            != expected_value
+            for field_name, expected_value in expected_values.items()
+        ):
+            raise ValueError("linked evidence-pack projection provenance binding mismatch")
+
     def _validated_linked_evidence_pack_projection(
         self,
         *,
@@ -1521,15 +1645,16 @@ class OperatorInspectionReadSurface:
             raise ValueError(
                 "linked evidence-pack projection has unsupported evidence-pack projection reason"
             )
-        if values["case_id"] != case_id:
+        typed_values = {key: value for key, value in values.items() if value is not None}
+        if typed_values["case_id"] != case_id:
             raise ValueError("linked evidence-pack projection case binding mismatch")
         if projection.get("authoritative_workflow_truth") is not False:
             raise ValueError("linked evidence-pack projection cannot carry workflow truth")
-        if values["workflow_authority"] != "none":
+        if typed_values["workflow_authority"] != "none":
             raise ValueError(
                 "linked evidence-pack projection cannot carry workflow authority"
             )
-        if values["authority_posture"] != _EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE:
+        if typed_values["authority_posture"] != _EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE:
             raise ValueError("linked evidence-pack projection must stay subordinate")
         if projection.get("operator_visible") is not None and projection.get(
             "operator_visible"
@@ -1586,14 +1711,18 @@ class OperatorInspectionReadSurface:
         if self._optional_string_from_mapping(
             provenance,
             "request_binding",
-        ) != values["evidence_request_id"] or self._optional_string_from_mapping(
+        ) != typed_values["evidence_request_id"] or self._optional_string_from_mapping(
             provenance,
             "case_binding",
         ) != case_id or self._optional_string_from_mapping(
             provenance,
             "source_id",
-        ) != values["source_id"]:
+        ) != typed_values["source_id"]:
             raise ValueError("linked evidence-pack projection provenance binding mismatch")
+        self._validate_linked_evidence_pack_provenance_bindings(
+            provenance=provenance,
+            custody=custody,
+        )
         if self._optional_string_from_mapping(
             provenance,
             "authority_posture",
@@ -1604,6 +1733,12 @@ class OperatorInspectionReadSurface:
             "source_native_score_authority",
         ) != "none":
             raise ValueError("linked evidence-pack projection cannot carry workflow authority")
+        self._validate_linked_evidence_pack_reason_consistency(
+            values=typed_values,
+            degraded_reasons=degraded_reasons,
+            unavailable_reasons=unavailable_reasons,
+            confidence=confidence,
+        )
 
         return dict(projection)
 

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -1763,9 +1763,13 @@ class OperatorInspectionReadSurface:
         ).total_seconds()
         if age_seconds < 0:
             raise ValueError("linked evidence-pack projection freshness window mismatch")
+        freshness_window_seconds = _parse_duration_seconds(registry_entry.freshness_window)
         if (
-            values["freshness_state"] == "fresh"
-            and age_seconds > _parse_duration_seconds(registry_entry.freshness_window)
+            (values["freshness_state"] == "fresh" and age_seconds > freshness_window_seconds)
+            or (
+                values["freshness_state"] == "stale"
+                and age_seconds <= freshness_window_seconds
+            )
         ):
             raise ValueError("linked evidence-pack projection freshness window mismatch")
 

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -36,6 +36,13 @@ _QUEUE_LANES = (
 )
 
 _EVIDENCE_PACK_PROJECTION_CONTENT_KEY = "evidence_pack_projection"
+_EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE = "subordinate_evidence_context_only"
+_EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES = {
+    "browser_state",
+    "browser_cache",
+    "ui_cache",
+    "cache",
+}
 _EVIDENCE_PACK_PROJECTION_REQUIRED_STRINGS = (
     "evidence_request_id",
     "case_id",
@@ -1207,6 +1214,10 @@ class OperatorInspectionReadSurface:
                 self._validated_linked_evidence_pack_projection(
                     projection=projection,
                     case_id=case_id,
+                    evidence_record_id=self._optional_string_from_mapping(
+                        evidence_record,
+                        "evidence_id",
+                    ),
                 )
             )
         return tuple(projections)
@@ -1216,6 +1227,7 @@ class OperatorInspectionReadSurface:
         *,
         projection: Mapping[str, object],
         case_id: str,
+        evidence_record_id: str | None,
     ) -> dict[str, object]:
         values = {
             field_name: self._optional_string_from_mapping(projection, field_name)
@@ -1229,6 +1241,20 @@ class OperatorInspectionReadSurface:
             raise ValueError("linked evidence-pack projection cannot carry workflow truth")
         if values["workflow_authority"] != "none":
             raise ValueError("linked evidence-pack projection cannot carry workflow authority")
+        if values["authority_posture"] != _EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE:
+            raise ValueError("linked evidence-pack projection must stay subordinate")
+        projection_source = self._optional_string_from_mapping(
+            projection,
+            "projection_source",
+        )
+        cache_sourced = projection.get("cache_sourced")
+        stale_cache = projection.get("stale_cache")
+        if (
+            (cache_sourced is not None and cache_sourced is not False)
+            or (stale_cache is not None and stale_cache is not False)
+            or projection_source in _EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES
+        ):
+            raise ValueError("linked evidence-pack projection cannot be cache sourced")
 
         custody = projection.get("custody")
         provenance = projection.get("provenance")
@@ -1241,6 +1267,11 @@ class OperatorInspectionReadSurface:
             raise ValueError(
                 "linked evidence-pack projection requires custody, provenance, and confidence maps"
             )
+        if evidence_record_id is None or self._optional_string_from_mapping(
+            custody,
+            "aegisops_evidence_record_id",
+        ) != evidence_record_id:
+            raise ValueError("linked evidence-pack projection custody binding mismatch")
         if self._optional_string_from_mapping(
             provenance,
             "request_binding",

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -1558,7 +1558,9 @@ class OperatorInspectionReadSurface:
     ) -> tuple[str, ...]:
         value = projection.get(key)
         if value is None:
-            return ()
+            raise ValueError(
+                "linked evidence-pack projection has unsupported evidence-pack projection reason"
+            )
         if not isinstance(value, (tuple, list)):
             raise ValueError(
                 "linked evidence-pack projection has unsupported evidence-pack projection reason"

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -1300,6 +1300,14 @@ class OperatorInspectionReadSurface:
     ) -> tuple[dict[str, object], ...]:
         projections: list[dict[str, object]] = []
         for evidence_record in linked_evidence_records:
+            if (
+                self._optional_string_from_mapping(
+                    evidence_record,
+                    "lifecycle_state",
+                )
+                != "validated"
+            ):
+                continue
             content = evidence_record.get("content")
             if not isinstance(content, Mapping):
                 continue
@@ -1342,6 +1350,12 @@ class OperatorInspectionReadSurface:
     ) -> Mapping[str, object] | None:
         projection = content.get(_EVIDENCE_PACK_PROJECTION_CONTENT_KEY)
         if projection is not None:
+            if not self._has_bounded_enrichment_producer_markers(
+                evidence_record=evidence_record,
+            ):
+                raise ValueError(
+                    "linked evidence-pack projection producer marker mismatch"
+                )
             if not isinstance(projection, Mapping):
                 raise ValueError("linked evidence-pack projection must be a mapping")
             return projection
@@ -1438,13 +1452,9 @@ class OperatorInspectionReadSurface:
             else None
         )
         return (
-            self._optional_string_from_mapping(evidence_record, "source_system")
-            == _EVIDENCE_PACK_BOUNDED_ENRICHMENT_SOURCE_SYSTEM
-            and self._optional_string_from_mapping(
-                evidence_record,
-                "derivation_relationship",
+            self._has_bounded_enrichment_producer_markers(
+                evidence_record=evidence_record,
             )
-            == _EVIDENCE_PACK_BOUNDED_ENRICHMENT_DERIVATION
             and content_adapter == _EVIDENCE_PACK_BOUNDED_ENRICHMENT_ADAPTER
             and all(
                 field_name in content
@@ -1460,6 +1470,21 @@ class OperatorInspectionReadSurface:
                     "content",
                 )
             )
+        )
+
+    def _has_bounded_enrichment_producer_markers(
+        self,
+        *,
+        evidence_record: Mapping[str, object],
+    ) -> bool:
+        return (
+            self._optional_string_from_mapping(evidence_record, "source_system")
+            == _EVIDENCE_PACK_BOUNDED_ENRICHMENT_SOURCE_SYSTEM
+            and self._optional_string_from_mapping(
+                evidence_record,
+                "derivation_relationship",
+            )
+            == _EVIDENCE_PACK_BOUNDED_ENRICHMENT_DERIVATION
         )
 
     @staticmethod
@@ -1687,8 +1712,8 @@ class OperatorInspectionReadSurface:
             raise ValueError("linked evidence-pack projection provenance binding mismatch")
 
     @staticmethod
-    def _is_sha256_hex(value: str | None) -> bool:
-        if value is None or len(value) != 64:
+    def _is_supported_reviewed_hash(value: str | None) -> bool:
+        if value is None or len(value) not in {32, 40, 64}:
             return False
         return all(character in "0123456789abcdefABCDEF" for character in value)
 
@@ -1696,7 +1721,10 @@ class OperatorInspectionReadSurface:
     def _is_sha256_digest(cls, value: str | None) -> bool:
         if value is None or not value.startswith("sha256:"):
             return False
-        return cls._is_sha256_hex(value.removeprefix("sha256:"))
+        digest = value.removeprefix("sha256:")
+        if len(digest) != 64:
+            return False
+        return all(character in "0123456789abcdefABCDEF" for character in digest)
 
     def _validate_linked_evidence_pack_metadata_formats(
         self,
@@ -1704,7 +1732,7 @@ class OperatorInspectionReadSurface:
         custody: Mapping[str, object],
         provenance: Mapping[str, object],
     ) -> None:
-        if not self._is_sha256_hex(
+        if not self._is_supported_reviewed_hash(
             self._optional_string_from_mapping(custody, "reviewed_file_hash")
         ) or not self._is_sha256_digest(
             self._optional_string_from_mapping(custody, "response_digest")

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -54,6 +54,9 @@ _EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS = {
     "gate_readiness_claim",
 }
 _EVIDENCE_PACK_SUPPORTED_SOURCE_ID = "malwarebazaar_hash_reputation"
+_EVIDENCE_PACK_BOUNDED_ENRICHMENT_SOURCE_SYSTEM = "phase63_bounded_enrichment_adapter"
+_EVIDENCE_PACK_BOUNDED_ENRICHMENT_DERIVATION = "bounded_enrichment_projection"
+_EVIDENCE_PACK_BOUNDED_ENRICHMENT_ADAPTER = "phase63_bounded_enrichment_adapter"
 _EVIDENCE_PACK_ALLOWED_PROJECTION_LABELS = {
     "consumer": frozenset({"case_workbench", "ai_grounding"}),
     "status": frozenset({"available", "degraded", "unavailable"}),
@@ -1281,9 +1284,9 @@ class OperatorInspectionReadSurface:
                 evidence_record,
                 "evidence_id",
             )
-            projection = self._linked_evidence_pack_projection_from_content(
+            projection = self._linked_evidence_pack_projection_from_record(
+                evidence_record=evidence_record,
                 content=content,
-                evidence_record_id=evidence_record_id,
             )
             if projection is None:
                 continue
@@ -1298,30 +1301,37 @@ class OperatorInspectionReadSurface:
             )
         return tuple(projections)
 
-    def _linked_evidence_pack_projection_from_content(
+    def _linked_evidence_pack_projection_from_record(
         self,
         *,
+        evidence_record: Mapping[str, object],
         content: Mapping[str, object],
-        evidence_record_id: str | None,
     ) -> Mapping[str, object] | None:
         projection = content.get(_EVIDENCE_PACK_PROJECTION_CONTENT_KEY)
         if projection is not None:
             if not isinstance(projection, Mapping):
                 raise ValueError("linked evidence-pack projection must be a mapping")
             return projection
-        if not self._looks_like_bounded_enrichment_pack(content):
+        if not self._is_bounded_enrichment_evidence_record(
+            evidence_record=evidence_record,
+            content=content,
+        ):
             return None
         return self._project_bounded_enrichment_evidence_pack(
             content=content,
-            evidence_record_id=evidence_record_id,
+            evidence_record=evidence_record,
         )
 
     def _project_bounded_enrichment_evidence_pack(
         self,
         *,
         content: Mapping[str, object],
-        evidence_record_id: str | None,
+        evidence_record: Mapping[str, object],
     ) -> Mapping[str, object]:
+        evidence_record_id = self._optional_string_from_mapping(
+            evidence_record,
+            "evidence_id",
+        )
         if evidence_record_id is None:
             raise ValueError("linked evidence-pack projection custody binding mismatch")
         looked_up_at = self._datetime_from_evidence_pack_content(
@@ -1331,8 +1341,11 @@ class OperatorInspectionReadSurface:
         provenance = content.get("provenance")
         if not isinstance(provenance, Mapping):
             raise ValueError("linked evidence-pack projection requires provenance map")
+        record_provenance = evidence_record.get("provenance")
+        if not isinstance(record_provenance, Mapping):
+            raise ValueError("linked evidence-pack projection requires provenance map")
         expected_custody_reference = self._optional_string_from_mapping(
-            provenance,
+            record_provenance,
             "custody_reference",
         )
         if expected_custody_reference is None:
@@ -1379,20 +1392,40 @@ class OperatorInspectionReadSurface:
         ).as_dict()
         return projection
 
-    @staticmethod
-    def _looks_like_bounded_enrichment_pack(content: Mapping[str, object]) -> bool:
-        return all(
-            field_name in content
-            for field_name in (
-                "evidence_request_id",
-                "case_id",
-                "source_id",
-                "file_hash",
-                "looked_up_at",
-                "custody",
-                "provenance",
-                "confidence",
-                "content",
+    def _is_bounded_enrichment_evidence_record(
+        self,
+        *,
+        evidence_record: Mapping[str, object],
+        content: Mapping[str, object],
+    ) -> bool:
+        content_payload = content.get("content")
+        content_adapter = (
+            self._optional_string_from_mapping(content_payload, "adapter")
+            if isinstance(content_payload, Mapping)
+            else None
+        )
+        return (
+            self._optional_string_from_mapping(evidence_record, "source_system")
+            == _EVIDENCE_PACK_BOUNDED_ENRICHMENT_SOURCE_SYSTEM
+            and self._optional_string_from_mapping(
+                evidence_record,
+                "derivation_relationship",
+            )
+            == _EVIDENCE_PACK_BOUNDED_ENRICHMENT_DERIVATION
+            and content_adapter == _EVIDENCE_PACK_BOUNDED_ENRICHMENT_ADAPTER
+            and all(
+                field_name in content
+                for field_name in (
+                    "evidence_request_id",
+                    "case_id",
+                    "source_id",
+                    "file_hash",
+                    "looked_up_at",
+                    "custody",
+                    "provenance",
+                    "confidence",
+                    "content",
+                )
             )
         )
 

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -9,6 +9,7 @@ from .evidence.evidence_freshness_provenance_projection import (
     EvidenceFreshnessProvenanceProjectionInput,
     project_evidence_freshness_provenance,
 )
+from .evidence.evidence_source_registry import PHASE63_EVIDENCE_SOURCE_REGISTRY
 from .models import (
     ActionExecutionRecord,
     ActionRequestRecord,
@@ -132,6 +133,27 @@ _EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS = frozenset(
         "freshness",
         "ambiguity_badge",
         "source_native_score_authority",
+    }
+)
+_EVIDENCE_PACK_PROJECTION_CONTRACT_FIELDS = frozenset(
+    {
+        *_EVIDENCE_PACK_PROJECTION_REQUIRED_STRINGS,
+        "degraded_reasons",
+        "unavailable_reasons",
+        "authoritative_workflow_truth",
+        "custody",
+        "provenance",
+        "confidence",
+    }
+)
+_EVIDENCE_PACK_PROJECTION_RECOGNIZED_FIELDS = frozenset(
+    {
+        *_EVIDENCE_PACK_PROJECTION_CONTRACT_FIELDS,
+        "cache_sourced",
+        "stale_cache",
+        "projection_source",
+        "operator_visible",
+        *_EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS,
     }
 )
 
@@ -1605,6 +1627,19 @@ class OperatorInspectionReadSurface:
             raise ValueError(
                 "linked evidence-pack projection has inconsistent evidence-pack projection reason"
             )
+        registry_entry = PHASE63_EVIDENCE_SOURCE_REGISTRY.get(values["source_id"])
+        if registry_entry is None:
+            raise ValueError(
+                "linked evidence-pack projection has unsupported evidence-pack projection source"
+            )
+        if "source_stale" in degraded_reasons and registry_entry.status != "degraded":
+            raise ValueError(
+                "linked evidence-pack projection source state reason mismatch"
+            )
+        if "source_denied" in unavailable_reasons and registry_entry.status != "disabled":
+            raise ValueError(
+                "linked evidence-pack projection source state reason mismatch"
+            )
 
     def _validate_linked_evidence_pack_provenance_bindings(
         self,
@@ -1766,6 +1801,16 @@ class OperatorInspectionReadSurface:
             "source_native_score_authority",
         ) != "none":
             raise ValueError("linked evidence-pack projection cannot carry workflow authority")
+        registry_entry = PHASE63_EVIDENCE_SOURCE_REGISTRY.get(typed_values["source_id"])
+        if registry_entry is None:
+            raise ValueError(
+                "linked evidence-pack projection has unsupported evidence-pack projection source"
+            )
+        if (
+            self._optional_string_from_mapping(confidence, "posture")
+            != registry_entry.confidence_posture
+        ):
+            raise ValueError("linked evidence-pack projection confidence posture mismatch")
         self._validate_linked_evidence_pack_reason_consistency(
             values=typed_values,
             degraded_reasons=degraded_reasons,
@@ -1773,7 +1818,22 @@ class OperatorInspectionReadSurface:
             confidence=confidence,
         )
 
-        return dict(projection)
+        missing_fields = _EVIDENCE_PACK_PROJECTION_CONTRACT_FIELDS - frozenset(
+            projection
+        )
+        if missing_fields:
+            raise ValueError("linked evidence-pack projection is missing required fields")
+        unexpected_fields = (
+            frozenset(projection) - _EVIDENCE_PACK_PROJECTION_RECOGNIZED_FIELDS
+        )
+        if unexpected_fields:
+            raise ValueError(
+                "linked evidence-pack projection has unexpected evidence-pack projection field"
+            )
+        return {
+            field_name: projection[field_name]
+            for field_name in _EVIDENCE_PACK_PROJECTION_CONTRACT_FIELDS
+        }
 
     def _build_case_timeline_projection(
         self,

--- a/control-plane/aegisops/control_plane/runtime/service_snapshots.py
+++ b/control-plane/aegisops/control_plane/runtime/service_snapshots.py
@@ -219,6 +219,7 @@ class CaseDetailSnapshot:
     linked_observation_records: tuple[dict[str, object], ...]
     linked_lead_records: tuple[dict[str, object], ...]
     linked_evidence_records: tuple[dict[str, object], ...]
+    linked_evidence_packs: tuple[dict[str, object], ...]
     linked_recommendation_records: tuple[dict[str, object], ...]
     linked_reconciliation_records: tuple[dict[str, object], ...]
     lifecycle_transitions: tuple[dict[str, object], ...]
@@ -247,6 +248,7 @@ class CaseDetailSnapshot:
                 "linked_observation_records": self.linked_observation_records,
                 "linked_lead_records": self.linked_lead_records,
                 "linked_evidence_records": self.linked_evidence_records,
+                "linked_evidence_packs": self.linked_evidence_packs,
                 "linked_recommendation_records": self.linked_recommendation_records,
                 "linked_reconciliation_records": self.linked_reconciliation_records,
                 "lifecycle_transitions": self.lifecycle_transitions,

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import pathlib
 import sys
 import unittest
@@ -10,6 +11,13 @@ if str(TESTS_ROOT) not in sys.path:
 
 from _cli_inspection_support import *  # noqa: F403
 from _cli_inspection_support import _approved_payload_binding_hash, _load_wazuh_fixture
+from aegisops.control_plane.evidence.bounded_enrichment_adapter import (
+    BoundedEnrichmentAdapter,
+    BoundedEnrichmentAdapterInput,
+)
+from aegisops.control_plane.evidence.reviewed_evidence_requests import (
+    ReviewedEvidenceRequestRecord,
+)
 
 
 class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
@@ -1172,6 +1180,84 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             },
         }
 
+    def _phase63_response_digest(self, response: dict[str, object]) -> str:
+        response_bytes = json.dumps(
+            response,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        return "sha256:" + hashlib.sha256(response_bytes).hexdigest()
+
+    def _phase63_bounded_enrichment_pack_content(
+        self,
+        *,
+        case_id: str,
+        evidence_record_id: str,
+        reviewed_at: datetime,
+        evidence_request_id: str = "evidence-request-enrichment-001",
+    ) -> dict[str, object]:
+        file_hash = "b" * 64
+        response = {
+            "query_status": "ok",
+            "sha256_hash": file_hash,
+            "signature": "example-family",
+            "first_seen": "2026-05-29T00:00:00Z",
+            "last_seen": "2026-05-30T00:00:00Z",
+        }
+        request = ReviewedEvidenceRequestRecord(
+            evidence_request_id=evidence_request_id,
+            case_id=case_id,
+            requester_identity="analyst-001",
+            requester_role="security_analyst",
+            target={
+                "target_class": "reviewed_file_hash",
+                "file_hash": file_hash,
+                "case_id": case_id,
+            },
+            source_id="malwarebazaar_hash_reputation",
+            requested_scope="bounded_read_only_hash_reputation",
+            custody={
+                "reviewed_by": "reviewer-001",
+                "custody_owner": "IT Operations, Information Systems Department",
+                "custody_reference": "custody-ref-enrichment-001",
+                "provenance_chain": "AegisOps evidence record custody",
+            },
+            authorization={
+                "authorized": True,
+                "reviewed_scope": "bounded_read_only_hash_reputation",
+                "decision_id": "approval-decision-001",
+            },
+            linked_case_context={
+                "case_id": case_id,
+                "admitting_evidence_id": evidence_record_id,
+                "reviewed_context_id": "reviewed-context-001",
+            },
+            requested_at=reviewed_at - timedelta(minutes=5),
+            expires_at=reviewed_at + timedelta(hours=2),
+            lifecycle_state="reviewed",
+            authority_posture=(
+                "aegisops_owned_workflow_context_subordinate_evidence_output"
+            ),
+        )
+        pack = BoundedEnrichmentAdapter().build_evidence_pack(
+            BoundedEnrichmentAdapterInput(
+                request=request,
+                file_hash=file_hash,
+                looked_up_at=reviewed_at,
+                response=response,
+                custody={
+                    "reviewed_file_hash": file_hash,
+                    "enrichment_request_id": "enrichment-request-001",
+                    "collection_timestamp": reviewed_at.isoformat(),
+                    "response_digest": self._phase63_response_digest(response),
+                    "aegisops_evidence_record_id": evidence_record_id,
+                },
+            ),
+            now=reviewed_at,
+        )
+        return pack.as_dict()
+
     def test_cli_case_detail_exposes_direct_linked_evidence_pack_projections(
         self,
     ) -> None:
@@ -1252,6 +1338,65 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
         self.assertFalse(linked_pack["authoritative_workflow_truth"])
         self.assertEqual(linked_pack["workflow_authority"], "none")
 
+    def test_cli_case_detail_projects_persisted_bounded_enrichment_pack(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        pack_content = self._phase63_bounded_enrichment_pack_content(
+            case_id=promoted_case.case_id,
+            evidence_record_id="evidence-enrichment-001",
+            reviewed_at=reviewed_at,
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-enrichment-001",
+                source_record_id="phase63://evidence-request-enrichment-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="phase63_bounded_enrichment_adapter",
+                collector_identity="case_workbench",
+                acquired_at=reviewed_at,
+                derivation_relationship="bounded_enrichment_projection",
+                lifecycle_state="validated",
+                provenance=pack_content["provenance"],
+                content=pack_content,
+            )
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            [
+                "inspect-case-detail",
+                "--case-id",
+                promoted_case.case_id,
+            ],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(len(payload["linked_evidence_packs"]), 1)
+        linked_pack = payload["linked_evidence_packs"][0]
+        self.assertEqual(
+            linked_pack["evidence_request_id"],
+            "evidence-request-enrichment-001",
+        )
+        self.assertEqual(linked_pack["case_id"], promoted_case.case_id)
+        self.assertEqual(
+            linked_pack["custody"]["aegisops_evidence_record_id"],
+            "evidence-enrichment-001",
+        )
+        self.assertEqual(
+            linked_pack["provenance"]["authority_posture"],
+            "subordinate_evidence_context_only",
+        )
+        self.assertEqual(
+            linked_pack["confidence"]["source_native_score_authority"],
+            "none",
+        )
+
     def test_cli_case_detail_rejects_malformed_linked_evidence_pack_projections(
         self,
     ) -> None:
@@ -1285,6 +1430,34 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                 {"projection_source": "browser_state"},
                 "cannot be cache sourced",
             ),
+            (
+                "hidden operator pack",
+                {"operator_visible": False},
+                "must stay operator visible",
+            ),
+            (
+                "release readiness claim",
+                {"release_readiness_claim": "rc_ready"},
+                "cannot claim release readiness",
+            ),
+            (
+                "nested provenance authority",
+                {
+                    "provenance": {
+                        "authority_posture": "authoritative_aegisops_record",
+                    },
+                },
+                "must stay subordinate",
+            ),
+            (
+                "nested confidence authority",
+                {
+                    "confidence": {
+                        "source_native_score_authority": "workflow_truth",
+                    },
+                },
+                "cannot carry workflow authority",
+            ),
         )
 
         for label, overrides, expected_message in cases:
@@ -1297,13 +1470,14 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                     evidence_record_id="evidence-enrichment-001",
                     reviewed_at=reviewed_at,
                 )
-                if "custody" in overrides:
-                    projection["custody"] = {
-                        **projection["custody"],
-                        **overrides["custody"],
-                    }
-                else:
-                    projection.update(overrides)
+                for field_name, override in overrides.items():
+                    if field_name in {"custody", "provenance", "confidence"}:
+                        projection[field_name] = {
+                            **projection[field_name],
+                            **override,
+                        }
+                    else:
+                        projection[field_name] = override
                 service.persist_record(
                     EvidenceRecord(
                         evidence_id="evidence-enrichment-001",

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -1147,8 +1147,8 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             "confidence_state": "present",
             "provenance_state": "bound",
             "conflict_state": "conflicting",
-            "source_state": "degraded",
-            "uncertainty_label": "stale_review_required",
+            "source_state": "available",
+            "uncertainty_label": "unresolved_conflict",
             "degraded_reasons": ["stale_reputation", "conflicting_enrichment"],
             "unavailable_reasons": [],
             "authority_posture": "subordinate_evidence_context_only",
@@ -1175,7 +1175,7 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             "confidence": {
                 "ambiguity_badge": "unresolved",
                 "freshness": "stale",
-                "posture": "subordinate",
+                "posture": "external_hash_reputation_subordinate_context",
                 "source_native_score_authority": "none",
             },
         }
@@ -1452,6 +1452,30 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                 "unsupported evidence-pack projection reason",
             ),
             (
+                "available status with degraded reason",
+                {"status": "available"},
+                "inconsistent evidence-pack projection reason",
+            ),
+            (
+                "degraded status without degraded reason",
+                {
+                    "degraded_reasons": [],
+                    "freshness_state": "fresh",
+                    "conflict_state": "none",
+                    "uncertainty_label": "related_entity_not_authoritative",
+                    "confidence": {
+                        "ambiguity_badge": "related-entity",
+                        "freshness": "fresh",
+                    },
+                },
+                "inconsistent evidence-pack projection reason",
+            ),
+            (
+                "stale state without stale reason",
+                {"degraded_reasons": ["conflicting_enrichment"]},
+                "inconsistent evidence-pack projection reason",
+            ),
+            (
                 "missing custody field",
                 {
                     "custody": {
@@ -1486,6 +1510,15 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                     },
                 },
                 "custody binding mismatch",
+            ),
+            (
+                "provenance target mismatch",
+                {
+                    "provenance": {
+                        "target_binding": "c" * 64,
+                    },
+                },
+                "provenance binding mismatch",
             ),
             (
                 "cache sourced",

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -1629,6 +1629,7 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
     ) -> None:
         expired_timestamp = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
         current_timestamp = datetime.now(timezone.utc).isoformat()
+        omit_field = object()
         cases = (
             (
                 "non-subordinate posture",
@@ -1683,6 +1684,16 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             (
                 "unsupported unavailable reason",
                 {"unavailable_reasons": ["approval_truth"]},
+                "unsupported evidence-pack projection reason",
+            ),
+            (
+                "missing degraded reason array",
+                {"degraded_reasons": omit_field},
+                "unsupported evidence-pack projection reason",
+            ),
+            (
+                "null unavailable reason array",
+                {"unavailable_reasons": None},
                 "unsupported evidence-pack projection reason",
             ),
             (
@@ -1956,7 +1967,9 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                     reviewed_at=reviewed_at,
                 )
                 for field_name, override in overrides.items():
-                    if field_name in {"custody", "provenance", "confidence"}:
+                    if override is omit_field:
+                        projection.pop(field_name, None)
+                    elif field_name in {"custody", "provenance", "confidence"}:
                         projection[field_name] = {
                             **projection[field_name],
                             **override,

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -1397,6 +1397,89 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             "none",
         )
 
+    def test_cli_case_detail_ignores_unmarked_evidence_pack_lookalikes(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-lookalike-001",
+                source_record_id="phase63://lookalike",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="external_evidence_archive",
+                collector_identity="case_workbench",
+                acquired_at=reviewed_at,
+                derivation_relationship="related_evidence_context",
+                lifecycle_state="validated",
+                provenance={},
+                content={
+                    "evidence_request_id": "evidence-request-lookalike-001",
+                    "case_id": promoted_case.case_id,
+                    "source_id": "malwarebazaar_hash_reputation",
+                    "file_hash": "b" * 64,
+                    "looked_up_at": reviewed_at.isoformat(),
+                    "custody": {},
+                    "provenance": {},
+                    "confidence": {},
+                    "content": {},
+                },
+            )
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            [
+                "inspect-case-detail",
+                "--case-id",
+                promoted_case.case_id,
+            ],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["linked_evidence_packs"], [])
+
+    def test_cli_case_detail_rejects_raw_pack_with_tampered_custody_reference(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        pack_content = self._phase63_bounded_enrichment_pack_content(
+            case_id=promoted_case.case_id,
+            evidence_record_id="evidence-enrichment-001",
+            reviewed_at=reviewed_at,
+        )
+        tampered_pack_content = {
+            **pack_content,
+            "provenance": {
+                **pack_content["provenance"],
+                "custody_reference": "custody-ref-tampered",
+            },
+        }
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-enrichment-001",
+                source_record_id="phase63://evidence-request-enrichment-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="phase63_bounded_enrichment_adapter",
+                collector_identity="case_workbench",
+                acquired_at=reviewed_at,
+                derivation_relationship="bounded_enrichment_projection",
+                lifecycle_state="validated",
+                provenance=pack_content["provenance"],
+                content=tampered_pack_content,
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "provenance_binding_mismatch"):
+            service.inspect_case_detail(promoted_case.case_id).to_dict()
+
     def test_cli_case_detail_rejects_malformed_linked_evidence_pack_projections(
         self,
     ) -> None:

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -1521,6 +1521,7 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
     def test_cli_case_detail_rejects_malformed_linked_evidence_pack_projections(
         self,
     ) -> None:
+        expired_timestamp = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
         cases = (
             (
                 "non-subordinate posture",
@@ -1765,6 +1766,29 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                     },
                 },
                 "source state reason mismatch",
+            ),
+            (
+                "fresh direct projection outside registry freshness window",
+                {
+                    "status": "available",
+                    "degraded_reasons": [],
+                    "unavailable_reasons": [],
+                    "freshness_state": "fresh",
+                    "conflict_state": "none",
+                    "source_state": "available",
+                    "uncertainty_label": "related_entity_not_authoritative",
+                    "custody": {
+                        "collection_timestamp": expired_timestamp,
+                    },
+                    "provenance": {
+                        "collection_timestamp": expired_timestamp,
+                    },
+                    "confidence": {
+                        "ambiguity_badge": "related-entity",
+                        "freshness": "fresh",
+                    },
+                },
+                "freshness window",
             ),
             (
                 "unrecognized workflow truth field",

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -1480,6 +1480,44 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
         with self.assertRaisesRegex(ValueError, "provenance_binding_mismatch"):
             service.inspect_case_detail(promoted_case.case_id).to_dict()
 
+    def test_cli_case_detail_rejects_direct_pack_with_tampered_record_custody_reference(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        projection = self._phase63_evidence_pack_projection(
+            case_id=promoted_case.case_id,
+            evidence_record_id="evidence-enrichment-001",
+            reviewed_at=reviewed_at,
+        )
+        record_provenance = projection["provenance"]
+        projection = {
+            **projection,
+            "provenance": {
+                **projection["provenance"],
+                "custody_reference": "custody-ref-tampered",
+            },
+        }
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-enrichment-001",
+                source_record_id="phase63://evidence-request-enrichment-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="phase63_bounded_enrichment_adapter",
+                collector_identity="case_workbench",
+                acquired_at=reviewed_at,
+                derivation_relationship="bounded_enrichment_projection",
+                lifecycle_state="validated",
+                provenance=record_provenance,
+                content={"evidence_pack_projection": projection},
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "provenance binding mismatch"):
+            service.inspect_case_detail(promoted_case.case_id).to_dict()
+
     def test_cli_case_detail_rejects_malformed_linked_evidence_pack_projections(
         self,
     ) -> None:
@@ -1488,6 +1526,11 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                 "non-subordinate posture",
                 {"authority_posture": "authoritative_aegisops_record"},
                 "must stay subordinate",
+            ),
+            (
+                "unsupported case detail consumer",
+                {"consumer": "ai_grounding"},
+                "unsupported evidence-pack projection label",
             ),
             (
                 "unsupported status label",
@@ -1602,6 +1645,42 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                     },
                 },
                 "provenance binding mismatch",
+            ),
+            (
+                "invalid reviewed file hash",
+                {
+                    "custody": {
+                        "reviewed_file_hash": "not-a-hash",
+                    },
+                    "provenance": {
+                        "target_binding": "not-a-hash",
+                    },
+                },
+                "invalid evidence-pack metadata",
+            ),
+            (
+                "invalid response digest",
+                {
+                    "custody": {
+                        "response_digest": "not-a-digest",
+                    },
+                    "provenance": {
+                        "response_digest": "not-a-digest",
+                    },
+                },
+                "invalid evidence-pack metadata",
+            ),
+            (
+                "non-aware collection timestamp",
+                {
+                    "custody": {
+                        "collection_timestamp": "2026-05-30T00:00:00",
+                    },
+                    "provenance": {
+                        "collection_timestamp": "2026-05-30T00:00:00",
+                    },
+                },
+                "timezone-aware timestamps",
             ),
             (
                 "cache sourced",

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -1137,6 +1137,7 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
         evidence_request_id: str = "evidence-request-enrichment-001",
         file_hash: str = "b" * 64,
     ) -> dict[str, object]:
+        collection_timestamp = (reviewed_at - timedelta(days=2)).isoformat()
         return {
             "evidence_request_id": evidence_request_id,
             "case_id": case_id,
@@ -1157,7 +1158,7 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             "workflow_authority": "none",
             "custody": {
                 "aegisops_evidence_record_id": evidence_record_id,
-                "collection_timestamp": reviewed_at.isoformat(),
+                "collection_timestamp": collection_timestamp,
                 "enrichment_request_id": "enrichment-request-001",
                 "response_digest": "sha256:" + "a" * 64,
                 "reviewed_file_hash": file_hash,
@@ -1165,7 +1166,7 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             "provenance": {
                 "authority_posture": "subordinate_evidence_context_only",
                 "case_binding": case_id,
-                "collection_timestamp": reviewed_at.isoformat(),
+                "collection_timestamp": collection_timestamp,
                 "custody_reference": "custody-ref-enrichment-001",
                 "enrichment_request_id": "enrichment-request-001",
                 "request_binding": evidence_request_id,
@@ -1627,6 +1628,7 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
         self,
     ) -> None:
         expired_timestamp = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+        current_timestamp = datetime.now(timezone.utc).isoformat()
         cases = (
             (
                 "non-subordinate posture",
@@ -1695,6 +1697,12 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                     "freshness_state": "fresh",
                     "conflict_state": "none",
                     "uncertainty_label": "related_entity_not_authoritative",
+                    "custody": {
+                        "collection_timestamp": current_timestamp,
+                    },
+                    "provenance": {
+                        "collection_timestamp": current_timestamp,
+                    },
                     "confidence": {
                         "ambiguity_badge": "related-entity",
                         "freshness": "fresh",
@@ -1848,6 +1856,12 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                     "conflict_state": "none",
                     "source_state": "degraded",
                     "uncertainty_label": "stale_review_required",
+                    "custody": {
+                        "collection_timestamp": current_timestamp,
+                    },
+                    "provenance": {
+                        "collection_timestamp": current_timestamp,
+                    },
                     "confidence": {
                         "ambiguity_badge": "related-entity",
                         "freshness": "fresh",
@@ -1865,6 +1879,12 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                     "conflict_state": "none",
                     "source_state": "unavailable",
                     "uncertainty_label": "source_unavailable",
+                    "custody": {
+                        "collection_timestamp": current_timestamp,
+                    },
+                    "provenance": {
+                        "collection_timestamp": current_timestamp,
+                    },
                     "confidence": {
                         "ambiguity_badge": "related-entity",
                         "freshness": "fresh",
@@ -1891,6 +1911,29 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                     "confidence": {
                         "ambiguity_badge": "related-entity",
                         "freshness": "fresh",
+                    },
+                },
+                "freshness window",
+            ),
+            (
+                "stale direct projection inside registry freshness window",
+                {
+                    "status": "degraded",
+                    "degraded_reasons": ["stale_reputation"],
+                    "unavailable_reasons": [],
+                    "freshness_state": "stale",
+                    "conflict_state": "none",
+                    "source_state": "available",
+                    "uncertainty_label": "stale_review_required",
+                    "custody": {
+                        "collection_timestamp": current_timestamp,
+                    },
+                    "provenance": {
+                        "collection_timestamp": current_timestamp,
+                    },
+                    "confidence": {
+                        "ambiguity_badge": "related-entity",
+                        "freshness": "stale",
                     },
                 },
                 "freshness window",

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -1432,6 +1432,53 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                 "unsupported evidence-pack projection label",
             ),
             (
+                "unsupported source id",
+                {
+                    "source_id": "workflow_gate",
+                    "provenance": {
+                        "source_id": "workflow_gate",
+                    },
+                },
+                "unsupported evidence-pack projection source",
+            ),
+            (
+                "unsupported degraded reason",
+                {"degraded_reasons": ["case_truth"]},
+                "unsupported evidence-pack projection reason",
+            ),
+            (
+                "unsupported unavailable reason",
+                {"unavailable_reasons": ["approval_truth"]},
+                "unsupported evidence-pack projection reason",
+            ),
+            (
+                "missing custody field",
+                {
+                    "custody": {
+                        "reviewed_file_hash": "",
+                    },
+                },
+                "missing required metadata fields",
+            ),
+            (
+                "missing provenance field",
+                {
+                    "provenance": {
+                        "custody_reference": "",
+                    },
+                },
+                "missing required metadata fields",
+            ),
+            (
+                "missing confidence field",
+                {
+                    "confidence": {
+                        "posture": "",
+                    },
+                },
+                "missing required metadata fields",
+            ),
+            (
                 "custody mismatch",
                 {
                     "custody": {

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -1135,6 +1135,7 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
         evidence_record_id: str,
         reviewed_at: datetime,
         evidence_request_id: str = "evidence-request-enrichment-001",
+        file_hash: str = "b" * 64,
     ) -> dict[str, object]:
         return {
             "evidence_request_id": evidence_request_id,
@@ -1159,7 +1160,7 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                 "collection_timestamp": reviewed_at.isoformat(),
                 "enrichment_request_id": "enrichment-request-001",
                 "response_digest": "sha256:" + "a" * 64,
-                "reviewed_file_hash": "b" * 64,
+                "reviewed_file_hash": file_hash,
             },
             "provenance": {
                 "authority_posture": "subordinate_evidence_context_only",
@@ -1170,7 +1171,7 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                 "request_binding": evidence_request_id,
                 "response_digest": "sha256:" + "a" * 64,
                 "source_id": "malwarebazaar_hash_reputation",
-                "target_binding": "b" * 64,
+                "target_binding": file_hash,
             },
             "confidence": {
                 "ambiguity_badge": "unresolved",
@@ -1338,6 +1339,49 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
         self.assertFalse(linked_pack["authoritative_workflow_truth"])
         self.assertEqual(linked_pack["workflow_authority"], "none")
 
+    def test_cli_case_detail_accepts_supported_direct_pack_hash_algorithms(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        for label, file_hash in (
+            ("md5", "b" * 32),
+            ("sha1", "c" * 40),
+        ):
+            with self.subTest(label=label):
+                projection = self._phase63_evidence_pack_projection(
+                    case_id=promoted_case.case_id,
+                    evidence_record_id=f"evidence-enrichment-{label}",
+                    reviewed_at=reviewed_at,
+                    evidence_request_id=f"evidence-request-enrichment-{label}",
+                    file_hash=file_hash,
+                )
+                service.persist_record(
+                    EvidenceRecord(
+                        evidence_id=f"evidence-enrichment-{label}",
+                        source_record_id=f"phase63://evidence-request-enrichment-{label}",
+                        alert_id=promoted_case.alert_id,
+                        case_id=promoted_case.case_id,
+                        source_system="phase63_bounded_enrichment_adapter",
+                        collector_identity="case_workbench",
+                        acquired_at=reviewed_at,
+                        derivation_relationship="bounded_enrichment_projection",
+                        lifecycle_state="validated",
+                        provenance=projection["provenance"],
+                        content={"evidence_pack_projection": projection},
+                    )
+                )
+
+        payload = service.inspect_case_detail(promoted_case.case_id).to_dict()
+
+        linked_hashes = {
+            pack["custody"]["reviewed_file_hash"]
+            for pack in payload["linked_evidence_packs"]
+        }
+        self.assertIn("b" * 32, linked_hashes)
+        self.assertIn("c" * 40, linked_hashes)
+
     def test_cli_case_detail_projects_persisted_bounded_enrichment_pack(
         self,
     ) -> None:
@@ -1441,6 +1485,67 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
         )
 
         payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["linked_evidence_packs"], [])
+
+    def test_cli_case_detail_rejects_direct_pack_without_producer_markers(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        projection = self._phase63_evidence_pack_projection(
+            case_id=promoted_case.case_id,
+            evidence_record_id="evidence-external-direct-001",
+            reviewed_at=reviewed_at,
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-external-direct-001",
+                source_record_id="external://evidence-request-enrichment-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="external_evidence_archive",
+                collector_identity="case_workbench",
+                acquired_at=reviewed_at,
+                derivation_relationship="related_evidence_context",
+                lifecycle_state="validated",
+                provenance=projection["provenance"],
+                content={"evidence_pack_projection": projection},
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "producer marker mismatch"):
+            service.inspect_case_detail(promoted_case.case_id).to_dict()
+
+    def test_cli_case_detail_skips_non_validated_evidence_pack_records(
+        self,
+    ) -> None:
+        _, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        projection = self._phase63_evidence_pack_projection(
+            case_id=promoted_case.case_id,
+            evidence_record_id="evidence-under-review-direct-001",
+            reviewed_at=reviewed_at,
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-under-review-direct-001",
+                source_record_id="phase63://evidence-request-enrichment-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="phase63_bounded_enrichment_adapter",
+                collector_identity="case_workbench",
+                acquired_at=reviewed_at,
+                derivation_relationship="bounded_enrichment_projection",
+                lifecycle_state="collected",
+                provenance=projection["provenance"],
+                content={"evidence_pack_projection": projection},
+            )
+        )
+
+        payload = service.inspect_case_detail(promoted_case.case_id).to_dict()
+
         self.assertEqual(payload["linked_evidence_packs"], [])
 
     def test_cli_case_detail_rejects_raw_pack_with_tampered_custody_reference(

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -1120,6 +1120,124 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             ["github_audit", "wazuh", "unknown"],
         )
 
+    def test_cli_case_detail_exposes_direct_linked_evidence_pack_projections(
+        self,
+    ) -> None:
+        store, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        projection = {
+            "evidence_request_id": "evidence-request-enrichment-001",
+            "case_id": promoted_case.case_id,
+            "source_id": "malwarebazaar_hash_reputation",
+            "consumer": "case_workbench",
+            "status": "degraded",
+            "freshness_state": "stale",
+            "custody_state": "complete",
+            "confidence_state": "present",
+            "provenance_state": "bound",
+            "conflict_state": "conflicting",
+            "source_state": "degraded",
+            "uncertainty_label": "stale_review_required",
+            "degraded_reasons": ["stale_reputation", "conflicting_enrichment"],
+            "unavailable_reasons": [],
+            "authority_posture": "subordinate_evidence_context_only",
+            "authoritative_workflow_truth": False,
+            "workflow_authority": "none",
+            "custody": {
+                "aegisops_evidence_record_id": "evidence-enrichment-001",
+                "collection_timestamp": reviewed_at.isoformat(),
+                "enrichment_request_id": "enrichment-request-001",
+                "response_digest": "sha256:" + "a" * 64,
+                "reviewed_file_hash": "b" * 64,
+            },
+            "provenance": {
+                "authority_posture": "subordinate_evidence_context_only",
+                "case_binding": promoted_case.case_id,
+                "collection_timestamp": reviewed_at.isoformat(),
+                "custody_reference": "custody-ref-enrichment-001",
+                "enrichment_request_id": "enrichment-request-001",
+                "request_binding": "evidence-request-enrichment-001",
+                "response_digest": "sha256:" + "a" * 64,
+                "source_id": "malwarebazaar_hash_reputation",
+                "target_binding": "b" * 64,
+            },
+            "confidence": {
+                "ambiguity_badge": "unresolved",
+                "freshness": "stale",
+                "posture": "subordinate",
+                "source_native_score_authority": "none",
+            },
+        }
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-enrichment-001",
+                source_record_id="phase63://evidence-request-enrichment-001",
+                alert_id=promoted_case.alert_id,
+                case_id=promoted_case.case_id,
+                source_system="phase63_bounded_enrichment_adapter",
+                collector_identity="case_workbench",
+                acquired_at=reviewed_at,
+                derivation_relationship="bounded_enrichment_projection",
+                lifecycle_state="validated",
+                provenance=projection["provenance"],
+                content={"evidence_pack_projection": projection},
+            )
+        )
+        service.persist_record(
+            EvidenceRecord(
+                evidence_id="evidence-sibling-enrichment-001",
+                source_record_id="phase63://evidence-request-sibling-001",
+                alert_id=None,
+                case_id="case-sibling",
+                source_system="phase63_bounded_enrichment_adapter",
+                collector_identity="case_workbench",
+                acquired_at=reviewed_at,
+                derivation_relationship="bounded_enrichment_projection",
+                lifecycle_state="validated",
+                provenance={},
+                content={
+                    "evidence_pack_projection": {
+                        **projection,
+                        "evidence_request_id": "evidence-request-sibling-001",
+                        "case_id": "case-sibling",
+                        "provenance": {
+                            **projection["provenance"],
+                            "request_binding": "evidence-request-sibling-001",
+                            "case_binding": "case-sibling",
+                        },
+                    }
+                },
+            )
+        )
+
+        stdout = io.StringIO()
+        main.main(
+            [
+                "inspect-case-detail",
+                "--case-id",
+                promoted_case.case_id,
+            ],
+            stdout=stdout,
+            service=service,
+        )
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(
+            [pack["evidence_request_id"] for pack in payload["linked_evidence_packs"]],
+            ["evidence-request-enrichment-001"],
+        )
+        linked_pack = payload["linked_evidence_packs"][0]
+        self.assertEqual(linked_pack["case_id"], promoted_case.case_id)
+        self.assertEqual(linked_pack["freshness_state"], "stale")
+        self.assertEqual(linked_pack["conflict_state"], "conflicting")
+        self.assertEqual(
+            linked_pack["provenance"]["custody_reference"],
+            "custody-ref-enrichment-001",
+        )
+        self.assertFalse(linked_pack["authoritative_workflow_truth"])
+        self.assertEqual(linked_pack["workflow_authority"], "none")
+
     def test_cli_records_bounded_operator_casework_actions(self) -> None:
         _, service, alert, evidence_id, reviewed_at = (
             self._build_phase19_in_scope_alert_without_case()

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -1407,6 +1407,31 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                 "must stay subordinate",
             ),
             (
+                "unsupported status label",
+                {"status": "rc_ready"},
+                "unsupported evidence-pack projection label",
+            ),
+            (
+                "unsupported freshness label",
+                {"freshness_state": "rc_ready"},
+                "unsupported evidence-pack projection label",
+            ),
+            (
+                "unsupported conflict label",
+                {"conflict_state": "ready_to_close"},
+                "unsupported evidence-pack projection label",
+            ),
+            (
+                "unsupported source label",
+                {"source_state": "ready_to_close"},
+                "unsupported evidence-pack projection label",
+            ),
+            (
+                "unsupported uncertainty label",
+                {"uncertainty_label": "case_truth"},
+                "unsupported evidence-pack projection label",
+            ),
+            (
                 "custody mismatch",
                 {
                     "custody": {

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -1646,6 +1646,52 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                 },
                 "cannot carry workflow authority",
             ),
+            (
+                "spoofed confidence posture",
+                {
+                    "confidence": {
+                        "posture": "workflow_truth_confidence",
+                    },
+                },
+                "confidence posture mismatch",
+            ),
+            (
+                "enabled source claims stale registry state",
+                {
+                    "degraded_reasons": ["source_stale"],
+                    "freshness_state": "fresh",
+                    "conflict_state": "none",
+                    "source_state": "degraded",
+                    "uncertainty_label": "stale_review_required",
+                    "confidence": {
+                        "ambiguity_badge": "related-entity",
+                        "freshness": "fresh",
+                    },
+                },
+                "source state reason mismatch",
+            ),
+            (
+                "enabled source claims denied registry state",
+                {
+                    "status": "unavailable",
+                    "degraded_reasons": [],
+                    "unavailable_reasons": ["source_denied"],
+                    "freshness_state": "fresh",
+                    "conflict_state": "none",
+                    "source_state": "unavailable",
+                    "uncertainty_label": "source_unavailable",
+                    "confidence": {
+                        "ambiguity_badge": "related-entity",
+                        "freshness": "fresh",
+                    },
+                },
+                "source state reason mismatch",
+            ),
+            (
+                "unrecognized workflow truth field",
+                {"can_complete_workflow": True},
+                "unexpected evidence-pack projection field",
+            ),
         )
 
         for label, overrides, expected_message in cases:

--- a/control-plane/tests/test_cli_inspection_workflow_family.py
+++ b/control-plane/tests/test_cli_inspection_workflow_family.py
@@ -1120,15 +1120,17 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             ["github_audit", "wazuh", "unknown"],
         )
 
-    def test_cli_case_detail_exposes_direct_linked_evidence_pack_projections(
+    def _phase63_evidence_pack_projection(
         self,
-    ) -> None:
-        store, service, promoted_case, _evidence_id, reviewed_at = (
-            self._build_phase19_in_scope_case()
-        )
-        projection = {
-            "evidence_request_id": "evidence-request-enrichment-001",
-            "case_id": promoted_case.case_id,
+        *,
+        case_id: str,
+        evidence_record_id: str,
+        reviewed_at: datetime,
+        evidence_request_id: str = "evidence-request-enrichment-001",
+    ) -> dict[str, object]:
+        return {
+            "evidence_request_id": evidence_request_id,
+            "case_id": case_id,
             "source_id": "malwarebazaar_hash_reputation",
             "consumer": "case_workbench",
             "status": "degraded",
@@ -1145,7 +1147,7 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             "authoritative_workflow_truth": False,
             "workflow_authority": "none",
             "custody": {
-                "aegisops_evidence_record_id": "evidence-enrichment-001",
+                "aegisops_evidence_record_id": evidence_record_id,
                 "collection_timestamp": reviewed_at.isoformat(),
                 "enrichment_request_id": "enrichment-request-001",
                 "response_digest": "sha256:" + "a" * 64,
@@ -1153,11 +1155,11 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
             },
             "provenance": {
                 "authority_posture": "subordinate_evidence_context_only",
-                "case_binding": promoted_case.case_id,
+                "case_binding": case_id,
                 "collection_timestamp": reviewed_at.isoformat(),
                 "custody_reference": "custody-ref-enrichment-001",
                 "enrichment_request_id": "enrichment-request-001",
-                "request_binding": "evidence-request-enrichment-001",
+                "request_binding": evidence_request_id,
                 "response_digest": "sha256:" + "a" * 64,
                 "source_id": "malwarebazaar_hash_reputation",
                 "target_binding": "b" * 64,
@@ -1169,6 +1171,18 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
                 "source_native_score_authority": "none",
             },
         }
+
+    def test_cli_case_detail_exposes_direct_linked_evidence_pack_projections(
+        self,
+    ) -> None:
+        store, service, promoted_case, _evidence_id, reviewed_at = (
+            self._build_phase19_in_scope_case()
+        )
+        projection = self._phase63_evidence_pack_projection(
+            case_id=promoted_case.case_id,
+            evidence_record_id="evidence-enrichment-001",
+            reviewed_at=reviewed_at,
+        )
         service.persist_record(
             EvidenceRecord(
                 evidence_id="evidence-enrichment-001",
@@ -1237,6 +1251,77 @@ class CliInspectionWorkflowFamilyTests(ControlPlaneCliInspectionTestBase):
         )
         self.assertFalse(linked_pack["authoritative_workflow_truth"])
         self.assertEqual(linked_pack["workflow_authority"], "none")
+
+    def test_cli_case_detail_rejects_malformed_linked_evidence_pack_projections(
+        self,
+    ) -> None:
+        cases = (
+            (
+                "non-subordinate posture",
+                {"authority_posture": "authoritative_aegisops_record"},
+                "must stay subordinate",
+            ),
+            (
+                "custody mismatch",
+                {
+                    "custody": {
+                        "aegisops_evidence_record_id": "evidence-other",
+                    },
+                },
+                "custody binding mismatch",
+            ),
+            (
+                "cache sourced",
+                {"cache_sourced": True},
+                "cannot be cache sourced",
+            ),
+            (
+                "stale cache",
+                {"stale_cache": True},
+                "cannot be cache sourced",
+            ),
+            (
+                "browser projection source",
+                {"projection_source": "browser_state"},
+                "cannot be cache sourced",
+            ),
+        )
+
+        for label, overrides, expected_message in cases:
+            with self.subTest(label=label):
+                _, service, promoted_case, _evidence_id, reviewed_at = (
+                    self._build_phase19_in_scope_case()
+                )
+                projection = self._phase63_evidence_pack_projection(
+                    case_id=promoted_case.case_id,
+                    evidence_record_id="evidence-enrichment-001",
+                    reviewed_at=reviewed_at,
+                )
+                if "custody" in overrides:
+                    projection["custody"] = {
+                        **projection["custody"],
+                        **overrides["custody"],
+                    }
+                else:
+                    projection.update(overrides)
+                service.persist_record(
+                    EvidenceRecord(
+                        evidence_id="evidence-enrichment-001",
+                        source_record_id="phase63://evidence-request-enrichment-001",
+                        alert_id=promoted_case.alert_id,
+                        case_id=promoted_case.case_id,
+                        source_system="phase63_bounded_enrichment_adapter",
+                        collector_identity="case_workbench",
+                        acquired_at=reviewed_at,
+                        derivation_relationship="bounded_enrichment_projection",
+                        lifecycle_state="validated",
+                        provenance=projection["provenance"],
+                        content={"evidence_pack_projection": projection},
+                    )
+                )
+
+                with self.assertRaisesRegex(ValueError, expected_message):
+                    service.inspect_case_detail(promoted_case.case_id).to_dict()
 
     def test_cli_records_bounded_operator_casework_actions(self) -> None:
         _, service, alert, evidence_id, reviewed_at = (

--- a/control-plane/tests/test_service_snapshot_extraction.py
+++ b/control-plane/tests/test_service_snapshot_extraction.py
@@ -80,6 +80,58 @@ class ServiceSnapshotExtractionTests(unittest.TestCase):
             },
         )
 
+    def test_case_detail_snapshot_serializes_linked_evidence_pack_projections(self) -> None:
+        from aegisops.control_plane.service import CaseDetailSnapshot
+
+        snapshot = CaseDetailSnapshot(
+            read_only=True,
+            case_id="case-1",
+            case_record={"case_id": "case-1"},
+            advisory_output={},
+            reviewed_context={},
+            linked_alert_ids=(),
+            linked_observation_ids=(),
+            linked_lead_ids=(),
+            linked_evidence_ids=("evidence-1",),
+            linked_recommendation_ids=(),
+            linked_reconciliation_ids=(),
+            linked_alert_records=(),
+            linked_observation_records=(),
+            linked_lead_records=(),
+            linked_evidence_records=(),
+            linked_evidence_packs=(
+                {
+                    "case_id": "case-1",
+                    "evidence_request_id": "evidence-request-1",
+                    "custody": {"aegisops_evidence_record_id": "evidence-1"},
+                    "provenance": {"request_binding": "evidence-request-1"},
+                },
+            ),
+            linked_recommendation_records=(),
+            linked_reconciliation_records=(),
+            lifecycle_transitions=(),
+            cross_source_timeline=(),
+            case_timeline_projection={},
+            provenance_summary={},
+            current_action_review=None,
+            action_reviews=(),
+            external_ticket_reference={},
+        )
+
+        payload = snapshot.to_dict()
+
+        self.assertEqual(
+            payload["linked_evidence_packs"],
+            [
+                {
+                    "case_id": "case-1",
+                    "evidence_request_id": "evidence-request-1",
+                    "custody": {"aegisops_evidence_record_id": "evidence-1"},
+                    "provenance": {"request_binding": "evidence-request-1"},
+                }
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add a case-detail evidence pack review table for linked backend evidence packs
- Fail closed on cache/browser-sourced evidence truth, missing custody/provenance labels, hidden stale/conflict labels, workflow authority, readiness claims, and role bypass
- Cover backend reread after case writes so edited UI evidence ids do not become evidence-pack truth

## Verification
- npm --prefix apps/operator-ui test -- evidence-pack
- npm --prefix apps/operator-ui test -- casework
- npm --prefix apps/operator-ui run typecheck
- npm --prefix apps/operator-ui run build
- node <codex-supervisor-root>/dist/index.js issue-lint 1337 --config <supervisor-config-path>
- git diff --check