### PR TITLE
Split case detail evidence-pack section

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx
@@ -8,6 +8,7 @@ import {
   createAuthorizedFetch,
   jsonResponse,
 } from "./OperatorRoutes.testSupport";
+import { EvidencePackReviewSection } from "./operatorConsolePages/caseDetailEvidencePackSection";
 
 const freshCollectionTimestamp = new Date().toISOString();
 const staleCollectionTimestamp = new Date(
@@ -146,6 +147,23 @@ const fullRouteTestTimeout = 15_000;
 describe("case detail evidence pack UI", () => {
   beforeEach(() => {
     resetOperatorQueryCacheForTests();
+  });
+
+  it("keeps evidence-pack rendering isolated behind the case-detail evidence-pack section", () => {
+    render(<EvidencePackReviewSection evidencePacks={[createEvidencePack()]} />);
+
+    const evidencePackTable = screen.getByRole("table", {
+      name: "Linked evidence packs",
+    });
+    const rows = within(evidencePackTable).getAllByRole("row").slice(1);
+
+    expect(rows).toHaveLength(1);
+    expect(
+      within(rows[0] as HTMLElement).getByText("evidence-request-001"),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[0] as HTMLElement).getByText("Subordinate evidence context only"),
+    ).toBeInTheDocument();
   });
 
   it("renders linked evidence pack custody, provenance, stale/conflict, freshness, confidence, uncertainty, and source state as subordinate context", async () => {

--- a/apps/operator-ui/src/app/operatorConsolePages/caseDetailEvidencePackSection.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/caseDetailEvidencePackSection.tsx
@@ -1,0 +1,154 @@
+import {
+  Chip,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import {
+  asRecord,
+  asString,
+  EmptyState,
+  formatValue,
+  SectionCard,
+  statusTone,
+  type UnknownRecord,
+} from "./shared";
+
+export function EvidencePackReviewSection({
+  evidencePacks,
+}: {
+  evidencePacks: UnknownRecord[];
+}) {
+  return (
+    <SectionCard
+      subtitle="Evidence packs show backend-reviewed freshness, custody, confidence, provenance, conflict, uncertainty, and source posture as subordinate review context only."
+      title="Evidence pack review"
+    >
+      {evidencePacks.length > 0 ? (
+        <Table aria-label="Linked evidence packs" size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Evidence pack</TableCell>
+              <TableCell>Source</TableCell>
+              <TableCell>Freshness</TableCell>
+              <TableCell>Confidence</TableCell>
+              <TableCell>Conflict</TableCell>
+              <TableCell>Uncertainty</TableCell>
+              <TableCell>Source state</TableCell>
+              <TableCell>Custody</TableCell>
+              <TableCell>Provenance</TableCell>
+              <TableCell>Boundary</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {evidencePacks.map((pack, index) => (
+              <EvidencePackReviewRow
+                key={`${asString(pack.evidence_request_id) ?? "evidence-pack"}-${index}`}
+                pack={pack}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      ) : (
+        <EmptyState message="No linked evidence packs were returned for this case." />
+      )}
+    </SectionCard>
+  );
+}
+
+function EvidencePackReviewRow({ pack }: { pack: UnknownRecord }) {
+  const freshnessState = asString(pack.freshness_state);
+  const conflictState = asString(pack.conflict_state);
+  const sourceState = asString(pack.source_state);
+  const custody = asRecord(pack.custody);
+  const provenance = asRecord(pack.provenance);
+
+  return (
+    <TableRow>
+      <TableCell>{formatValue(pack.evidence_request_id)}</TableCell>
+      <TableCell>{formatValue(pack.source_id)}</TableCell>
+      <TableCell>
+        <Chip
+          color={
+            freshnessState === "stale_review_required"
+              ? "warning"
+              : statusTone(freshnessState)
+          }
+          label={freshnessState ?? "unknown"}
+          size="small"
+          variant="outlined"
+        />
+      </TableCell>
+      <TableCell>{formatValue(pack.confidence_state)}</TableCell>
+      <TableCell>
+        <Chip
+          color={evidencePackConflictTone(conflictState)}
+          label={conflictState ?? "unknown"}
+          size="small"
+          variant="outlined"
+        />
+      </TableCell>
+      <TableCell>{formatValue(pack.uncertainty_label)}</TableCell>
+      <TableCell>
+        <Chip
+          color={evidencePackSourceTone(sourceState)}
+          label={sourceState ?? "unknown"}
+          size="small"
+          variant="outlined"
+        />
+      </TableCell>
+      <TableCell>
+        <Stack spacing={0.5}>
+          <Typography variant="body2">{formatValue(pack.custody_state)}</Typography>
+          <Typography color="text.secondary" variant="caption">
+            {formatValue(
+              custody?.aegisops_evidence_record_id ??
+                custody?.enrichment_request_id ??
+                custody?.collection_timestamp,
+            )}
+          </Typography>
+        </Stack>
+      </TableCell>
+      <TableCell>
+        <Stack spacing={0.5}>
+          <Typography variant="body2">{formatValue(pack.provenance_state)}</Typography>
+          <Typography color="text.secondary" variant="caption">
+            {formatValue(
+              provenance?.custody_reference ??
+                provenance?.request_binding ??
+                provenance?.source_id,
+            )}
+          </Typography>
+        </Stack>
+      </TableCell>
+      <TableCell>
+        <Typography color="text.secondary" variant="body2">
+          Subordinate evidence context only
+        </Typography>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function evidencePackConflictTone(
+  conflictState: string | null,
+): ReturnType<typeof statusTone> {
+  if (conflictState === "conflicting") {
+    return "warning";
+  }
+  return statusTone(conflictState);
+}
+
+function evidencePackSourceTone(sourceState: string | null): ReturnType<typeof statusTone> {
+  if (sourceState === "unavailable") {
+    return "error";
+  }
+  if (sourceState === "degraded") {
+    return "warning";
+  }
+  return statusTone(sourceState);
+}

--- a/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx
@@ -42,6 +42,7 @@ import {
   useOperatorRecord,
   ValueList,
 } from "./shared";
+import { EvidencePackReviewSection } from "./caseDetailEvidencePackSection";
 
 export function CaseDetailPageBody({
   caseId,
@@ -278,107 +279,7 @@ export function CaseDetailPageBody({
         )}
       </SectionCard>
 
-      <SectionCard
-        subtitle="Evidence packs show backend-reviewed freshness, custody, confidence, provenance, conflict, uncertainty, and source posture as subordinate review context only."
-        title="Evidence pack review"
-      >
-        {evidencePacks.length > 0 ? (
-          <Table aria-label="Linked evidence packs" size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>Evidence pack</TableCell>
-                <TableCell>Source</TableCell>
-                <TableCell>Freshness</TableCell>
-                <TableCell>Confidence</TableCell>
-                <TableCell>Conflict</TableCell>
-                <TableCell>Uncertainty</TableCell>
-                <TableCell>Source state</TableCell>
-                <TableCell>Custody</TableCell>
-                <TableCell>Provenance</TableCell>
-                <TableCell>Boundary</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {evidencePacks.map((pack, index) => {
-                const freshnessState = asString(pack.freshness_state);
-                const conflictState = asString(pack.conflict_state);
-                const sourceState = asString(pack.source_state);
-                const custody = asRecord(pack.custody);
-                const provenance = asRecord(pack.provenance);
-                const packId = asString(pack.evidence_request_id);
-
-                return (
-                  <TableRow key={`${packId ?? "evidence-pack"}-${index}`}>
-                    <TableCell>{formatValue(pack.evidence_request_id)}</TableCell>
-                    <TableCell>{formatValue(pack.source_id)}</TableCell>
-                    <TableCell>
-                      <Chip
-                        color={
-                          freshnessState === "stale_review_required"
-                            ? "warning"
-                            : statusTone(freshnessState)
-                        }
-                        label={freshnessState ?? "unknown"}
-                        size="small"
-                        variant="outlined"
-                      />
-                    </TableCell>
-                    <TableCell>{formatValue(pack.confidence_state)}</TableCell>
-                    <TableCell>
-                      <Chip
-                        color={evidencePackConflictTone(conflictState)}
-                        label={conflictState ?? "unknown"}
-                        size="small"
-                        variant="outlined"
-                      />
-                    </TableCell>
-                    <TableCell>{formatValue(pack.uncertainty_label)}</TableCell>
-                    <TableCell>
-                      <Chip
-                        color={evidencePackSourceTone(sourceState)}
-                        label={sourceState ?? "unknown"}
-                        size="small"
-                        variant="outlined"
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <Stack spacing={0.5}>
-                        <Typography variant="body2">{formatValue(pack.custody_state)}</Typography>
-                        <Typography color="text.secondary" variant="caption">
-                          {formatValue(
-                            custody?.aegisops_evidence_record_id ??
-                              custody?.enrichment_request_id ??
-                              custody?.collection_timestamp,
-                          )}
-                        </Typography>
-                      </Stack>
-                    </TableCell>
-                    <TableCell>
-                      <Stack spacing={0.5}>
-                        <Typography variant="body2">{formatValue(pack.provenance_state)}</Typography>
-                        <Typography color="text.secondary" variant="caption">
-                          {formatValue(
-                            provenance?.custody_reference ??
-                              provenance?.request_binding ??
-                              provenance?.source_id,
-                          )}
-                        </Typography>
-                      </Stack>
-                    </TableCell>
-                    <TableCell>
-                      <Typography color="text.secondary" variant="body2">
-                        Subordinate evidence context only
-                      </Typography>
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        ) : (
-          <EmptyState message="No linked evidence packs were returned for this case." />
-        )}
-      </SectionCard>
+      <EvidencePackReviewSection evidencePacks={evidencePacks} />
 
       <SectionCard
         subtitle="Subordinate alert, evidence, and reconciliation context stays visible but secondary to the authoritative case state."
@@ -497,23 +398,4 @@ export function CaseDetailPageBody({
 
 function readBackendLinkedEvidencePacks(data: UnknownRecord) {
   return asRecordArray(getPath(data, "linked_evidence_packs"));
-}
-
-function evidencePackConflictTone(
-  conflictState: string | null,
-): ReturnType<typeof statusTone> {
-  if (conflictState === "conflicting") {
-    return "warning";
-  }
-  return statusTone(conflictState);
-}
-
-function evidencePackSourceTone(sourceState: string | null): ReturnType<typeof statusTone> {
-  if (sourceState === "unavailable") {
-    return "error";
-  }
-  if (sourceState === "degraded") {
-    return "warning";
-  }
-  return statusTone(sourceState);
 }


### PR DESCRIPTION
## Summary
- Extract case detail evidence-pack review rendering into a focused EvidencePackReviewSection component.
- Keep the existing linked evidence pack table labels, ordering, subordinate-boundary text, and empty state.
- Add a focused component-boundary test while preserving the existing route-level fail-closed evidence-pack tests.

## Verification
- npm run test --workspace @aegisops/operator-ui -- OperatorRoutes.casework.evidence-pack.test.tsx
- npm run typecheck --workspace @aegisops/operator-ui
- bash scripts/verify-publishable-path-hygiene.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1351 --config <supervisor-config-path>
- git diff --check

Closes #1351