### PR TITLE
Close out Phase 63.R maintainability refactor

### DIFF
--- a/docs/phase-63-closeout-evaluation.md
+++ b/docs/phase-63-closeout-evaluation.md
@@ -168,3 +168,140 @@ Phase 66 can consume Phase 63 as one RC evidence input for Evidence Expansion v1
 Phase 66 or a separately reviewed support-bundle slice must still provide the support-bundle artifact and verifier evidence required by Phase 51.3 before any Pilot, Beta, RC, GA, or replacement-readiness gate can treat support evidence as satisfied.
 
 Phase 63 closeout is release and planning evidence only. It does not add endpoint remediation authority, source-native truth, AI authority, UI authority, browser authority, verifier authority, issue-lint authority, approval bypass, execution bypass, reconciliation bypass, Controlled Write, Hard Write, Phase 64 limitation ownership, Phase 65 upgrade work, Phase 66 RC proof, Phase 67 GA proof, or readiness and replacement claims.
+
+## Phase 63.R Maintainability Refactor Closeout Addendum
+
+- **Status**: Accepted as behavior-preserving maintainability refactor closeout evidence; Phase 63 Evidence Expansion v1 authority and readiness boundaries are unchanged.
+- **Date**: 2026-05-31
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1348, #1349, #1350, #1351, #1352, #1353, #1354
+
+Phase 63.R is accepted only as a maintainability refactor closeout that preserves Phase 63 evidence registry, evidence-pack projection, operator UI evidence-pack visibility, AI grounding, authority boundaries, and readiness limits.
+
+This addendum does not claim new product behavior, evidence-source breadth, workflow authority, AI authority, UI authority, verifier authority, issue-lint authority, Phase 66 RC proof, Beta, RC, GA, or commercial replacement readiness.
+
+### Phase 63.R Child Issue Outcomes
+
+| Issue | Scope | Outcome |
+| --- | --- | --- |
+| #1348 | Epic: Phase 63.R maintainability refactor | Closed by the ordered #1349 through #1354 evidence packet. |
+| #1349 | 63.R.1 Extract evidence pack inspection projection helper | Closed. Extracted `evidence_pack_projection.py` from `operator_inspection.py` while preserving case-detail evidence-pack projection behavior and subordinate evidence posture. |
+| #1350 | 63.R.2 Extract linked evidence pack validator | Closed. Extracted `linkedEvidencePackValidator.ts` and focused extraction tests while preserving backend-authoritative detail-reader validation and fail-closed UI data boundaries. |
+| #1351 | 63.R.3 Split case evidence pack review section | Closed. Extracted `caseDetailEvidencePackSection.tsx` while preserving rendered case-detail evidence-pack review behavior, route behavior, and subordinate UI posture. |
+| #1352 | 63.R.4 Decompose AI grounding adapter seams | Closed. Extracted AI grounding payload, prompt-validation, and validation helpers while preserving cited advisory grounding and no-authority behavior. |
+| #1353 | 63.R.5 Split evidence source registry catalogs | Closed. Extracted evidence source registry data and validation catalog helpers while preserving the bounded Phase 63 source registry and no-source-native-authority posture. |
+| #1354 | 63.R.6 Phase 63.R maintainability refactor closeout | Closed when this addendum, focused closeout verifier, hotspot verifier, path hygiene, focused backend/UI/AI tests, registry verifier, and issue-lint evidence pass. |
+
+### Phase 63.R Changed Files
+
+Phase 63.R materially added or tightened these repo-owned surfaces:
+
+- `control-plane/aegisops/control_plane/inspection/evidence_pack_projection.py`
+- `control-plane/aegisops/control_plane/operator_inspection.py`
+- `apps/operator-ui/src/operatorDataProvider/linkedEvidencePackValidator.ts`
+- `apps/operator-ui/src/operatorDataProvider/detailReaders.ts`
+- `apps/operator-ui/src/operatorDataProvider/detailReaders.evidence-pack-extraction.test.ts`
+- `apps/operator-ui/src/app/operatorConsolePages/caseDetailEvidencePackSection.tsx`
+- `apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx`
+- `control-plane/aegisops/control_plane/assistant/ai_grounding_payload.py`
+- `control-plane/aegisops/control_plane/assistant/ai_grounding_prompt_validation.py`
+- `control-plane/aegisops/control_plane/assistant/ai_grounding_validation.py`
+- `control-plane/aegisops/control_plane/assistant/ai_grounding_adapter.py`
+- `control-plane/aegisops/control_plane/evidence/evidence_source_registry_data.py`
+- `control-plane/aegisops/control_plane/evidence/evidence_source_validation_catalog.py`
+- `control-plane/aegisops/control_plane/evidence/evidence_source_registry.py`
+- `control-plane/tests/test_phase63_evidence_source_registry.py`
+- `docs/phase-63-1-evidence-source-registry-v1-validation.md`
+- `scripts/verify-phase-63-1-evidence-source-registry-v1.sh`
+- `docs/phase-63-closeout-evaluation.md`
+- `scripts/verify-phase-63-r-closeout-evaluation.sh`
+- `scripts/test-verify-phase-63-r-closeout-evaluation.sh`
+
+### Phase 63.R Behavior Preservation
+
+| Refactor seam | Original owner | Before Phase 63.R | Preserved Phase 63.R shape |
+| --- | --- | --- | --- |
+| Evidence-pack inspection projection | `operator_inspection.py` | Projection assembly lived in the operator inspection module. | Projection assembly lives in `evidence_pack_projection.py`; `operator_inspection.py` delegates while preserving case-detail output semantics. |
+| Linked evidence-pack validation | `detailReaders.ts` | Detail-reader validation and linked evidence-pack rules lived together. | Evidence-pack validation lives in `linkedEvidencePackValidator.ts`; `detailReaders.ts` remains the backend-detail reader boundary. |
+| Case evidence-pack UI section | `caseDetailSurfaces.tsx` | Evidence-pack review rendering lived inside the broader case detail surface. | Evidence-pack review rendering lives in `caseDetailEvidencePackSection.tsx`; the case detail surface composes it without changing route behavior. |
+| AI grounding adapter validation | `ai_grounding_adapter.py` | Payload shaping, prompt validation, and authority checks lived in one adapter module. | Payload, prompt-validation, and grounding-validation helpers are split while preserving cited advisory and no-authority checks. |
+| Evidence source registry catalogs | `evidence_source_registry.py` | Registry data and validation catalog rules lived with registry entrypoints. | Registry data and validation catalog helpers are split while preserving the bounded `osquery_host_state` and `malwarebazaar_hash_reputation` registry. |
+
+### Phase 63.R Measurements
+
+| Seam | Closeout measurement |
+| --- | --- |
+| Evidence-pack inspection projection | `evidence_pack_projection.py` is 781 lines after extraction; `operator_inspection.py` delegates to the helper and remains the operator inspection facade. |
+| Linked evidence-pack validation | `linkedEvidencePackValidator.ts` is 600 lines after extraction; `detailReaders.ts` is 661 lines and keeps the backend-detail reader boundary. |
+| Case evidence-pack UI section | `caseDetailEvidencePackSection.tsx` is 154 lines after extraction; `caseDetailSurfaces.tsx` is 401 lines and composes the section. |
+| AI grounding adapter validation | `ai_grounding_adapter.py` is 68 lines after extraction; helper modules carry payload, prompt-validation, and grounding-validation logic. |
+| Evidence source registry catalogs | `evidence_source_registry.py` is 392 lines after extraction; registry data and validation catalog helpers are split into focused modules. |
+
+### Phase 63.R Verification Evidence
+
+Focused backend, UI, AI, registry, path hygiene, and maintainability commands that must pass:
+
+- `python3 -m unittest control-plane.tests.test_phase63_5_evidence_freshness_provenance_projection`
+- `python3 -m unittest control-plane.tests.test_phase63_7_ai_grounding_adapter`
+- `python3 -m unittest control-plane.tests.test_phase63_evidence_source_registry`
+- `npm run test --workspace @aegisops/operator-ui -- detailReaders.evidence-pack-extraction.test.ts OperatorRoutes.casework.evidence-pack.test.tsx`
+- `npm run typecheck --workspace @aegisops/operator-ui`
+- `bash scripts/verify-phase-63-1-evidence-source-registry-v1.sh`
+- `bash scripts/verify-maintainability-hotspots.sh`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+- `bash scripts/verify-phase-63-r-closeout-evaluation.sh`
+- `bash scripts/test-verify-phase-63-r-closeout-evaluation.sh`
+
+Issue-lint evidence:
+
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1348 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1349 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1350 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1351 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1352 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1353 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1354 --config <supervisor-config-path>`
+
+Each Phase 63.R issue-lint command should report `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, and `high_risk_blocking_ambiguity=none`.
+
+The maintainability hotspot verifier remains unchanged and continues to report only the reviewed `service.py` baseline rather than hiding a new Phase 63.R hotspot.
+
+Observed closeout results from this branch:
+
+| Evidence class | Observed result |
+| --- | --- |
+| Backend projection, AI grounding, and registry unit tests | `python3 -m unittest control-plane.tests.test_phase63_5_evidence_freshness_provenance_projection control-plane.tests.test_phase63_7_ai_grounding_adapter control-plane.tests.test_phase63_evidence_source_registry` ran 119 tests and reported `OK`. |
+| Operator UI focused tests | `npm run test --workspace @aegisops/operator-ui -- detailReaders.evidence-pack-extraction.test.ts OperatorRoutes.casework.evidence-pack.test.tsx` reported 2 test files and 47 tests passed. |
+| Operator UI typecheck | `npm run typecheck --workspace @aegisops/operator-ui` completed `tsc --noEmit`. |
+| Registry verifier | `bash scripts/verify-phase-63-1-evidence-source-registry-v1.sh` ran 51 focused tests and reported the Phase 63.1 registry contract passes. |
+| Maintainability hotspot verifier | `bash scripts/verify-maintainability-hotspots.sh` reported the known `service.py` baseline only: 1379 lines, 1227 effective lines, 95 facade methods, and 7 signals. |
+| Publishable path hygiene | `bash scripts/verify-publishable-path-hygiene.sh` reported publishable tracked content does not contain workstation-local absolute paths. |
+| Closeout verifier | `bash scripts/verify-phase-63-r-closeout-evaluation.sh` reported Phase 63.R closeout evidence, behavior preservation, verifier evidence, authority limits, and handoff boundaries pass. |
+| Closeout verifier self-test | `bash scripts/test-verify-phase-63-r-closeout-evaluation.sh` reported Phase 63.R closeout evaluation verifier tests passed. |
+| Existing Phase 63 closeout verifier | `bash scripts/verify-phase-63-8-closeout-evaluation.sh` reported the Phase 63.8 closeout evaluation contract and focused negative checks pass after this addendum. |
+
+Observed issue-lint summary:
+
+| Issue | `execution_ready` | `missing_required` | `missing_recommended` | `metadata_errors` | `high_risk_blocking_ambiguity` |
+| --- | --- | --- | --- | --- | --- |
+| #1348 | yes | none | none | none | none |
+| #1349 | yes | none | none | none | none |
+| #1350 | yes | none | none | none | none |
+| #1351 | yes | none | none | none | none |
+| #1352 | yes | none | none | none | none |
+| #1353 | yes | none | none | none | none |
+| #1354 | yes | none | none | none | none |
+
+### Phase 63.R Accepted Limitations
+
+- Phase 63.R does not add product behavior, evidence-source breadth, new evidence collection, case truth, approval truth, execution truth, reconciliation truth, release truth, gate truth, readiness truth, AI authority, UI authority, browser authority, source-native authority, verifier authority, issue-lint authority, Controlled Write, or Hard Write.
+- Phase 63.R does not claim Phase 66 RC proof, Phase 67 GA proof, Beta readiness, RC readiness, GA readiness, self-service commercial readiness, or commercial replacement readiness.
+- Phase 63.R does not change support-bundle disposition, Phase 64 limitation ownership, Phase 65 upgrade work, Phase 66 RC gates, Phase 67 GA gates, production rollout posture, or replacement-readiness posture.
+- Phase 63.R verifier output, issue-lint output, docs text, extracted helpers, UI section modules, registries, and advisory grounding helpers remain review evidence only. They do not become AegisOps case, approval, execution, reconciliation, release, gate, readiness, or closeout truth.
+
+### Phase 64, Phase 65, And Phase 66 Handoff
+
+Phase 64, Phase 65, and Phase 66 may consume the split modules, focused extraction tests, registry verifier evidence, unchanged maintainability guard, and explicit non-expansion posture as reviewed maintainability evidence only.
+
+Future phases must still prove limitation ownership, upgrade work, RC evidence, support-bundle evidence, rollout operational hygiene, backup/restore evidence, SIEM/SOAR breadth, and real gate acceptance outside Phase 63.R.

--- a/scripts/test-verify-phase-63-r-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-63-r-closeout-evaluation.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-63-r-closeout-evaluation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+copy_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs"
+  cp "${repo_root}/docs/phase-63-closeout-evaluation.md" "${target}/docs/phase-63-closeout-evaluation.md"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_issue_repo="${workdir}/missing-issue"
+copy_valid_repo "${missing_issue_repo}"
+perl -0pi -e 's/\| #1352 \| 63\.R\.4 Decompose AI grounding adapter seams \| Closed\. Extracted AI grounding payload, prompt-validation, and validation helpers while preserving cited advisory grounding and no-authority behavior\. \|\n//' \
+  "${missing_issue_repo}/docs/phase-63-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_issue_repo}" \
+  "Missing Phase 63.R closeout evidence: | #1352 | 63.R.4 Decompose AI grounding adapter seams | Closed. Extracted AI grounding payload, prompt-validation, and validation helpers while preserving cited advisory grounding and no-authority behavior. |"
+
+missing_measurement_repo="${workdir}/missing-measurement"
+copy_valid_repo "${missing_measurement_repo}"
+perl -0pi -e 's/\| Evidence source registry catalogs \| `evidence_source_registry\.py` \| Registry data and validation catalog rules lived with registry entrypoints\. \| Registry data and validation catalog helpers are split while preserving the bounded `osquery_host_state` and `malwarebazaar_hash_reputation` registry\. \|\n//' \
+  "${missing_measurement_repo}/docs/phase-63-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_measurement_repo}" \
+  'Missing Phase 63.R closeout evidence: | Evidence source registry catalogs | `evidence_source_registry.py` | Registry data and validation catalog rules lived with registry entrypoints. | Registry data and validation catalog helpers are split while preserving the bounded `osquery_host_state` and `malwarebazaar_hash_reputation` registry. |'
+
+missing_issue_lint_repo="${workdir}/missing-issue-lint"
+copy_valid_repo "${missing_issue_lint_repo}"
+perl -0pi -e 's/`node <codex-supervisor-root>\/dist\/index\.js issue-lint 1354 --config <supervisor-config-path>`\n//' \
+  "${missing_issue_lint_repo}/docs/phase-63-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_issue_lint_repo}" \
+  "Missing Phase 63.R closeout evidence: \`node <codex-supervisor-root>/dist/index.js issue-lint 1354 --config <supervisor-config-path>\`"
+
+missing_authority_repo="${workdir}/missing-authority"
+copy_valid_repo "${missing_authority_repo}"
+perl -0pi -e 's/Phase 63\.R does not add product behavior, evidence-source breadth, new evidence collection, case truth, approval truth, execution truth, reconciliation truth, release truth, gate truth, readiness truth, AI authority, UI authority, browser authority, source-native authority, verifier authority, issue-lint authority, Controlled Write, or Hard Write\.//' \
+  "${missing_authority_repo}/docs/phase-63-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_authority_repo}" \
+  "Missing Phase 63.R closeout evidence: Phase 63.R does not add product behavior"
+
+missing_handoff_repo="${workdir}/missing-handoff"
+copy_valid_repo "${missing_handoff_repo}"
+perl -0pi -e 's/Phase 64, Phase 65, and Phase 66 may consume the split modules, focused extraction tests, registry verifier evidence, unchanged maintainability guard, and explicit non-expansion posture as reviewed maintainability evidence only\.//' \
+  "${missing_handoff_repo}/docs/phase-63-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_handoff_repo}" \
+  "Missing Phase 63.R closeout evidence: Phase 64, Phase 65, and Phase 66 may consume the split modules"
+
+forbidden_repo="${workdir}/forbidden"
+copy_valid_repo "${forbidden_repo}"
+printf '%s\n' "Phase 63.R proves RC readiness." >>"${forbidden_repo}/docs/phase-63-closeout-evaluation.md"
+assert_fails_with \
+  "${forbidden_repo}" \
+  "Forbidden Phase 63.R closeout evaluation claim: Phase 63.R proves RC readiness"
+
+baseline_hide_repo="${workdir}/baseline-hide"
+copy_valid_repo "${baseline_hide_repo}"
+printf '%s\n' "Maintainability baseline was raised to hide a new Phase 63.R hotspot" >>"${baseline_hide_repo}/docs/phase-63-closeout-evaluation.md"
+assert_fails_with \
+  "${baseline_hide_repo}" \
+  "Forbidden Phase 63.R closeout evaluation claim: Maintainability baseline was raised to hide a new Phase 63.R hotspot"
+
+absolute_path_repo="${workdir}/absolute-path"
+copy_valid_repo "${absolute_path_repo}"
+mac_home_prefix="/""Users/example"
+printf 'Run %s/Dev/codex-supervisor/dist/index.js.\n' "${mac_home_prefix}" >>"${absolute_path_repo}/docs/phase-63-closeout-evaluation.md"
+assert_fails_with \
+  "${absolute_path_repo}" \
+  "Forbidden Phase 63.R closeout evaluation: workstation-local absolute path detected"
+
+echo "Phase 63.R closeout evaluation verifier tests passed."

--- a/scripts/verify-phase-63-r-closeout-evaluation.sh
+++ b/scripts/verify-phase-63-r-closeout-evaluation.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+doc_path="docs/phase-63-closeout-evaluation.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+
+require_phrase() {
+  local phrase="$1"
+  local description="$2"
+
+  if ! grep -Fq -- "${phrase}" "${absolute_doc_path}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+if [[ ! -s "${absolute_doc_path}" ]]; then
+  echo "Missing Phase 63.R closeout evaluation: ${doc_path}" >&2
+  exit 1
+fi
+
+required_phrases=()
+while IFS= read -r phrase; do
+  required_phrases+=("${phrase}")
+done <<'EOF'
+## Phase 63.R Maintainability Refactor Closeout Addendum
+- **Status**: Accepted as behavior-preserving maintainability refactor closeout evidence; Phase 63 Evidence Expansion v1 authority and readiness boundaries are unchanged.
+- **Related Issues**: #1348, #1349, #1350, #1351, #1352, #1353, #1354
+Phase 63.R is accepted only as a maintainability refactor closeout that preserves Phase 63 evidence registry, evidence-pack projection, operator UI evidence-pack visibility, AI grounding, authority boundaries, and readiness limits.
+This addendum does not claim new product behavior, evidence-source breadth, workflow authority, AI authority, UI authority, verifier authority, issue-lint authority, Phase 66 RC proof, Beta, RC, GA, or commercial replacement readiness.
+| #1348 | Epic: Phase 63.R maintainability refactor | Closed by the ordered #1349 through #1354 evidence packet. |
+| #1349 | 63.R.1 Extract evidence pack inspection projection helper | Closed. Extracted `evidence_pack_projection.py` from `operator_inspection.py` while preserving case-detail evidence-pack projection behavior and subordinate evidence posture. |
+| #1350 | 63.R.2 Extract linked evidence pack validator | Closed. Extracted `linkedEvidencePackValidator.ts` and focused extraction tests while preserving backend-authoritative detail-reader validation and fail-closed UI data boundaries. |
+| #1351 | 63.R.3 Split case evidence pack review section | Closed. Extracted `caseDetailEvidencePackSection.tsx` while preserving rendered case-detail evidence-pack review behavior, route behavior, and subordinate UI posture. |
+| #1352 | 63.R.4 Decompose AI grounding adapter seams | Closed. Extracted AI grounding payload, prompt-validation, and validation helpers while preserving cited advisory grounding and no-authority behavior. |
+| #1353 | 63.R.5 Split evidence source registry catalogs | Closed. Extracted evidence source registry data and validation catalog helpers while preserving the bounded Phase 63 source registry and no-source-native-authority posture. |
+| #1354 | 63.R.6 Phase 63.R maintainability refactor closeout | Closed when this addendum, focused closeout verifier, hotspot verifier, path hygiene, focused backend/UI/AI tests, registry verifier, and issue-lint evidence pass. |
+`control-plane/aegisops/control_plane/inspection/evidence_pack_projection.py`
+`control-plane/aegisops/control_plane/operator_inspection.py`
+`apps/operator-ui/src/operatorDataProvider/linkedEvidencePackValidator.ts`
+`apps/operator-ui/src/operatorDataProvider/detailReaders.ts`
+`apps/operator-ui/src/operatorDataProvider/detailReaders.evidence-pack-extraction.test.ts`
+`apps/operator-ui/src/app/operatorConsolePages/caseDetailEvidencePackSection.tsx`
+`apps/operator-ui/src/app/operatorConsolePages/caseDetailSurfaces.tsx`
+`apps/operator-ui/src/app/OperatorRoutes.casework.evidence-pack.test.tsx`
+`control-plane/aegisops/control_plane/assistant/ai_grounding_payload.py`
+`control-plane/aegisops/control_plane/assistant/ai_grounding_prompt_validation.py`
+`control-plane/aegisops/control_plane/assistant/ai_grounding_validation.py`
+`control-plane/aegisops/control_plane/assistant/ai_grounding_adapter.py`
+`control-plane/aegisops/control_plane/evidence/evidence_source_registry_data.py`
+`control-plane/aegisops/control_plane/evidence/evidence_source_validation_catalog.py`
+`control-plane/aegisops/control_plane/evidence/evidence_source_registry.py`
+| Evidence-pack inspection projection | `operator_inspection.py` | Projection assembly lived in the operator inspection module. | Projection assembly lives in `evidence_pack_projection.py`; `operator_inspection.py` delegates while preserving case-detail output semantics. |
+| Linked evidence-pack validation | `detailReaders.ts` | Detail-reader validation and linked evidence-pack rules lived together. | Evidence-pack validation lives in `linkedEvidencePackValidator.ts`; `detailReaders.ts` remains the backend-detail reader boundary. |
+| Case evidence-pack UI section | `caseDetailSurfaces.tsx` | Evidence-pack review rendering lived inside the broader case detail surface. | Evidence-pack review rendering lives in `caseDetailEvidencePackSection.tsx`; the case detail surface composes it without changing route behavior. |
+| AI grounding adapter validation | `ai_grounding_adapter.py` | Payload shaping, prompt validation, and authority checks lived in one adapter module. | Payload, prompt-validation, and grounding-validation helpers are split while preserving cited advisory and no-authority checks. |
+| Evidence source registry catalogs | `evidence_source_registry.py` | Registry data and validation catalog rules lived with registry entrypoints. | Registry data and validation catalog helpers are split while preserving the bounded `osquery_host_state` and `malwarebazaar_hash_reputation` registry. |
+`python3 -m unittest control-plane.tests.test_phase63_5_evidence_freshness_provenance_projection`
+`python3 -m unittest control-plane.tests.test_phase63_7_ai_grounding_adapter`
+`python3 -m unittest control-plane.tests.test_phase63_evidence_source_registry`
+`npm run test --workspace @aegisops/operator-ui -- detailReaders.evidence-pack-extraction.test.ts OperatorRoutes.casework.evidence-pack.test.tsx`
+`npm run typecheck --workspace @aegisops/operator-ui`
+`bash scripts/verify-phase-63-1-evidence-source-registry-v1.sh`
+`bash scripts/verify-maintainability-hotspots.sh`
+`bash scripts/verify-publishable-path-hygiene.sh`
+`bash scripts/verify-phase-63-r-closeout-evaluation.sh`
+`bash scripts/test-verify-phase-63-r-closeout-evaluation.sh`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1348 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1349 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1350 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1351 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1352 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1353 --config <supervisor-config-path>`
+`node <codex-supervisor-root>/dist/index.js issue-lint 1354 --config <supervisor-config-path>`
+Each Phase 63.R issue-lint command should report `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, and `high_risk_blocking_ambiguity=none`.
+The maintainability hotspot verifier remains unchanged and continues to report only the reviewed `service.py` baseline rather than hiding a new Phase 63.R hotspot.
+Phase 63.R does not add product behavior, evidence-source breadth, new evidence collection, case truth, approval truth, execution truth, reconciliation truth, release truth, gate truth, readiness truth, AI authority, UI authority, browser authority, source-native authority, verifier authority, issue-lint authority, Controlled Write, or Hard Write.
+Phase 63.R does not claim Phase 66 RC proof, Phase 67 GA proof, Beta readiness, RC readiness, GA readiness, self-service commercial readiness, or commercial replacement readiness.
+Phase 64, Phase 65, and Phase 66 may consume the split modules, focused extraction tests, registry verifier evidence, unchanged maintainability guard, and explicit non-expansion posture as reviewed maintainability evidence only.
+Future phases must still prove limitation ownership, upgrade work, RC evidence, support-bundle evidence, rollout operational hygiene, backup/restore evidence, SIEM/SOAR breadth, and real gate acceptance outside Phase 63.R.
+EOF
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${phrase}" "Phase 63.R closeout evidence"
+done
+
+mac_home_prefix="$(printf '/%s/' 'Users')"
+unix_home_prefix="$(printf '/%s/' 'home')"
+windows_backslash_prefix="$(printf '[A-Za-z]:\\\\%s\\\\' 'Users')"
+windows_slash_prefix="$(printf '[A-Za-z]:/%s/' 'Users')"
+absolute_path_boundary='(^|[[:space:]`"'\''(<[{=])'
+absolute_path_pattern="${absolute_path_boundary}(${mac_home_prefix}|${unix_home_prefix}|${windows_backslash_prefix}|${windows_slash_prefix})[^ <\`]+"
+if grep -Eq -- "${absolute_path_pattern}" "${absolute_doc_path}"; then
+  echo "Forbidden Phase 63.R closeout evaluation: workstation-local absolute path detected" >&2
+  exit 1
+fi
+
+for forbidden in \
+  "Phase 63.R adds product behavior" \
+  "Phase 63.R expands evidence-source breadth" \
+  "Phase 63.R changes workflow authority" \
+  "Phase 63.R changes AI authority" \
+  "Phase 63.R changes UI authority" \
+  "Phase 63.R proves Beta readiness" \
+  "Phase 63.R proves RC readiness" \
+  "Phase 63.R proves GA readiness" \
+  "Phase 63.R proves commercial replacement readiness" \
+  "Phase 63.R implements Controlled Write" \
+  "Phase 63.R implements Hard Write" \
+  "Verifier output is Phase 63.R release truth" \
+  "Issue-lint output is Phase 63.R release truth" \
+  "Maintainability baseline was raised to hide a new Phase 63.R hotspot"; do
+  if grep -Fq -- "${forbidden}" "${absolute_doc_path}"; then
+    echo "Forbidden Phase 63.R closeout evaluation claim: ${forbidden}" >&2
+    exit 1
+  fi
+done
+
+echo "Phase 63.R closeout evaluation records refactor child outcomes, behavior preservation, verifier evidence, authority limits, and handoff boundaries."


### PR DESCRIPTION
## Summary
- adds the Phase 63.R maintainability refactor closeout addendum
- adds focused Phase 63.R closeout verifier and verifier self-test
- records child issue outcomes, verification evidence, issue-lint summary, and non-expansion boundaries

## Verification
- python3 -m unittest control-plane.tests.test_phase63_5_evidence_freshness_provenance_projection control-plane.tests.test_phase63_7_ai_grounding_adapter control-plane.tests.test_phase63_evidence_source_registry
- npm run test --workspace @aegisops/operator-ui -- detailReaders.evidence-pack-extraction.test.ts OperatorRoutes.casework.evidence-pack.test.tsx
- npm run typecheck --workspace @aegisops/operator-ui
- bash scripts/verify-phase-63-1-evidence-source-registry-v1.sh
- bash scripts/verify-maintainability-hotspots.sh
- bash scripts/verify-publishable-path-hygiene.sh
- bash scripts/verify-phase-63-r-closeout-evaluation.sh
- bash scripts/test-verify-phase-63-r-closeout-evaluation.sh
- bash scripts/verify-phase-63-8-closeout-evaluation.sh
- issue-lint 1348 through 1354