### PR TITLE
Add Phase 63 evidence-pack contract drift guard

### DIFF
--- a/control-plane/aegisops/control_plane/assistant/ai_grounding_validation.py
+++ b/control-plane/aegisops/control_plane/assistant/ai_grounding_validation.py
@@ -50,6 +50,11 @@ _NEGATIVE_AUTHORITY = (
     "readiness_truth",
     "workflow_truth",
 )
+_FORBIDDEN_READINESS_CLAIMS = (
+    "release_readiness_claim",
+    "rc_readiness_claim",
+    "gate_readiness_claim",
+)
 _REQUIRED_CUSTODY_FIELDS = (
     "reviewed_file_hash",
     "enrichment_request_id",
@@ -220,6 +225,8 @@ def _projection_reasons(
     else:
         reasons.extend(_grounding_source_reasons(source_id, projection))
     if projection.get("authoritative_workflow_truth") is not False:
+        reasons.append("grounding_authority_promotion_attempt")
+    if any(claim_name in projection for claim_name in _FORBIDDEN_READINESS_CLAIMS):
         reasons.append("grounding_authority_promotion_attempt")
     if projection.get("workflow_authority") != _NO_WORKFLOW_AUTHORITY:
         reasons.append("grounding_authority_promotion_attempt")

--- a/control-plane/tests/test_phase63_7_ai_grounding_adapter.py
+++ b/control-plane/tests/test_phase63_7_ai_grounding_adapter.py
@@ -1299,6 +1299,21 @@ class Phase637AIGroundingAdapterTests(unittest.TestCase):
         self.assertFalse(payload["ai_generation_allowed"])
         self.assertEqual(payload["grounding_items"], ())
 
+    def test_readiness_claims_in_grounding_projection_fail_closed(self) -> None:
+        projection = {
+            **_projection(),
+            "release_readiness_claim": "ready",
+        }
+
+        payload = build_ai_grounding_adapter(
+            grounding_context_payload=_grounding_payload(projections=(projection,))
+        )
+
+        self.assertEqual(payload["decision"], "fallback")
+        self.assertIn("grounding_authority_promotion_attempt", payload["unresolved_reasons"])
+        self.assertFalse(payload["ai_generation_allowed"])
+        self.assertEqual(payload["grounding_items"], ())
+
     def test_advertised_agent_and_tool_are_registered(self) -> None:
         with (REPO_ROOT / "docs/automation/ai-agent-registry.json").open() as stream:
             agent_registry = json.load(stream)

--- a/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
+++ b/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
@@ -25,6 +25,8 @@ from scripts.phase63_evidence_pack_contract_guard import (  # noqa: E402
     load_phase63_evidence_pack_contracts,
     _backend_no_workflow_authority_rejection,
     _backend_confidence_posture_rejection,
+    _py_backend_enforced_label_sets,
+    _py_backend_enforced_metadata_fields,
     _py_ai_state_reason_consistency_rules,
     _py_backend_state_reason_consistency_rules,
     _py_enforced_metadata_fields,
@@ -33,6 +35,7 @@ from scripts.phase63_evidence_pack_contract_guard import (  # noqa: E402
     _py_rejected_boolean_value,
     _AI_GROUNDING_SINGLETON_LABEL_FIELDS,
     _ts_enforced_freshness_window_milliseconds,
+    _ts_forbidden_projection_sources_rejection,
     _operator_ui_contract_from_source,
     _py_string_constant,
     _ts_forbidden_defined_pack_fields,
@@ -408,6 +411,49 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "metadata enforcement"):
             _operator_ui_contract_from_source(metadata_drift)
 
+    def test_operator_ui_source_authority_and_projection_source_checks_are_parsed(
+        self,
+    ) -> None:
+        source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+        contract = _operator_ui_contract_from_source(source)
+        self.assertEqual(
+            contract.supported_source_ids,
+            frozenset({"malwarebazaar_hash_reputation"}),
+        )
+        self.assertEqual(
+            contract.subordinate_authority_posture,
+            "subordinate_evidence_context_only",
+        )
+        self.assertEqual(
+            _ts_forbidden_projection_sources_rejection(source),
+            frozenset({"browser_state", "browser_cache", "ui_cache", "cache"}),
+        )
+
+        source_id_drift = source.replace(
+            "    if (sourceId !== EVIDENCE_PACK_SUPPORTED_SOURCE_ID) {\n"
+            "      throw new OperatorDataProviderContractError(\n"
+            "        `Resource cases linked_evidence_packs item ${evidenceRequestId} has an unsupported evidence-pack source.`,\n"
+            "      );\n"
+            "    }\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "source_id"):
+            _operator_ui_contract_from_source(source_id_drift)
+
+        authority_posture_drift = source.replace(
+            "      authorityPosture !== EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE ||\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "authority_posture"):
+            _operator_ui_contract_from_source(authority_posture_drift)
+
+        projection_source_drift = source.replace(
+            "      EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES.has(projectionSource ?? \"\")\n",
+            "      false\n",
+        )
+        with self.assertRaisesRegex(AssertionError, "projection-source"):
+            _operator_ui_contract_from_source(projection_source_drift)
+
     def test_operator_ui_recognized_fields_follow_spread_set(self) -> None:
         source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
         contract = _operator_ui_contract_from_source(source)
@@ -429,6 +475,69 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(AssertionError, "backend workflow authority"):
             _backend_no_workflow_authority_rejection(drifted_source)
+
+    def test_backend_label_source_and_metadata_enforcement_are_parsed(self) -> None:
+        from aegisops.control_plane.inspection import evidence_pack_projection
+
+        source = BACKEND_EVIDENCE_PACK_PROJECTION.read_text(encoding="utf-8")
+        self.assertEqual(
+            _py_backend_enforced_label_sets(
+                source,
+                evidence_pack_projection,
+            )["status"],
+            frozenset({"available", "degraded", "unavailable"}),
+        )
+        self.assertEqual(
+            contract_guard._py_rejected_string_values(
+                source,
+                ("subscript", "values", "source_id"),
+            ),
+            frozenset({"malwarebazaar_hash_reputation"}),
+        )
+        self.assertEqual(
+            _py_backend_enforced_metadata_fields(
+                source,
+                evidence_pack_projection,
+            )["confidence"],
+            evidence_pack_projection._EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS,
+        )
+
+        label_drift = source.replace(
+            "    for field_name, allowed_values in _EVIDENCE_PACK_ALLOWED_PROJECTION_LABELS.items():\n"
+            "        if values[field_name] not in allowed_values:\n"
+            "            raise ValueError(\n"
+            "                \"linked evidence-pack projection has unsupported evidence-pack projection label\"\n"
+            "            )\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "label enforcement"):
+            _py_backend_enforced_label_sets(label_drift, evidence_pack_projection)
+
+        source_id_drift = source.replace(
+            "    if values[\"source_id\"] != _EVIDENCE_PACK_SUPPORTED_SOURCE_ID:\n"
+            "        raise ValueError(\n"
+            "            \"linked evidence-pack projection has unsupported evidence-pack projection source\"\n"
+            "        )\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "source_id"):
+            contract_guard._py_rejected_string_values(
+                source_id_drift,
+                ("subscript", "values", "source_id"),
+            )
+
+        metadata_drift = source.replace(
+            "    _required_metadata_map_fields(\n"
+            "        confidence,\n"
+            "        _EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS,\n"
+            "    )\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "metadata enforcement"):
+            _py_backend_enforced_metadata_fields(
+                metadata_drift,
+                evidence_pack_projection,
+            )
 
     def test_backend_confidence_posture_parser_observes_representative_drift(
         self,

--- a/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
+++ b/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
@@ -153,6 +153,30 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                 "confidence fields",
             ),
             (
+                "provenance binding rule",
+                {
+                    "backend_contract": contract_with_drift(
+                        backend,
+                        "provenance_binding_rules",
+                        backend.provenance_binding_rules
+                        - frozenset({"custody_reference"}),
+                    )
+                },
+                "provenance binding rules",
+            ),
+            (
+                "metadata format rule",
+                {
+                    "ai_grounding_contract": contract_with_drift(
+                        ai,
+                        "metadata_format_rules",
+                        ai.metadata_format_rules
+                        - frozenset({"response_digest"}),
+                    )
+                },
+                "metadata format rules",
+            ),
+            (
                 "source ID",
                 {
                     "ai_grounding_contract": contract_with_drift(
@@ -207,6 +231,18 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                     )
                 },
                 "forbidden projection sources",
+            ),
+            (
+                "cache-sourced boolean",
+                {
+                    "operator_ui_contract": contract_with_drift(
+                        ui,
+                        "cache_boolean_false_fields",
+                        ui.cache_boolean_false_fields
+                        - frozenset({"stale_cache"}),
+                    )
+                },
+                "cache-sourced boolean denials",
             ),
             (
                 "readiness claim",
@@ -402,6 +438,13 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "label enforcement"):
             _operator_ui_contract_from_source(drifted_source)
 
+        helper_drift = source.replace(
+            "  if (!EVIDENCE_PACK_ALLOWED_LABELS[fieldName].has(value)) {\n",
+            "  if (false) {\n",
+        )
+        with self.assertRaisesRegex(AssertionError, "label validator semantics"):
+            _operator_ui_contract_from_source(helper_drift)
+
     def test_operator_ui_metadata_contract_requires_enforcement_calls(self) -> None:
         source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
 
@@ -425,6 +468,20 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(AssertionError, "metadata enforcement"):
             _operator_ui_contract_from_source(metadata_drift)
+
+        reason_helper_drift = source.replace(
+            "    if (!asString(reason) || !allowedReasons.has(asString(reason) ?? \"\")) {\n",
+            "    if (!asString(reason)) {\n",
+        )
+        with self.assertRaisesRegex(AssertionError, "reason validator semantics"):
+            _operator_ui_contract_from_source(reason_helper_drift)
+
+        metadata_helper_drift = source.replace(
+            "    fieldNames.length !== requiredFields.size ||\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "metadata-map validator semantics"):
+            _operator_ui_contract_from_source(metadata_helper_drift)
 
     def test_operator_ui_source_authority_and_projection_source_checks_are_parsed(
         self,
@@ -468,6 +525,43 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(AssertionError, "projection-source"):
             _operator_ui_contract_from_source(projection_source_drift)
+
+        cache_boolean_drift = source.replace(
+            "      (pack.stale_cache !== undefined && pack.stale_cache !== false) ||\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "cache-sourced boolean"):
+            _operator_ui_contract_from_source(cache_boolean_drift)
+
+    def test_operator_ui_provenance_and_metadata_formats_are_enforced(self) -> None:
+        source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+        self.assertIn(
+            "custody_reference",
+            contract_guard._ts_provenance_binding_rules(source),
+        )
+        self.assertIn(
+            "response_digest",
+            contract_guard._ts_metadata_format_rules(source),
+        )
+
+        provenance_drift = source.replace(
+            "      asString(provenance.custody_reference) !==\n"
+            "        linkedEvidenceRecordCustodyReference(\n"
+            "          response,\n"
+            "          evidenceRecordId,\n"
+            "          evidenceRequestId,\n"
+            "        )\n",
+            "      false\n",
+        )
+        with self.assertRaisesRegex(AssertionError, "provenance binding"):
+            contract_guard._ts_provenance_binding_rules(provenance_drift)
+
+        metadata_format_drift = source.replace(
+            "    !isSha256Digest(asString(custody.response_digest)) ||\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "metadata format"):
+            contract_guard._ts_metadata_format_rules(metadata_format_drift)
 
     def test_operator_ui_recognized_fields_follow_spread_set(self) -> None:
         source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
@@ -586,6 +680,18 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
             ),
             evidence_pack_projection._EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES,
         )
+        self.assertIn(
+            "custody_reference",
+            contract_guard._py_backend_provenance_binding_rules(source),
+        )
+        self.assertIn(
+            "response_digest",
+            contract_guard._py_backend_metadata_format_rules(source),
+        )
+        self.assertEqual(
+            contract_guard._py_backend_cache_boolean_rejections(source),
+            frozenset({"cache_sourced", "stale_cache"}),
+        )
         self.assertEqual(
             contract_guard._py_backend_forbidden_readiness_claim_rejection(
                 source,
@@ -635,6 +741,31 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                 forbidden_source_drift,
                 evidence_pack_projection,
             )
+
+        cache_boolean_drift = source.replace(
+            "        or (stale_cache is not None and stale_cache is not False)\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "cache-sourced boolean"):
+            contract_guard._py_backend_cache_boolean_rejections(cache_boolean_drift)
+
+        provenance_binding_drift = source.replace(
+            '        "custody_reference": record_custody_reference,\n',
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "provenance binding"):
+            contract_guard._py_backend_provenance_binding_rules(
+                provenance_binding_drift,
+            )
+
+        metadata_format_drift = source.replace(
+            "    ) or not _is_sha256_digest(\n"
+            "        _optional_string_from_mapping(custody, \"response_digest\")\n"
+            "    ):\n",
+            "    ):\n",
+        )
+        with self.assertRaisesRegex(AssertionError, "metadata format"):
+            contract_guard._py_backend_metadata_format_rules(metadata_format_drift)
 
         readiness_drift = source.replace(
             "    if any(\n"
@@ -870,6 +1001,50 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                 ai_grounding_validation,
             )
 
+    def test_ai_source_provenance_and_metadata_enforcement_are_parsed(self) -> None:
+        from aegisops.control_plane.assistant import ai_grounding_validation
+
+        source = AI_GROUNDING_VALIDATOR.read_text(encoding="utf-8")
+        self.assertEqual(
+            contract_guard._py_ai_supported_source_ids_rejection(
+                source,
+                ai_grounding_validation,
+            ),
+            frozenset({"malwarebazaar_hash_reputation"}),
+        )
+        self.assertIn(
+            "custody_reference",
+            contract_guard._py_ai_provenance_binding_rules(source),
+        )
+        self.assertIn(
+            "response_digest",
+            contract_guard._py_ai_metadata_format_rules(source),
+        )
+
+        source_id_drift = source.replace(
+            "    if registry_entry is None or source_id not in _SUPPORTED_GROUNDING_SOURCE_IDS:\n",
+            "    if registry_entry is None:\n",
+        )
+        with self.assertRaisesRegex(AssertionError, "source-id"):
+            contract_guard._py_ai_supported_source_ids_rejection(
+                source_id_drift,
+                ai_grounding_validation,
+            )
+
+        provenance_drift = source.replace(
+            '        "custody_reference": expected_custody_reference,\n',
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "provenance binding"):
+            contract_guard._py_ai_provenance_binding_rules(provenance_drift)
+
+        metadata_format_drift = source.replace(
+            "        or _SHA256_DIGEST_PATTERN.fullmatch(response_digest) is None\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "response-digest format"):
+            contract_guard._py_ai_metadata_format_rules(metadata_format_drift)
+
     def test_ai_no_workflow_authority_parser_observes_representative_drift(
         self,
     ) -> None:
@@ -1084,6 +1259,7 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
     def test_ai_authority_truth_denials_follow_scanner(self) -> None:
         from aegisops.control_plane.assistant import ai_grounding_validation
 
+        source = AI_GROUNDING_VALIDATOR.read_text(encoding="utf-8")
         original_scanner = ai_grounding_validation._scan_for_authority_claim
 
         def scanner_with_gap(value: object) -> bool:
@@ -1099,6 +1275,18 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
             _, _, ai = load_phase63_evidence_pack_contracts(REPO_ROOT)
 
         self.assertNotIn("readiness_truth", ai.authority_truth_denials)
+
+        scanner_call_drift = source.replace(
+            "            if _scan_for_authority_claim(\n"
+            "                scan_value\n"
+            "            ) or _scan_for_endpoint_command_language(scan_value):\n",
+            "            if _scan_for_endpoint_command_language(scan_value):\n",
+        )
+        with self.assertRaisesRegex(AssertionError, "authority-scan enforcement"):
+            contract_guard._py_ai_authority_truth_denials(
+                scanner_call_drift,
+                ai_grounding_validation,
+            )
 
     def test_state_reason_consistency_rules_are_loaded_from_validators(self) -> None:
         backend_source = BACKEND_EVIDENCE_PACK_PROJECTION.read_text(encoding="utf-8")

--- a/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
+++ b/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
@@ -465,6 +465,65 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
             _operator_ui_contract_from_source(drifted_source).recognized_fields,
         )
 
+    def test_operator_ui_authority_visibility_and_recognized_rejections_are_enforced(
+        self,
+    ) -> None:
+        source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+
+        self.assertEqual(
+            contract_guard._ts_subordinate_authority_posture_rejection(source),
+            "subordinate_evidence_context_only",
+        )
+        self.assertTrue(
+            contract_guard._ts_rejected_optional_pack_boolean_field(
+                source,
+                "operator_visible",
+            )
+        )
+        self.assertIn("operator_visible", contract_guard._ts_recognized_fields_rejection(source))
+
+        provenance_authority_drift = source.replace(
+            "    if (\n"
+            "      asString(provenance.authority_posture) !==\n"
+            "      EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE\n"
+            "    ) {\n"
+            "      throw new OperatorDataProviderContractError(\n"
+            "        `Resource cases linked_evidence_packs item ${evidenceRequestId} must keep provenance subordinate.`,\n"
+            "      );\n"
+            "    }\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "authority_posture"):
+            contract_guard._ts_subordinate_authority_posture_rejection(
+                provenance_authority_drift,
+            )
+
+        operator_visible_drift = source.replace(
+            "pack.operator_visible !== true",
+            "pack.operator_visible !== false",
+        )
+        self.assertFalse(
+            contract_guard._ts_rejected_optional_pack_boolean_field(
+                operator_visible_drift,
+                "operator_visible",
+            )
+        )
+
+        recognized_rejection_drift = source.replace(
+            "    if (\n"
+            "      Object.keys(pack).some(\n"
+            "        (fieldName) => !EVIDENCE_PACK_RECOGNIZED_FIELDS.has(fieldName),\n"
+            "      )\n"
+            "    ) {\n"
+            "      throw new OperatorDataProviderContractError(\n"
+            "        `Resource cases linked_evidence_packs item ${evidenceRequestId} has unexpected evidence-pack fields.`,\n"
+            "      );\n"
+            "    }\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "recognized-field"):
+            contract_guard._ts_recognized_fields_rejection(recognized_rejection_drift)
+
     def test_backend_authority_parser_observes_representative_drift(self) -> None:
         source = BACKEND_EVIDENCE_PACK_PROJECTION.read_text(encoding="utf-8")
         self.assertEqual(_backend_no_workflow_authority_rejection(source), "none")
@@ -475,6 +534,122 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(AssertionError, "backend workflow authority"):
             _backend_no_workflow_authority_rejection(drifted_source)
+
+    def test_backend_authority_reason_and_boundary_rejections_are_enforced(self) -> None:
+        from aegisops.control_plane.inspection import evidence_pack_projection
+
+        source = BACKEND_EVIDENCE_PACK_PROJECTION.read_text(encoding="utf-8")
+
+        self.assertEqual(
+            contract_guard._backend_subordinate_authority_posture_rejection(source),
+            "subordinate_evidence_context_only",
+        )
+        self.assertTrue(
+            contract_guard._py_rejected_optional_boolean_value(
+                source,
+                ("get", "projection", "operator_visible"),
+            )
+        )
+        self.assertEqual(
+            contract_guard._py_backend_enforced_reason_sets(
+                source,
+                evidence_pack_projection,
+            )["degraded_reasons"],
+            evidence_pack_projection._EVIDENCE_PACK_ALLOWED_DEGRADED_REASONS,
+        )
+        self.assertIn(
+            "operator_visible",
+            contract_guard._py_backend_recognized_fields_rejection(
+                source,
+                evidence_pack_projection,
+            ),
+        )
+        self.assertEqual(
+            contract_guard._py_backend_forbidden_projection_sources_rejection(
+                source,
+                evidence_pack_projection,
+            ),
+            evidence_pack_projection._EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES,
+        )
+        self.assertEqual(
+            contract_guard._py_backend_forbidden_readiness_claim_rejection(
+                source,
+                evidence_pack_projection,
+            ),
+            evidence_pack_projection._EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS,
+        )
+
+        provenance_authority_drift = source.replace(
+            '    if (\n'
+            '        _optional_string_from_mapping(provenance, "authority_posture")\n'
+            "        != _EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE\n"
+            "    ):\n"
+            '        raise ValueError("linked evidence-pack projection must stay subordinate")\n',
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "authority posture"):
+            contract_guard._backend_subordinate_authority_posture_rejection(
+                provenance_authority_drift,
+            )
+
+        reason_drift = source.replace(
+            "    if any(\n"
+            "        reason not in _EVIDENCE_PACK_ALLOWED_DEGRADED_REASONS\n"
+            "        for reason in degraded_reasons\n"
+            "    ) or any(\n"
+            "        reason not in _EVIDENCE_PACK_ALLOWED_UNAVAILABLE_REASONS\n"
+            "        for reason in unavailable_reasons\n"
+            "    ):\n"
+            "        raise ValueError(\n"
+            "            \"linked evidence-pack projection has unsupported evidence-pack projection reason\"\n"
+            "        )\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "reason enforcement"):
+            contract_guard._py_backend_enforced_reason_sets(
+                reason_drift,
+                evidence_pack_projection,
+            )
+
+        forbidden_source_drift = source.replace(
+            "        or projection_source in _EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "projection-source"):
+            contract_guard._py_backend_forbidden_projection_sources_rejection(
+                forbidden_source_drift,
+                evidence_pack_projection,
+            )
+
+        readiness_drift = source.replace(
+            "    if any(\n"
+            "        claim_name in projection\n"
+            "        for claim_name in _EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS\n"
+            "    ):\n"
+            "        raise ValueError(\"linked evidence-pack projection cannot claim release readiness\")\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "readiness-claim"):
+            contract_guard._py_backend_forbidden_readiness_claim_rejection(
+                readiness_drift,
+                evidence_pack_projection,
+            )
+
+        recognized_drift = source.replace(
+            "    unexpected_fields = (\n"
+            "        frozenset(projection) - _EVIDENCE_PACK_PROJECTION_RECOGNIZED_FIELDS\n"
+            "    )\n"
+            "    if unexpected_fields:\n"
+            "        raise ValueError(\n"
+            "            \"linked evidence-pack projection has unexpected evidence-pack projection field\"\n"
+            "        )\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "recognized-field"):
+            contract_guard._py_backend_recognized_fields_rejection(
+                recognized_drift,
+                evidence_pack_projection,
+            )
 
     def test_backend_label_source_and_metadata_enforcement_are_parsed(self) -> None:
         from aegisops.control_plane.inspection import evidence_pack_projection
@@ -690,6 +865,56 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
             _ai_confidence_posture_rejection(
                 missing_reason_drift,
                 "external_hash_reputation_subordinate_context",
+            )
+
+    def test_ai_authority_posture_and_reason_vocabulary_are_enforced(self) -> None:
+        from aegisops.control_plane.assistant import ai_grounding_validation
+
+        source = AI_GROUNDING_VALIDATOR.read_text(encoding="utf-8")
+        self.assertEqual(
+            contract_guard._ai_subordinate_authority_posture_rejection(source),
+            "subordinate_evidence_context_only",
+        )
+        self.assertEqual(
+            contract_guard._py_ai_enforced_reason_sets(
+                source,
+                ai_grounding_validation,
+            )["unavailable_reasons"],
+            ai_grounding_validation._ALLOWED_UNAVAILABLE_REASONS,
+        )
+
+        provenance_authority_drift = source.replace(
+            "        if provenance.get(\"authority_posture\") != _SUBORDINATE_AUTHORITY_POSTURE:\n"
+            "            reasons.append(\"grounding_authority_promotion_attempt\")\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "AI authority posture"):
+            contract_guard._ai_subordinate_authority_posture_rejection(
+                provenance_authority_drift,
+            )
+
+        missing_reason_call_drift = source.replace(
+            "    reasons.extend(_unsupported_projection_reason_reasons(projection))\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "reason vocabulary"):
+            contract_guard._py_ai_enforced_reason_sets(
+                missing_reason_call_drift,
+                ai_grounding_validation,
+            )
+
+        reason_constant_drift = source.replace(
+            "    if any(\n"
+            "        reason not in _ALLOWED_UNAVAILABLE_REASONS\n"
+            "        for reason in unavailable_reasons\n"
+            "    ):\n"
+            "        return (\"unsupported_grounding_reason\",)\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "reason vocabulary"):
+            contract_guard._py_ai_enforced_reason_sets(
+                reason_constant_drift,
+                ai_grounding_validation,
             )
 
     def test_ai_metadata_contract_uses_validator_allowed_fields(self) -> None:

--- a/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
+++ b/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
@@ -20,11 +20,13 @@ from scripts.phase63_evidence_pack_contract_guard import (  # noqa: E402
     contract_with_label_drift,
     load_phase63_evidence_pack_contracts,
     _backend_no_workflow_authority_rejection,
+    _backend_confidence_posture_rejection,
     _py_projection_get_string_rejection_labels,
     _AI_GROUNDING_SINGLETON_LABEL_FIELDS,
     _operator_ui_contract_from_source,
     _py_string_constant,
     _ts_forbidden_defined_pack_fields,
+    _ts_no_workflow_authority_rejection,
     _ts_rejected_pack_string_field,
 )
 
@@ -131,6 +133,17 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                 "source IDs",
             ),
             (
+                "recognized field",
+                {
+                    "operator_ui_contract": contract_with_drift(
+                        ui,
+                        "recognized_fields",
+                        ui.recognized_fields - frozenset({"operator_visible"}),
+                    )
+                },
+                "recognized fields",
+            ),
+            (
                 "freshness window",
                 {
                     "operator_ui_contract": contract_with_drift(
@@ -219,6 +232,7 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
             _ts_rejected_pack_string_field(source, "workflow_authority"),
             "none",
         )
+        self.assertEqual(_ts_no_workflow_authority_rejection(source), "none")
         self.assertEqual(
             _ts_forbidden_defined_pack_fields(
                 source,
@@ -244,6 +258,13 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
             _ts_rejected_pack_string_field(workflow_drift, "workflow_authority"),
             "advisory_only",
         )
+
+        confidence_authority_drift = source.replace(
+            'asString(confidence.source_native_score_authority) !== "none"',
+            'asString(confidence.source_native_score_authority) !== "advisory_only"',
+        )
+        with self.assertRaisesRegex(AssertionError, "workflow authority"):
+            _ts_no_workflow_authority_rejection(confidence_authority_drift)
 
         readiness_drift = source.replace(
             "      pack.gate_readiness_claim !== undefined\n",
@@ -286,6 +307,41 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "label enforcement"):
             _operator_ui_contract_from_source(drifted_source)
 
+    def test_operator_ui_metadata_contract_requires_enforcement_calls(self) -> None:
+        source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+
+        reason_drift = source.replace(
+            "    validateEvidencePackReasons(\n"
+            "      pack.degraded_reasons,\n"
+            "      EVIDENCE_PACK_ALLOWED_DEGRADED_REASONS,\n"
+            "    );\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "reason enforcement"):
+            _operator_ui_contract_from_source(reason_drift)
+
+        metadata_drift = source.replace(
+            "    validateEvidencePackMetadataMap(\n"
+            "      confidence,\n"
+            "      EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS,\n"
+            "      evidenceRequestId,\n"
+            "    );\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "metadata enforcement"):
+            _operator_ui_contract_from_source(metadata_drift)
+
+    def test_operator_ui_recognized_fields_follow_spread_set(self) -> None:
+        source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+        contract = _operator_ui_contract_from_source(source)
+        self.assertIn("operator_visible", contract.recognized_fields)
+
+        drifted_source = source.replace('  "operator_visible",\n', "")
+        self.assertNotIn(
+            "operator_visible",
+            _operator_ui_contract_from_source(drifted_source).recognized_fields,
+        )
+
     def test_backend_authority_parser_observes_representative_drift(self) -> None:
         source = BACKEND_EVIDENCE_PACK_PROJECTION.read_text(encoding="utf-8")
         self.assertEqual(_backend_no_workflow_authority_rejection(source), "none")
@@ -296,6 +352,44 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(AssertionError, "backend workflow authority"):
             _backend_no_workflow_authority_rejection(drifted_source)
+
+    def test_backend_confidence_posture_parser_observes_representative_drift(
+        self,
+    ) -> None:
+        source = BACKEND_EVIDENCE_PACK_PROJECTION.read_text(encoding="utf-8")
+        self.assertEqual(
+            _backend_confidence_posture_rejection(
+                source,
+                "external_hash_reputation_subordinate_context",
+            ),
+            "external_hash_reputation_subordinate_context",
+        )
+
+        literal_drift = source.replace(
+            "registry_entry.confidence_posture",
+            '"workflow_truth_confidence"',
+        )
+        self.assertEqual(
+            _backend_confidence_posture_rejection(
+                literal_drift,
+                "external_hash_reputation_subordinate_context",
+            ),
+            "workflow_truth_confidence",
+        )
+
+        missing_check_drift = source.replace(
+            '    if (\n'
+            '        _optional_string_from_mapping(confidence, "posture")\n'
+            "        != registry_entry.confidence_posture\n"
+            "    ):\n"
+            '        raise ValueError("linked evidence-pack projection confidence posture mismatch")\n',
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "confidence posture"):
+            _backend_confidence_posture_rejection(
+                missing_check_drift,
+                "external_hash_reputation_subordinate_context",
+            )
 
     def test_ai_singleton_label_parser_observes_representative_drift(self) -> None:
         source = AI_GROUNDING_VALIDATOR.read_text(encoding="utf-8")

--- a/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
+++ b/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+TESTS_ROOT = pathlib.Path(__file__).resolve().parent
+CONTROL_PLANE_ROOT = TESTS_ROOT.parent
+REPO_ROOT = CONTROL_PLANE_ROOT.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.phase63_evidence_pack_contract_guard import (  # noqa: E402
+    assert_phase63_evidence_pack_contract_aligned,
+    contract_with_drift,
+    contract_with_label_drift,
+    load_phase63_evidence_pack_contracts,
+)
+
+
+class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
+    def test_phase63_evidence_pack_contracts_stay_aligned(self) -> None:
+        assert_phase63_evidence_pack_contract_aligned(REPO_ROOT)
+
+    def test_drift_guard_fails_on_representative_contract_mismatches(self) -> None:
+        backend, ui, ai = load_phase63_evidence_pack_contracts(REPO_ROOT)
+        mismatch_cases = (
+            (
+                "label",
+                {
+                    "operator_ui_contract": contract_with_label_drift(
+                        ui,
+                        "status",
+                        frozenset({"available"}),
+                    )
+                },
+                "status labels",
+            ),
+            (
+                "degraded reason",
+                {
+                    "operator_ui_contract": contract_with_drift(
+                        ui,
+                        "degraded_reasons",
+                        frozenset({"stale_reputation"}),
+                    )
+                },
+                "degraded reasons",
+            ),
+            (
+                "custody field",
+                {
+                    "operator_ui_contract": contract_with_drift(
+                        ui,
+                        "required_custody_fields",
+                        ui.required_custody_fields - frozenset({"response_digest"}),
+                    )
+                },
+                "custody fields",
+            ),
+            (
+                "provenance field",
+                {
+                    "operator_ui_contract": contract_with_drift(
+                        ui,
+                        "required_provenance_fields",
+                        ui.required_provenance_fields
+                        - frozenset({"custody_reference"}),
+                    )
+                },
+                "provenance fields",
+            ),
+            (
+                "confidence field",
+                {
+                    "ai_grounding_contract": contract_with_drift(
+                        ai,
+                        "required_confidence_fields",
+                        ai.required_confidence_fields
+                        - frozenset({"ambiguity_badge"}),
+                    )
+                },
+                "confidence fields",
+            ),
+            (
+                "source ID",
+                {
+                    "ai_grounding_contract": contract_with_drift(
+                        ai,
+                        "supported_source_ids",
+                        frozenset({"sample_hash_reputation"}),
+                    )
+                },
+                "source IDs",
+            ),
+            (
+                "freshness window",
+                {
+                    "operator_ui_contract": contract_with_drift(
+                        ui,
+                        "freshness_window_seconds",
+                        ui.freshness_window_seconds + 1,
+                    )
+                },
+                "freshness window",
+            ),
+            (
+                "uncertainty label",
+                {
+                    "ai_grounding_contract": contract_with_label_drift(
+                        ai,
+                        "uncertainty_label",
+                        ai.labels["uncertainty_label"]
+                        - frozenset({"source_unavailable"}),
+                    )
+                },
+                "uncertainty_label labels",
+            ),
+            (
+                "forbidden projection source",
+                {
+                    "operator_ui_contract": contract_with_drift(
+                        ui,
+                        "forbidden_projection_sources",
+                        ui.forbidden_projection_sources - frozenset({"browser_state"}),
+                    )
+                },
+                "forbidden projection sources",
+            ),
+            (
+                "readiness claim",
+                {
+                    "operator_ui_contract": contract_with_drift(
+                        ui,
+                        "forbidden_readiness_claim_fields",
+                        ui.forbidden_readiness_claim_fields
+                        - frozenset({"gate_readiness_claim"}),
+                    )
+                },
+                "readiness claim fields",
+            ),
+            (
+                "authority truth denial",
+                {
+                    "ai_grounding_contract": contract_with_drift(
+                        ai,
+                        "authority_truth_denials",
+                        ai.authority_truth_denials - frozenset({"readiness_truth"}),
+                    )
+                },
+                "AI authority truth denial posture",
+            ),
+            (
+                "verifier source truth",
+                {
+                    "backend_contract": contract_with_drift(
+                        backend,
+                        "no_workflow_authority",
+                        "verifier_truth",
+                    )
+                },
+                "no workflow authority",
+            ),
+        )
+
+        for label, overrides, expected_message in mismatch_cases:
+            with self.subTest(label=label):
+                with self.assertRaisesRegex(AssertionError, expected_message):
+                    assert_phase63_evidence_pack_contract_aligned(
+                        REPO_ROOT,
+                        backend_contract=overrides.get("backend_contract", backend),
+                        operator_ui_contract=overrides.get("operator_ui_contract", ui),
+                        ai_grounding_contract=overrides.get(
+                            "ai_grounding_contract",
+                            ai,
+                        ),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
+++ b/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
@@ -26,6 +26,7 @@ from scripts.phase63_evidence_pack_contract_guard import (  # noqa: E402
     _backend_no_workflow_authority_rejection,
     _backend_confidence_posture_rejection,
     _py_ai_enforced_freshness_window_milliseconds,
+    _py_ai_forbidden_readiness_claim_rejection,
     _py_backend_enforced_label_sets,
     _py_backend_enforced_freshness_window_milliseconds,
     _py_backend_enforced_metadata_fields,
@@ -188,6 +189,27 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                 "source IDs",
             ),
             (
+                "coordinated source ID",
+                {
+                    "backend_contract": contract_with_drift(
+                        backend,
+                        "supported_source_ids",
+                        frozenset({"sample_hash_reputation"}),
+                    ),
+                    "operator_ui_contract": contract_with_drift(
+                        ui,
+                        "supported_source_ids",
+                        frozenset({"sample_hash_reputation"}),
+                    ),
+                    "ai_grounding_contract": contract_with_drift(
+                        ai,
+                        "supported_source_ids",
+                        frozenset({"sample_hash_reputation"}),
+                    ),
+                },
+                "source IDs",
+            ),
+            (
                 "recognized field",
                 {
                     "operator_ui_contract": contract_with_drift(
@@ -257,6 +279,17 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                 "readiness claim fields",
             ),
             (
+                "AI readiness claim",
+                {
+                    "ai_grounding_contract": contract_with_drift(
+                        ai,
+                        "forbidden_readiness_claim_fields",
+                        frozenset(),
+                    )
+                },
+                "readiness claim fields",
+            ),
+            (
                 "authority truth denial",
                 {
                     "ai_grounding_contract": contract_with_drift(
@@ -286,6 +319,27 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                         "authoritative_workflow_truth",
                         True,
                     )
+                },
+                "authoritative workflow truth denial",
+            ),
+            (
+                "coordinated workflow truth widening",
+                {
+                    "backend_contract": contract_with_drift(
+                        backend,
+                        "authoritative_workflow_truth",
+                        True,
+                    ),
+                    "operator_ui_contract": contract_with_drift(
+                        ui,
+                        "authoritative_workflow_truth",
+                        True,
+                    ),
+                    "ai_grounding_contract": contract_with_drift(
+                        ai,
+                        "authoritative_workflow_truth",
+                        True,
+                    ),
                 },
                 "authoritative workflow truth denial",
             ),
@@ -401,6 +455,24 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "FreshnessWindow"):
             _ts_enforced_freshness_window_milliseconds(drifted_source)
 
+    def test_operator_ui_source_state_reason_check_models_registry_status(
+        self,
+    ) -> None:
+        source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+        self.assertIn(
+            "source_state_matches_availability_reasons",
+            _ts_state_reason_consistency_rules(
+                source,
+                source_registry_status="enabled",
+            ),
+        )
+
+        with self.assertRaisesRegex(AssertionError, "valid source-state reasons"):
+            _ts_state_reason_consistency_rules(
+                source,
+                source_registry_status="degraded",
+            )
+
     def test_operator_ui_confidence_posture_uses_validator_check(self) -> None:
         source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
         self.assertEqual(
@@ -482,6 +554,35 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(AssertionError, "metadata-map validator semantics"):
             _operator_ui_contract_from_source(metadata_helper_drift)
+
+    def test_ai_readiness_claim_denial_is_parsed(self) -> None:
+        from aegisops.control_plane.assistant import ai_grounding_validation
+
+        source = AI_GROUNDING_VALIDATOR.read_text(encoding="utf-8")
+        self.assertEqual(
+            _py_ai_forbidden_readiness_claim_rejection(
+                source,
+                ai_grounding_validation,
+            ),
+            frozenset(
+                {
+                    "release_readiness_claim",
+                    "rc_readiness_claim",
+                    "gate_readiness_claim",
+                }
+            ),
+        )
+
+        readiness_drift = source.replace(
+            "    if any(claim_name in projection for claim_name in _FORBIDDEN_READINESS_CLAIMS):\n"
+            "        reasons.append(\"grounding_authority_promotion_attempt\")\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "readiness-claim"):
+            _py_ai_forbidden_readiness_claim_rejection(
+                readiness_drift,
+                ai_grounding_validation,
+            )
 
     def test_operator_ui_source_authority_and_projection_source_checks_are_parsed(
         self,

--- a/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
+++ b/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
@@ -13,6 +13,7 @@ if str(REPO_ROOT) not in sys.path:
 if str(CONTROL_PLANE_ROOT) not in sys.path:
     sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
+from scripts import phase63_evidence_pack_contract_guard as contract_guard  # noqa: E402
 from scripts.phase63_evidence_pack_contract_guard import (  # noqa: E402
     assert_phase63_evidence_pack_contract_aligned,
     contract_with_drift,
@@ -21,6 +22,8 @@ from scripts.phase63_evidence_pack_contract_guard import (  # noqa: E402
     _backend_no_workflow_authority_rejection,
     _py_projection_get_string_rejection_labels,
     _AI_GROUNDING_SINGLETON_LABEL_FIELDS,
+    _operator_ui_contract_from_source,
+    _py_string_constant,
     _ts_forbidden_defined_pack_fields,
     _ts_rejected_pack_string_field,
 )
@@ -132,8 +135,8 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                 {
                     "operator_ui_contract": contract_with_drift(
                         ui,
-                        "freshness_window_seconds",
-                        ui.freshness_window_seconds + 1,
+                        "freshness_window_milliseconds",
+                        ui.freshness_window_milliseconds + 1,
                     )
                 },
                 "freshness window",
@@ -254,6 +257,35 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
             frozenset({"release_readiness_claim", "rc_readiness_claim"}),
         )
 
+    def test_operator_ui_freshness_window_preserves_millisecond_precision(self) -> None:
+        source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+        self.assertEqual(
+            _operator_ui_contract_from_source(source).freshness_window_milliseconds,
+            21600000,
+        )
+
+        drifted_source = source.replace(
+            "6 * 60 * 60 * 1000",
+            "6 * 60 * 60 * 1000 + 500",
+        )
+
+        self.assertEqual(
+            _operator_ui_contract_from_source(
+                drifted_source,
+            ).freshness_window_milliseconds,
+            21600500,
+        )
+
+    def test_operator_ui_label_contract_requires_enforcement_calls(self) -> None:
+        source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+        drifted_source = source.replace(
+            '    validateEvidencePackLabel("source_state", sourceState, evidenceRequestId);\n',
+            "",
+        )
+
+        with self.assertRaisesRegex(AssertionError, "label enforcement"):
+            _operator_ui_contract_from_source(drifted_source)
+
     def test_backend_authority_parser_observes_representative_drift(self) -> None:
         source = BACKEND_EVIDENCE_PACK_PROJECTION.read_text(encoding="utf-8")
         self.assertEqual(_backend_no_workflow_authority_rejection(source), "none")
@@ -309,6 +341,20 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
             _, _, ai = load_phase63_evidence_pack_contracts(REPO_ROOT)
 
         self.assertNotIn("readiness_truth", ai.authority_truth_denials)
+
+    def test_python_string_constant_does_not_require_legacy_ast_str(self) -> None:
+        legacy_ast_str = getattr(contract_guard.ast, "Str", None)
+        if legacy_ast_str is not None:
+            delattr(contract_guard.ast, "Str")
+        try:
+            self.assertIsNone(_py_string_constant(contract_guard.ast.Constant(value=1)))
+            self.assertEqual(
+                _py_string_constant(contract_guard.ast.Constant(value="none")),
+                "none",
+            )
+        finally:
+            if legacy_ast_str is not None:
+                setattr(contract_guard.ast, "Str", legacy_ast_str)
 
 
 if __name__ == "__main__":

--- a/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
+++ b/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
@@ -25,7 +25,9 @@ from scripts.phase63_evidence_pack_contract_guard import (  # noqa: E402
     load_phase63_evidence_pack_contracts,
     _backend_no_workflow_authority_rejection,
     _backend_confidence_posture_rejection,
+    _py_ai_enforced_freshness_window_milliseconds,
     _py_backend_enforced_label_sets,
+    _py_backend_enforced_freshness_window_milliseconds,
     _py_backend_enforced_metadata_fields,
     _py_ai_state_reason_consistency_rules,
     _py_backend_state_reason_consistency_rules,
@@ -76,6 +78,19 @@ AI_GROUNDING_VALIDATOR = (
 class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
     def test_phase63_evidence_pack_contracts_stay_aligned(self) -> None:
         assert_phase63_evidence_pack_contract_aligned(REPO_ROOT)
+
+    def test_direct_script_entrypoint_runs_guard(self) -> None:
+        with mock.patch.object(
+            contract_guard,
+            "assert_phase63_evidence_pack_contract_aligned",
+        ) as guard:
+            with mock.patch("builtins.print") as mocked_print:
+                contract_guard._main()
+
+        guard.assert_called_once_with()
+        mocked_print.assert_called_once_with(
+            "Phase 63 evidence-pack contract guard passed"
+        )
 
     def test_drift_guard_fails_on_representative_contract_mismatches(self) -> None:
         backend, ui, ai = load_phase63_evidence_pack_contracts(REPO_ROOT)
@@ -714,6 +729,46 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                 evidence_pack_projection,
             )
 
+    def test_backend_freshness_window_enforcement_is_parsed(self) -> None:
+        from aegisops.control_plane.evidence import (
+            evidence_freshness_provenance_projection,
+        )
+
+        source = BACKEND_EVIDENCE_PACK_PROJECTION.read_text(encoding="utf-8")
+        self.assertEqual(
+            _py_backend_enforced_freshness_window_milliseconds(
+                source,
+                "PT6H",
+                evidence_freshness_provenance_projection,
+            ),
+            21600000,
+        )
+
+        missing_call_drift = source.replace(
+            "    _validate_linked_evidence_pack_freshness_window(\n"
+            "        values=typed_values,\n"
+            "        custody=custody,\n"
+            "    )\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "freshness-window enforcement call"):
+            _py_backend_enforced_freshness_window_milliseconds(
+                missing_call_drift,
+                "PT6H",
+                evidence_freshness_provenance_projection,
+            )
+
+        missing_registry_window_drift = source.replace(
+            "_parse_duration_seconds(registry_entry.freshness_window)",
+            '_parse_duration_seconds("PT6H")',
+        )
+        with self.assertRaisesRegex(AssertionError, "freshness-window enforcement"):
+            _py_backend_enforced_freshness_window_milliseconds(
+                missing_registry_window_drift,
+                "PT6H",
+                evidence_freshness_provenance_projection,
+            )
+
     def test_backend_confidence_posture_parser_observes_representative_drift(
         self,
     ) -> None:
@@ -947,6 +1002,49 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(AssertionError, "metadata enforcement"):
             _py_enforced_metadata_fields(source, drifted_namespace)
+
+    def test_ai_freshness_recomputation_enforcement_is_parsed(self) -> None:
+        from aegisops.control_plane.evidence import (
+            evidence_freshness_provenance_projection,
+        )
+
+        source = AI_GROUNDING_VALIDATOR.read_text(encoding="utf-8")
+        self.assertEqual(
+            _py_ai_enforced_freshness_window_milliseconds(
+                source,
+                "PT6H",
+                evidence_freshness_provenance_projection,
+            ),
+            21600000,
+        )
+
+        missing_call_drift = source.replace(
+            "    reasons.extend(\n"
+            "        _freshness_recomputation_reasons(\n"
+            "            projection,\n"
+            "            grounded_at,\n"
+            "            expected_collection_timestamp,\n"
+            "        )\n"
+            "    )\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "freshness recomputation"):
+            _py_ai_enforced_freshness_window_milliseconds(
+                missing_call_drift,
+                "PT6H",
+                evidence_freshness_provenance_projection,
+            )
+
+        missing_registry_window_drift = source.replace(
+            "_parse_duration_seconds(registry_entry.freshness_window)",
+            '_parse_duration_seconds("PT6H")',
+        )
+        with self.assertRaisesRegex(AssertionError, "freshness recomputation"):
+            _py_ai_enforced_freshness_window_milliseconds(
+                missing_registry_window_drift,
+                "PT6H",
+                evidence_freshness_provenance_projection,
+            )
 
     def test_workflow_truth_boolean_rejections_are_parsed(self) -> None:
         backend_source = BACKEND_EVIDENCE_PACK_PROJECTION.read_text(encoding="utf-8")

--- a/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
+++ b/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pathlib
 import sys
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 TESTS_ROOT = pathlib.Path(__file__).resolve().parent
@@ -15,18 +16,23 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
 
 from scripts import phase63_evidence_pack_contract_guard as contract_guard  # noqa: E402
 from scripts.phase63_evidence_pack_contract_guard import (  # noqa: E402
+    _ai_confidence_posture_rejection,
+    _ai_no_workflow_authority_rejection,
     assert_phase63_evidence_pack_contract_aligned,
     contract_with_drift,
     contract_with_label_drift,
     load_phase63_evidence_pack_contracts,
     _backend_no_workflow_authority_rejection,
     _backend_confidence_posture_rejection,
+    _py_enforced_metadata_fields,
     _py_projection_get_string_rejection_labels,
+    _py_rejected_boolean_value,
     _AI_GROUNDING_SINGLETON_LABEL_FIELDS,
     _operator_ui_contract_from_source,
     _py_string_constant,
     _ts_forbidden_defined_pack_fields,
     _ts_no_workflow_authority_rejection,
+    _ts_rejected_pack_boolean_field,
     _ts_rejected_pack_string_field,
 )
 
@@ -210,6 +216,17 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                     )
                 },
                 "no workflow authority",
+            ),
+            (
+                "workflow truth denial",
+                {
+                    "ai_grounding_contract": contract_with_drift(
+                        ai,
+                        "authoritative_workflow_truth",
+                        True,
+                    )
+                },
+                "authoritative workflow truth denial",
             ),
         )
 
@@ -415,6 +432,118 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                 _AI_GROUNDING_SINGLETON_LABEL_FIELDS,
             )["custody_state"],
             frozenset({"reviewed"}),
+        )
+
+    def test_ai_no_workflow_authority_parser_observes_representative_drift(
+        self,
+    ) -> None:
+        source = AI_GROUNDING_VALIDATOR.read_text(encoding="utf-8")
+        self.assertEqual(_ai_no_workflow_authority_rejection(source), "none")
+
+        workflow_drift = source.replace(
+            'projection.get("workflow_authority") != _NO_WORKFLOW_AUTHORITY',
+            'projection.get("workflow_authority") != "advisory_only"',
+        )
+        with self.assertRaisesRegex(AssertionError, "AI workflow authority"):
+            _ai_no_workflow_authority_rejection(workflow_drift)
+
+        confidence_authority_drift = source.replace(
+            'confidence.get("source_native_score_authority") != _NO_WORKFLOW_AUTHORITY',
+            'confidence.get("source_native_score_authority") != "advisory_only"',
+        )
+        with self.assertRaisesRegex(AssertionError, "AI workflow authority"):
+            _ai_no_workflow_authority_rejection(confidence_authority_drift)
+
+    def test_ai_confidence_posture_parser_observes_representative_drift(self) -> None:
+        source = AI_GROUNDING_VALIDATOR.read_text(encoding="utf-8")
+        self.assertEqual(
+            _ai_confidence_posture_rejection(
+                source,
+                "external_hash_reputation_subordinate_context",
+            ),
+            "external_hash_reputation_subordinate_context",
+        )
+
+        literal_drift = source.replace(
+            'confidence.get("posture") != registry_entry.confidence_posture',
+            'confidence.get("posture") != "workflow_truth_confidence"',
+        )
+        self.assertEqual(
+            _ai_confidence_posture_rejection(
+                literal_drift,
+                "external_hash_reputation_subordinate_context",
+            ),
+            "workflow_truth_confidence",
+        )
+
+        missing_reason_drift = source.replace(
+            '"grounding_confidence_posture_mismatch"',
+            '"grounding_confidence_posture_changed"',
+        )
+        with self.assertRaisesRegex(AssertionError, "AI confidence posture"):
+            _ai_confidence_posture_rejection(
+                missing_reason_drift,
+                "external_hash_reputation_subordinate_context",
+            )
+
+    def test_ai_metadata_contract_uses_validator_allowed_fields(self) -> None:
+        from aegisops.control_plane.assistant import ai_grounding_validation
+
+        source = AI_GROUNDING_VALIDATOR.read_text(encoding="utf-8")
+        fields = _py_enforced_metadata_fields(source, ai_grounding_validation)
+        self.assertEqual(
+            fields["confidence"],
+            ai_grounding_validation._ALLOWED_CONFIDENCE_FIELDS,
+        )
+
+        drifted_namespace = SimpleNamespace(
+            _ALLOWED_CUSTODY_FIELDS=ai_grounding_validation._ALLOWED_CUSTODY_FIELDS,
+            _ALLOWED_PROVENANCE_FIELDS=(
+                ai_grounding_validation._ALLOWED_PROVENANCE_FIELDS
+            ),
+            _ALLOWED_CONFIDENCE_FIELDS=(
+                ai_grounding_validation._ALLOWED_CONFIDENCE_FIELDS
+                - frozenset({"ambiguity_badge"})
+            ),
+        )
+        self.assertNotEqual(
+            _py_enforced_metadata_fields(source, drifted_namespace)["confidence"],
+            ai_grounding_validation._REQUIRED_CONFIDENCE_FIELDS,
+        )
+
+    def test_workflow_truth_boolean_rejections_are_parsed(self) -> None:
+        backend_source = BACKEND_EVIDENCE_PACK_PROJECTION.read_text(encoding="utf-8")
+        ai_source = AI_GROUNDING_VALIDATOR.read_text(encoding="utf-8")
+        ui_source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+
+        self.assertFalse(
+            _py_rejected_boolean_value(
+                backend_source,
+                ("get", "projection", "authoritative_workflow_truth"),
+            )
+        )
+        self.assertFalse(
+            _py_rejected_boolean_value(
+                ai_source,
+                ("get", "projection", "authoritative_workflow_truth"),
+            )
+        )
+        self.assertFalse(
+            _ts_rejected_pack_boolean_field(
+                ui_source,
+                "authoritative_workflow_truth",
+            )
+        )
+
+        ui_drift = ui_source.replace(
+            "pack.authoritative_workflow_truth !== false",
+            "pack.authoritative_workflow_truth !== true",
+        )
+        self.assertTrue(
+            _ts_rejected_pack_boolean_field(
+                ui_drift,
+                "authoritative_workflow_truth",
+            )
         )
 
     def test_ai_authority_truth_denials_follow_scanner(self) -> None:

--- a/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
+++ b/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
@@ -15,6 +15,18 @@ from scripts.phase63_evidence_pack_contract_guard import (  # noqa: E402
     contract_with_drift,
     contract_with_label_drift,
     load_phase63_evidence_pack_contracts,
+    _ts_forbidden_defined_pack_fields,
+    _ts_rejected_pack_string_field,
+)
+
+
+OPERATOR_UI_VALIDATOR = (
+    REPO_ROOT
+    / "apps"
+    / "operator-ui"
+    / "src"
+    / "operatorDataProvider"
+    / "linkedEvidencePackValidator.ts"
 )
 
 
@@ -175,6 +187,50 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                             ai,
                         ),
                     )
+
+    def test_operator_ui_authority_and_readiness_denials_are_parsed(self) -> None:
+        source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+        self.assertEqual(
+            _ts_rejected_pack_string_field(source, "workflow_authority"),
+            "none",
+        )
+        self.assertEqual(
+            _ts_forbidden_defined_pack_fields(
+                source,
+                "cannot claim release readiness",
+            ),
+            frozenset(
+                {
+                    "release_readiness_claim",
+                    "rc_readiness_claim",
+                    "gate_readiness_claim",
+                }
+            ),
+        )
+
+    def test_operator_ui_denial_parser_observes_representative_drift(self) -> None:
+        source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+
+        workflow_drift = source.replace(
+            'workflowAuthority !== "none"',
+            'workflowAuthority !== "advisory_only"',
+        )
+        self.assertEqual(
+            _ts_rejected_pack_string_field(workflow_drift, "workflow_authority"),
+            "advisory_only",
+        )
+
+        readiness_drift = source.replace(
+            "      pack.gate_readiness_claim !== undefined\n",
+            "",
+        )
+        self.assertEqual(
+            _ts_forbidden_defined_pack_fields(
+                readiness_drift,
+                "cannot claim release readiness",
+            ),
+            frozenset({"release_readiness_claim", "rc_readiness_claim"}),
+        )
 
 
 if __name__ == "__main__":

--- a/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
+++ b/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
@@ -16,6 +16,7 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
 
 from scripts import phase63_evidence_pack_contract_guard as contract_guard  # noqa: E402
 from scripts.phase63_evidence_pack_contract_guard import (  # noqa: E402
+    _AI_GROUNDING_ALLOWED_LABEL_FIELDS,
     _ai_confidence_posture_rejection,
     _ai_no_workflow_authority_rejection,
     assert_phase63_evidence_pack_contract_aligned,
@@ -24,16 +25,22 @@ from scripts.phase63_evidence_pack_contract_guard import (  # noqa: E402
     load_phase63_evidence_pack_contracts,
     _backend_no_workflow_authority_rejection,
     _backend_confidence_posture_rejection,
+    _py_ai_state_reason_consistency_rules,
+    _py_backend_state_reason_consistency_rules,
     _py_enforced_metadata_fields,
     _py_projection_get_string_rejection_labels,
+    _py_projection_get_membership_labels,
     _py_rejected_boolean_value,
     _AI_GROUNDING_SINGLETON_LABEL_FIELDS,
+    _ts_enforced_freshness_window_milliseconds,
     _operator_ui_contract_from_source,
     _py_string_constant,
     _ts_forbidden_defined_pack_fields,
     _ts_no_workflow_authority_rejection,
+    _ts_rejected_mapping_string_field,
     _ts_rejected_pack_boolean_field,
     _ts_rejected_pack_string_field,
+    _ts_state_reason_consistency_rules,
 )
 
 
@@ -228,6 +235,18 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                 },
                 "authoritative workflow truth denial",
             ),
+            (
+                "state reason consistency",
+                {
+                    "operator_ui_contract": contract_with_drift(
+                        ui,
+                        "state_reason_consistency_rules",
+                        ui.state_reason_consistency_rules
+                        - frozenset({"uncertainty_label_matches_state"}),
+                    )
+                },
+                "state/reason consistency rules",
+            ),
         )
 
         for label, overrides, expected_message in mismatch_cases:
@@ -313,6 +332,47 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
             ).freshness_window_milliseconds,
             21600500,
         )
+
+    def test_operator_ui_freshness_window_requires_validator_call(self) -> None:
+        source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+        drifted_source = source.replace(
+            "    validateEvidencePackFreshnessWindow(\n"
+            "      custody,\n"
+            "      freshnessState,\n"
+            "      evidenceRequestId,\n"
+            "    );\n",
+            "",
+        )
+
+        with self.assertRaisesRegex(AssertionError, "FreshnessWindow"):
+            _ts_enforced_freshness_window_milliseconds(drifted_source)
+
+    def test_operator_ui_confidence_posture_uses_validator_check(self) -> None:
+        source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+        self.assertEqual(
+            _ts_rejected_mapping_string_field(source, "confidence", "posture"),
+            "external_hash_reputation_subordinate_context",
+        )
+
+        literal_drift = source.replace(
+            "asString(confidence.posture) !== EVIDENCE_PACK_CONFIDENCE_POSTURE",
+            'asString(confidence.posture) !== "workflow_truth_confidence"',
+        )
+        self.assertEqual(
+            _ts_rejected_mapping_string_field(literal_drift, "confidence", "posture"),
+            "workflow_truth_confidence",
+        )
+
+        missing_check = source.replace(
+            "    if (asString(confidence.posture) !== EVIDENCE_PACK_CONFIDENCE_POSTURE) {\n"
+            "      throw new OperatorDataProviderContractError(\n"
+            "        `Resource cases linked_evidence_packs item ${evidenceRequestId} has an unsupported confidence posture.`,\n"
+            "      );\n"
+            "    }\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "confidence.posture"):
+            _ts_rejected_mapping_string_field(missing_check, "confidence", "posture")
 
     def test_operator_ui_label_contract_requires_enforcement_calls(self) -> None:
         source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
@@ -416,6 +476,7 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
                 _AI_GROUNDING_SINGLETON_LABEL_FIELDS,
             ),
             {
+                "consumer": frozenset({"ai_grounding"}),
                 "custody_state": frozenset({"complete"}),
                 "provenance_state": frozenset({"bound"}),
                 "confidence_state": frozenset({"present"}),
@@ -433,6 +494,42 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
             )["custody_state"],
             frozenset({"reviewed"}),
         )
+
+    def test_ai_allowed_label_parser_observes_representative_drift(self) -> None:
+        from aegisops.control_plane.assistant import ai_grounding_validation
+
+        source = AI_GROUNDING_VALIDATOR.read_text(encoding="utf-8")
+        self.assertEqual(
+            _py_projection_get_membership_labels(
+                source,
+                _AI_GROUNDING_ALLOWED_LABEL_FIELDS,
+                ai_grounding_validation,
+            )["status"],
+            ai_grounding_validation._ALLOWED_STATUS,
+        )
+
+        missing_check = source.replace(
+            '    if projection.get("status") not in _ALLOWED_STATUS:\n'
+            '        reasons.append("unsupported_grounding_status")\n',
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "status"):
+            _py_projection_get_membership_labels(
+                missing_check,
+                _AI_GROUNDING_ALLOWED_LABEL_FIELDS,
+                ai_grounding_validation,
+            )
+
+        wrong_constant = source.replace(
+            'projection.get("status") not in _ALLOWED_STATUS',
+            'projection.get("status") not in _ALLOWED_FRESHNESS',
+        )
+        with self.assertRaisesRegex(AssertionError, "unexpected constant"):
+            _py_projection_get_membership_labels(
+                wrong_constant,
+                _AI_GROUNDING_ALLOWED_LABEL_FIELDS,
+                ai_grounding_validation,
+            )
 
     def test_ai_no_workflow_authority_parser_observes_representative_drift(
         self,
@@ -497,19 +594,25 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
         )
 
         drifted_namespace = SimpleNamespace(
+            _REQUIRED_CUSTODY_FIELDS=ai_grounding_validation._REQUIRED_CUSTODY_FIELDS,
+            _REQUIRED_PROVENANCE_FIELDS=(
+                ai_grounding_validation._REQUIRED_PROVENANCE_FIELDS
+            ),
+            _REQUIRED_CONFIDENCE_FIELDS=(
+                tuple(
+                    field
+                    for field in ai_grounding_validation._REQUIRED_CONFIDENCE_FIELDS
+                    if field != "ambiguity_badge"
+                )
+            ),
             _ALLOWED_CUSTODY_FIELDS=ai_grounding_validation._ALLOWED_CUSTODY_FIELDS,
             _ALLOWED_PROVENANCE_FIELDS=(
                 ai_grounding_validation._ALLOWED_PROVENANCE_FIELDS
             ),
-            _ALLOWED_CONFIDENCE_FIELDS=(
-                ai_grounding_validation._ALLOWED_CONFIDENCE_FIELDS
-                - frozenset({"ambiguity_badge"})
-            ),
+            _ALLOWED_CONFIDENCE_FIELDS=ai_grounding_validation._ALLOWED_CONFIDENCE_FIELDS,
         )
-        self.assertNotEqual(
-            _py_enforced_metadata_fields(source, drifted_namespace)["confidence"],
-            ai_grounding_validation._REQUIRED_CONFIDENCE_FIELDS,
-        )
+        with self.assertRaisesRegex(AssertionError, "metadata enforcement"):
+            _py_enforced_metadata_fields(source, drifted_namespace)
 
     def test_workflow_truth_boolean_rejections_are_parsed(self) -> None:
         backend_source = BACKEND_EVIDENCE_PACK_PROJECTION.read_text(encoding="utf-8")
@@ -564,6 +667,51 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
             _, _, ai = load_phase63_evidence_pack_contracts(REPO_ROOT)
 
         self.assertNotIn("readiness_truth", ai.authority_truth_denials)
+
+    def test_state_reason_consistency_rules_are_loaded_from_validators(self) -> None:
+        backend_source = BACKEND_EVIDENCE_PACK_PROJECTION.read_text(encoding="utf-8")
+        ai_source = AI_GROUNDING_VALIDATOR.read_text(encoding="utf-8")
+        ui_source = OPERATOR_UI_VALIDATOR.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "uncertainty_label_matches_state",
+            _py_backend_state_reason_consistency_rules(backend_source),
+        )
+        self.assertIn(
+            "available_status_has_no_reasons",
+            _py_ai_state_reason_consistency_rules(ai_source),
+        )
+        self.assertIn(
+            "confidence_ambiguity_badge_matches_conflict",
+            _ts_state_reason_consistency_rules(ui_source),
+        )
+
+        backend_drift = backend_source.replace(
+            'values["status"] == "available"',
+            'values["status"] == "ready"',
+        )
+        with self.assertRaisesRegex(AssertionError, "state/reason"):
+            _py_backend_state_reason_consistency_rules(backend_drift)
+
+        ai_drift = ai_source.replace(
+            "    reasons.extend(_state_consistency_reasons(projection))\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "state/reason"):
+            _py_ai_state_reason_consistency_rules(ai_drift)
+
+        ui_drift = ui_source.replace(
+            "    validateEvidencePackReasonConsistency(pack, confidence, {\n"
+            "      status,\n"
+            "      freshnessState,\n"
+            "      conflictState,\n"
+            "      sourceState,\n"
+            "      uncertaintyLabel,\n"
+            "    });\n",
+            "",
+        )
+        with self.assertRaisesRegex(AssertionError, "ReasonConsistency"):
+            _ts_state_reason_consistency_rules(ui_drift)
 
     def test_python_string_constant_does_not_require_legacy_ast_str(self) -> None:
         legacy_ast_str = getattr(contract_guard.ast, "Str", None)

--- a/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
+++ b/control-plane/tests/test_phase63_evidence_pack_contract_drift_guard.py
@@ -3,18 +3,24 @@ from __future__ import annotations
 import pathlib
 import sys
 import unittest
+from unittest import mock
 
 TESTS_ROOT = pathlib.Path(__file__).resolve().parent
 CONTROL_PLANE_ROOT = TESTS_ROOT.parent
 REPO_ROOT = CONTROL_PLANE_ROOT.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
+if str(CONTROL_PLANE_ROOT) not in sys.path:
+    sys.path.insert(0, str(CONTROL_PLANE_ROOT))
 
 from scripts.phase63_evidence_pack_contract_guard import (  # noqa: E402
     assert_phase63_evidence_pack_contract_aligned,
     contract_with_drift,
     contract_with_label_drift,
     load_phase63_evidence_pack_contracts,
+    _backend_no_workflow_authority_rejection,
+    _py_projection_get_string_rejection_labels,
+    _AI_GROUNDING_SINGLETON_LABEL_FIELDS,
     _ts_forbidden_defined_pack_fields,
     _ts_rejected_pack_string_field,
 )
@@ -27,6 +33,22 @@ OPERATOR_UI_VALIDATOR = (
     / "src"
     / "operatorDataProvider"
     / "linkedEvidencePackValidator.ts"
+)
+BACKEND_EVIDENCE_PACK_PROJECTION = (
+    REPO_ROOT
+    / "control-plane"
+    / "aegisops"
+    / "control_plane"
+    / "inspection"
+    / "evidence_pack_projection.py"
+)
+AI_GROUNDING_VALIDATOR = (
+    REPO_ROOT
+    / "control-plane"
+    / "aegisops"
+    / "control_plane"
+    / "assistant"
+    / "ai_grounding_validation.py"
 )
 
 
@@ -231,6 +253,62 @@ class Phase63EvidencePackContractDriftGuardTests(unittest.TestCase):
             ),
             frozenset({"release_readiness_claim", "rc_readiness_claim"}),
         )
+
+    def test_backend_authority_parser_observes_representative_drift(self) -> None:
+        source = BACKEND_EVIDENCE_PACK_PROJECTION.read_text(encoding="utf-8")
+        self.assertEqual(_backend_no_workflow_authority_rejection(source), "none")
+
+        drifted_source = source.replace(
+            'typed_values["workflow_authority"] != "none"',
+            'typed_values["workflow_authority"] != "advisory_only"',
+        )
+        with self.assertRaisesRegex(AssertionError, "backend workflow authority"):
+            _backend_no_workflow_authority_rejection(drifted_source)
+
+    def test_ai_singleton_label_parser_observes_representative_drift(self) -> None:
+        source = AI_GROUNDING_VALIDATOR.read_text(encoding="utf-8")
+        self.assertEqual(
+            _py_projection_get_string_rejection_labels(
+                source,
+                _AI_GROUNDING_SINGLETON_LABEL_FIELDS,
+            ),
+            {
+                "custody_state": frozenset({"complete"}),
+                "provenance_state": frozenset({"bound"}),
+                "confidence_state": frozenset({"present"}),
+            },
+        )
+
+        drifted_source = source.replace(
+            'projection.get("custody_state") != "complete"',
+            'projection.get("custody_state") != "reviewed"',
+        )
+        self.assertEqual(
+            _py_projection_get_string_rejection_labels(
+                drifted_source,
+                _AI_GROUNDING_SINGLETON_LABEL_FIELDS,
+            )["custody_state"],
+            frozenset({"reviewed"}),
+        )
+
+    def test_ai_authority_truth_denials_follow_scanner(self) -> None:
+        from aegisops.control_plane.assistant import ai_grounding_validation
+
+        original_scanner = ai_grounding_validation._scan_for_authority_claim
+
+        def scanner_with_gap(value: object) -> bool:
+            if value == "readiness_truth":
+                return False
+            return original_scanner(value)
+
+        with mock.patch.object(
+            ai_grounding_validation,
+            "_scan_for_authority_claim",
+            side_effect=scanner_with_gap,
+        ):
+            _, _, ai = load_phase63_evidence_pack_contracts(REPO_ROOT)
+
+        self.assertNotIn("readiness_truth", ai.authority_truth_denials)
 
 
 if __name__ == "__main__":

--- a/docs/phase-63-closeout-evaluation.md
+++ b/docs/phase-63-closeout-evaluation.md
@@ -244,6 +244,7 @@ Focused backend, UI, AI, registry, path hygiene, and maintainability commands th
 
 - `python3 -m unittest control-plane.tests.test_phase63_5_evidence_freshness_provenance_projection`
 - `python3 -m unittest control-plane.tests.test_phase63_7_ai_grounding_adapter`
+- `python3 -m unittest control-plane.tests.test_phase63_evidence_pack_contract_drift_guard`
 - `python3 -m unittest control-plane.tests.test_phase63_evidence_source_registry`
 - `npm run test --workspace @aegisops/operator-ui -- detailReaders.evidence-pack-extraction.test.ts OperatorRoutes.casework.evidence-pack.test.tsx`
 - `npm run typecheck --workspace @aegisops/operator-ui`
@@ -266,6 +267,8 @@ Issue-lint evidence:
 Each Phase 63.R issue-lint command should report `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, and `high_risk_blocking_ambiguity=none`.
 
 The maintainability hotspot verifier remains unchanged and continues to report only the reviewed `service.py` baseline rather than hiding a new Phase 63.R hotspot.
+
+The Phase 63 evidence-pack contract drift guard compares the overlapping backend projection, operator-ui validation, and AI grounding validation contract for labels, reason sets, custody/provenance/confidence fields, source IDs, freshness window, uncertainty labels, forbidden projection sources, readiness-claim rejection, and no-authority posture. The guard is review evidence only and does not add product behavior, evidence-source breadth, UI authority, AI authority, verifier authority, source-native truth, issue-lint truth, or readiness truth.
 
 Observed closeout results from this branch:
 

--- a/scripts/phase63_evidence_pack_contract_guard.py
+++ b/scripts/phase63_evidence_pack_contract_guard.py
@@ -56,7 +56,7 @@ class Phase63EvidencePackContract:
     subordinate_authority_posture: str
     no_workflow_authority: str
     confidence_posture: str
-    freshness_window_seconds: int
+    freshness_window_milliseconds: int
     forbidden_projection_sources: frozenset[str]
     forbidden_readiness_claim_fields: frozenset[str]
     authority_truth_denials: frozenset[str]
@@ -136,9 +136,9 @@ def assert_phase63_evidence_pack_contract_aligned(
     )
     _assert_equal(
         "freshness window",
-        backend.freshness_window_seconds,
-        ui.freshness_window_seconds,
-        ai.freshness_window_seconds,
+        backend.freshness_window_milliseconds,
+        ui.freshness_window_milliseconds,
+        ai.freshness_window_milliseconds,
     )
     _assert_equal(
         "subordinate authority posture",
@@ -256,8 +256,9 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
             validator_source
         ),
         confidence_posture=registry_entry.confidence_posture,
-        freshness_window_seconds=source_projection._parse_duration_seconds(
-            registry_entry.freshness_window
+        freshness_window_milliseconds=(
+            source_projection._parse_duration_seconds(registry_entry.freshness_window)
+            * 1000
         ),
         forbidden_projection_sources=frozenset(
             inspection_projection._EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES
@@ -329,8 +330,9 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
         ),
         no_workflow_authority=ai_grounding_validation._NO_WORKFLOW_AUTHORITY,
         confidence_posture=registry_entry.confidence_posture,
-        freshness_window_seconds=source_projection._parse_duration_seconds(
-            registry_entry.freshness_window
+        freshness_window_milliseconds=(
+            source_projection._parse_duration_seconds(registry_entry.freshness_window)
+            * 1000
         ),
         forbidden_projection_sources=frozenset(),
         forbidden_readiness_claim_fields=frozenset(),
@@ -351,6 +353,10 @@ def _operator_ui_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContrac
         / "operatorDataProvider"
         / "linkedEvidencePackValidator.ts"
     ).read_text(encoding="utf-8")
+    return _operator_ui_contract_from_source(source)
+
+
+def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContract:
     labels = _ts_allowed_labels(source)
     freshness_window_ms = _ts_number_expression(
         source,
@@ -391,7 +397,7 @@ def _operator_ui_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContrac
             source,
             "EVIDENCE_PACK_CONFIDENCE_POSTURE",
         ),
-        freshness_window_seconds=freshness_window_ms // 1000,
+        freshness_window_milliseconds=freshness_window_ms,
         forbidden_projection_sources=_ts_set(
             source,
             "EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES",
@@ -413,7 +419,7 @@ def _ts_allowed_labels(source: str) -> dict[str, frozenset[str]]:
     if match is None:
         raise AssertionError("operator UI evidence-pack labels are not discoverable")
     body = match.group("body")
-    return {
+    labels = {
         key: frozenset(_string_literals(value_source))
         for key, value_source in re.findall(
             r"(\w+):\s*new Set\(\[(.*?)\]\),",
@@ -421,6 +427,21 @@ def _ts_allowed_labels(source: str) -> dict[str, frozenset[str]]:
             re.S,
         )
     }
+    enforced_labels = _ts_enforced_label_keys(source)
+    if frozenset(labels) != enforced_labels:
+        raise AssertionError("operator UI evidence-pack label enforcement drift")
+    return labels
+
+
+def _ts_enforced_label_keys(source: str) -> frozenset[str]:
+    labels = frozenset(
+        re.findall(r'\bvalidateEvidencePackLabel\(\s*"([^"]+)"\s*,', source)
+    )
+    if not labels:
+        raise AssertionError(
+            "operator UI evidence-pack label enforcement is not discoverable"
+        )
+    return labels
 
 
 def _backend_no_workflow_authority_rejection(source: str) -> str:
@@ -504,7 +525,8 @@ def _py_rejection_target(node: ast.AST) -> tuple[str, str, str] | None:
 
 
 def _py_subscript_key(node: ast.AST) -> str | None:
-    if isinstance(node, ast.Index):
+    index_type = getattr(ast, "Index", None)
+    if index_type is not None and isinstance(node, index_type):
         node = node.value
     return _py_string_constant(node)
 
@@ -512,8 +534,6 @@ def _py_subscript_key(node: ast.AST) -> str | None:
 def _py_string_constant(node: ast.AST) -> str | None:
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return node.value
-    if isinstance(node, ast.Str):
-        return node.s
     return None
 
 

--- a/scripts/phase63_evidence_pack_contract_guard.py
+++ b/scripts/phase63_evidence_pack_contract_guard.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, replace
+import pathlib
+import re
+import sys
+from types import MappingProxyType
+from typing import Mapping
+
+
+_LABEL_KEYS = (
+    "consumer",
+    "status",
+    "freshness_state",
+    "custody_state",
+    "confidence_state",
+    "provenance_state",
+    "conflict_state",
+    "source_state",
+    "uncertainty_label",
+)
+_SHARED_LABEL_KEYS = tuple(key for key in _LABEL_KEYS if key != "consumer")
+_AUTHORITY_TRUTH_DENIALS = frozenset(
+    {
+        "evidence_truth_creation",
+        "source_truth_creation",
+        "readiness_truth",
+        "release_truth",
+        "workflow_truth",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Phase63EvidencePackContract:
+    labels: Mapping[str, frozenset[str]]
+    degraded_reasons: frozenset[str]
+    unavailable_reasons: frozenset[str]
+    required_custody_fields: frozenset[str]
+    required_provenance_fields: frozenset[str]
+    required_confidence_fields: frozenset[str]
+    contract_fields: frozenset[str]
+    supported_source_ids: frozenset[str]
+    subordinate_authority_posture: str
+    no_workflow_authority: str
+    confidence_posture: str
+    freshness_window_seconds: int
+    forbidden_projection_sources: frozenset[str]
+    forbidden_readiness_claim_fields: frozenset[str]
+    authority_truth_denials: frozenset[str]
+
+
+def assert_phase63_evidence_pack_contract_aligned(
+    repo_root: pathlib.Path | str | None = None,
+    *,
+    backend_contract: Phase63EvidencePackContract | None = None,
+    operator_ui_contract: Phase63EvidencePackContract | None = None,
+    ai_grounding_contract: Phase63EvidencePackContract | None = None,
+) -> None:
+    root = pathlib.Path(repo_root) if repo_root is not None else _default_repo_root()
+    backend = backend_contract or _backend_contract(root)
+    ui = operator_ui_contract or _operator_ui_contract(root)
+    ai = ai_grounding_contract or _ai_grounding_contract(root)
+
+    _assert_equal(
+        "case-workbench consumer labels",
+        backend.labels["consumer"],
+        frozenset({"case_workbench"}),
+    )
+    _assert_equal(
+        "operator-ui consumer labels",
+        ui.labels["consumer"],
+        backend.labels["consumer"],
+    )
+    _assert_equal(
+        "AI grounding consumer labels",
+        ai.labels["consumer"],
+        frozenset({"ai_grounding"}),
+    )
+    for label_key in _SHARED_LABEL_KEYS:
+        _assert_equal(
+            f"{label_key} labels",
+            backend.labels[label_key],
+            ui.labels[label_key],
+            ai.labels[label_key],
+        )
+
+    _assert_equal(
+        "degraded reasons",
+        backend.degraded_reasons,
+        ui.degraded_reasons,
+        ai.degraded_reasons,
+    )
+    _assert_equal(
+        "unavailable reasons",
+        backend.unavailable_reasons,
+        ui.unavailable_reasons,
+        ai.unavailable_reasons,
+    )
+    _assert_equal(
+        "custody fields",
+        backend.required_custody_fields,
+        ui.required_custody_fields,
+        ai.required_custody_fields,
+    )
+    _assert_equal(
+        "provenance fields",
+        backend.required_provenance_fields,
+        ui.required_provenance_fields,
+        ai.required_provenance_fields,
+    )
+    _assert_equal(
+        "confidence fields",
+        backend.required_confidence_fields,
+        ui.required_confidence_fields,
+        ai.required_confidence_fields,
+    )
+    _assert_equal("contract fields", backend.contract_fields, ui.contract_fields)
+    _assert_equal(
+        "source IDs",
+        backend.supported_source_ids,
+        ui.supported_source_ids,
+        ai.supported_source_ids,
+    )
+    _assert_equal(
+        "freshness window",
+        backend.freshness_window_seconds,
+        ui.freshness_window_seconds,
+        ai.freshness_window_seconds,
+    )
+    _assert_equal(
+        "subordinate authority posture",
+        backend.subordinate_authority_posture,
+        ui.subordinate_authority_posture,
+        ai.subordinate_authority_posture,
+    )
+    _assert_equal(
+        "no workflow authority",
+        backend.no_workflow_authority,
+        ui.no_workflow_authority,
+        ai.no_workflow_authority,
+    )
+    _assert_equal(
+        "confidence posture",
+        backend.confidence_posture,
+        ui.confidence_posture,
+        ai.confidence_posture,
+    )
+    _assert_equal(
+        "forbidden projection sources",
+        backend.forbidden_projection_sources,
+        ui.forbidden_projection_sources,
+    )
+    _assert_equal(
+        "readiness claim fields",
+        backend.forbidden_readiness_claim_fields,
+        ui.forbidden_readiness_claim_fields,
+    )
+    _assert_equal(
+        "AI authority truth denial posture",
+        _AUTHORITY_TRUTH_DENIALS,
+        ai.authority_truth_denials & _AUTHORITY_TRUTH_DENIALS,
+    )
+
+
+def load_phase63_evidence_pack_contracts(
+    repo_root: pathlib.Path | str | None = None,
+) -> tuple[
+    Phase63EvidencePackContract,
+    Phase63EvidencePackContract,
+    Phase63EvidencePackContract,
+]:
+    root = pathlib.Path(repo_root) if repo_root is not None else _default_repo_root()
+    return (
+        _backend_contract(root),
+        _operator_ui_contract(root),
+        _ai_grounding_contract(root),
+    )
+
+
+def _default_repo_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[1]
+
+
+def _ensure_control_plane_path(repo_root: pathlib.Path) -> None:
+    control_plane_root = repo_root / "control-plane"
+    if str(control_plane_root) not in sys.path:
+        sys.path.insert(0, str(control_plane_root))
+
+
+def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
+    _ensure_control_plane_path(repo_root)
+    from aegisops.control_plane.evidence import (  # noqa: WPS433
+        evidence_freshness_provenance_projection as source_projection,
+    )
+    from aegisops.control_plane.evidence.evidence_source_registry import (  # noqa: WPS433
+        PHASE63_EVIDENCE_SOURCE_REGISTRY,
+    )
+    from aegisops.control_plane.inspection import (  # noqa: WPS433
+        evidence_pack_projection as inspection_projection,
+    )
+
+    source_id = inspection_projection._EVIDENCE_PACK_SUPPORTED_SOURCE_ID
+    registry_entry = PHASE63_EVIDENCE_SOURCE_REGISTRY[source_id]
+    labels = {
+        key: frozenset(
+            inspection_projection._EVIDENCE_PACK_ALLOWED_PROJECTION_LABELS[key]
+        )
+        for key in _LABEL_KEYS
+    }
+    return Phase63EvidencePackContract(
+        labels=MappingProxyType(labels),
+        degraded_reasons=frozenset(
+            inspection_projection._EVIDENCE_PACK_ALLOWED_DEGRADED_REASONS
+        ),
+        unavailable_reasons=frozenset(
+            inspection_projection._EVIDENCE_PACK_ALLOWED_UNAVAILABLE_REASONS
+        ),
+        required_custody_fields=frozenset(
+            inspection_projection._EVIDENCE_PACK_REQUIRED_CUSTODY_FIELDS
+        ),
+        required_provenance_fields=frozenset(
+            inspection_projection._EVIDENCE_PACK_REQUIRED_PROVENANCE_FIELDS
+        ),
+        required_confidence_fields=frozenset(
+            inspection_projection._EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS
+        ),
+        contract_fields=frozenset(
+            inspection_projection._EVIDENCE_PACK_PROJECTION_CONTRACT_FIELDS
+        ),
+        supported_source_ids=frozenset({source_id}),
+        subordinate_authority_posture=(
+            inspection_projection._EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE
+        ),
+        no_workflow_authority=source_projection._NO_WORKFLOW_AUTHORITY,
+        confidence_posture=registry_entry.confidence_posture,
+        freshness_window_seconds=source_projection._parse_duration_seconds(
+            registry_entry.freshness_window
+        ),
+        forbidden_projection_sources=frozenset(
+            inspection_projection._EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES
+        ),
+        forbidden_readiness_claim_fields=frozenset(
+            inspection_projection._EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS
+        ),
+        authority_truth_denials=frozenset(),
+    )
+
+
+def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
+    _ensure_control_plane_path(repo_root)
+    from aegisops.control_plane.assistant import ai_grounding_validation  # noqa: WPS433
+    from aegisops.control_plane.evidence import (  # noqa: WPS433
+        evidence_freshness_provenance_projection as source_projection,
+    )
+    from aegisops.control_plane.evidence.evidence_source_registry import (  # noqa: WPS433
+        PHASE63_EVIDENCE_SOURCE_REGISTRY,
+    )
+
+    source_ids = frozenset(ai_grounding_validation._SUPPORTED_GROUNDING_SOURCE_IDS)
+    if len(source_ids) != 1:
+        raise AssertionError("AI grounding source IDs must stay explicit")
+    source_id = next(iter(source_ids))
+    registry_entry = PHASE63_EVIDENCE_SOURCE_REGISTRY[source_id]
+    labels = {
+        "consumer": frozenset({"ai_grounding"}),
+        "status": frozenset(ai_grounding_validation._ALLOWED_STATUS),
+        "freshness_state": frozenset(ai_grounding_validation._ALLOWED_FRESHNESS),
+        "custody_state": frozenset({"complete"}),
+        "confidence_state": frozenset({"present"}),
+        "provenance_state": frozenset({"bound"}),
+        "conflict_state": frozenset(ai_grounding_validation._ALLOWED_CONFLICT),
+        "source_state": frozenset(ai_grounding_validation._ALLOWED_SOURCE_STATE),
+        "uncertainty_label": frozenset(ai_grounding_validation._ALLOWED_UNCERTAINTY),
+    }
+    return Phase63EvidencePackContract(
+        labels=MappingProxyType(labels),
+        degraded_reasons=frozenset(ai_grounding_validation._ALLOWED_DEGRADED_REASONS),
+        unavailable_reasons=frozenset(
+            ai_grounding_validation._ALLOWED_UNAVAILABLE_REASONS
+        ),
+        required_custody_fields=frozenset(
+            ai_grounding_validation._REQUIRED_CUSTODY_FIELDS
+        ),
+        required_provenance_fields=frozenset(
+            ai_grounding_validation._REQUIRED_PROVENANCE_FIELDS
+        ),
+        required_confidence_fields=frozenset(
+            ai_grounding_validation._REQUIRED_CONFIDENCE_FIELDS
+        ),
+        contract_fields=frozenset(),
+        supported_source_ids=source_ids,
+        subordinate_authority_posture=(
+            ai_grounding_validation._SUBORDINATE_AUTHORITY_POSTURE
+        ),
+        no_workflow_authority=ai_grounding_validation._NO_WORKFLOW_AUTHORITY,
+        confidence_posture=registry_entry.confidence_posture,
+        freshness_window_seconds=source_projection._parse_duration_seconds(
+            registry_entry.freshness_window
+        ),
+        forbidden_projection_sources=frozenset(),
+        forbidden_readiness_claim_fields=frozenset(),
+        authority_truth_denials=frozenset(ai_grounding_validation._NEGATIVE_AUTHORITY),
+    )
+
+
+def _operator_ui_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
+    source = (
+        repo_root
+        / "apps"
+        / "operator-ui"
+        / "src"
+        / "operatorDataProvider"
+        / "linkedEvidencePackValidator.ts"
+    ).read_text(encoding="utf-8")
+    labels = _ts_allowed_labels(source)
+    freshness_window_ms = _ts_number_expression(
+        source,
+        "EVIDENCE_PACK_FRESHNESS_WINDOW_MS",
+    )
+    return Phase63EvidencePackContract(
+        labels=MappingProxyType(labels),
+        degraded_reasons=_ts_set(source, "EVIDENCE_PACK_ALLOWED_DEGRADED_REASONS"),
+        unavailable_reasons=_ts_set(
+            source,
+            "EVIDENCE_PACK_ALLOWED_UNAVAILABLE_REASONS",
+        ),
+        required_custody_fields=_ts_set(
+            source,
+            "EVIDENCE_PACK_REQUIRED_CUSTODY_FIELDS",
+        ),
+        required_provenance_fields=_ts_set(
+            source,
+            "EVIDENCE_PACK_REQUIRED_PROVENANCE_FIELDS",
+        ),
+        required_confidence_fields=_ts_set(
+            source,
+            "EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS",
+        ),
+        contract_fields=_ts_set(source, "EVIDENCE_PACK_CONTRACT_FIELDS"),
+        supported_source_ids=frozenset(
+            {_ts_string_constant(source, "EVIDENCE_PACK_SUPPORTED_SOURCE_ID")}
+        ),
+        subordinate_authority_posture=_ts_string_constant(
+            source,
+            "EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE",
+        ),
+        no_workflow_authority="none",
+        confidence_posture=_ts_string_constant(
+            source,
+            "EVIDENCE_PACK_CONFIDENCE_POSTURE",
+        ),
+        freshness_window_seconds=freshness_window_ms // 1000,
+        forbidden_projection_sources=_ts_set(
+            source,
+            "EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES",
+        ),
+        forbidden_readiness_claim_fields=frozenset(
+            {
+                "release_readiness_claim",
+                "rc_readiness_claim",
+                "gate_readiness_claim",
+            }
+        ),
+        authority_truth_denials=frozenset(),
+    )
+
+
+def _ts_allowed_labels(source: str) -> dict[str, frozenset[str]]:
+    match = re.search(
+        r"const EVIDENCE_PACK_ALLOWED_LABELS = \{(?P<body>.*?)\n\};",
+        source,
+        re.S,
+    )
+    if match is None:
+        raise AssertionError("operator UI evidence-pack labels are not discoverable")
+    body = match.group("body")
+    return {
+        key: frozenset(_string_literals(value_source))
+        for key, value_source in re.findall(
+            r"(\w+):\s*new Set\(\[(.*?)\]\),",
+            body,
+            re.S,
+        )
+    }
+
+
+def _ts_set(source: str, name: str) -> frozenset[str]:
+    match = re.search(
+        rf"const {re.escape(name)} = new Set\(\[(?P<body>.*?)\]\);",
+        source,
+        re.S,
+    )
+    if match is None:
+        raise AssertionError(f"operator UI constant {name} is not discoverable")
+    return frozenset(_string_literals(match.group("body")))
+
+
+def _ts_string_constant(source: str, name: str) -> str:
+    match = re.search(rf'const {re.escape(name)} =\s*"([^"]+)";', source)
+    if match is None:
+        raise AssertionError(f"operator UI constant {name} is not discoverable")
+    return match.group(1)
+
+
+def _ts_number_expression(source: str, name: str) -> int:
+    match = re.search(rf"const {re.escape(name)} =\s*([0-9\s*+/()-]+);", source)
+    if match is None:
+        raise AssertionError(f"operator UI constant {name} is not discoverable")
+    expression = match.group(1)
+    if not re.fullmatch(r"[0-9\s*+/()-]+", expression):
+        raise AssertionError(f"operator UI constant {name} is not a safe expression")
+    return _safe_integer_expression(expression)
+
+
+def _safe_integer_expression(expression: str) -> int:
+    def evaluate(node: ast.AST) -> int:
+        if isinstance(node, ast.Expression):
+            return evaluate(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, int):
+            return node.value
+        if isinstance(node, ast.BinOp) and isinstance(
+            node.op,
+            (ast.Add, ast.Sub, ast.Mult, ast.FloorDiv, ast.Div),
+        ):
+            left = evaluate(node.left)
+            right = evaluate(node.right)
+            if isinstance(node.op, ast.Add):
+                return left + right
+            if isinstance(node.op, ast.Sub):
+                return left - right
+            if isinstance(node.op, ast.Mult):
+                return left * right
+            if right == 0:
+                raise AssertionError("operator UI numeric constant divides by zero")
+            if isinstance(node.op, ast.FloorDiv):
+                return left // right
+            if left % right != 0:
+                raise AssertionError("operator UI numeric constant is not integral")
+            return left // right
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            return -evaluate(node.operand)
+        raise AssertionError("operator UI numeric constant is not a safe expression")
+
+    return evaluate(ast.parse(expression, mode="eval"))
+
+
+def _string_literals(value: str) -> tuple[str, ...]:
+    return tuple(re.findall(r'"([^"]+)"', value))
+
+
+def _assert_equal(label: str, first: object, *others: object) -> None:
+    for other in others:
+        if first != other:
+            raise AssertionError(f"Phase 63 evidence-pack contract drift: {label}")
+
+
+def contract_with_drift(
+    contract: Phase63EvidencePackContract,
+    field_name: str,
+    value: object,
+) -> Phase63EvidencePackContract:
+    return replace(contract, **{field_name: value})
+
+
+def contract_with_label_drift(
+    contract: Phase63EvidencePackContract,
+    label_name: str,
+    values: frozenset[str],
+) -> Phase63EvidencePackContract:
+    labels = dict(contract.labels)
+    labels[label_name] = values
+    return replace(contract, labels=MappingProxyType(labels))

--- a/scripts/phase63_evidence_pack_contract_guard.py
+++ b/scripts/phase63_evidence_pack_contract_guard.py
@@ -94,6 +94,14 @@ _METADATA_FORMAT_RULES = frozenset(
     }
 )
 _CACHE_BOOLEAN_FALSE_FIELDS = frozenset({"cache_sourced", "stale_cache"})
+_BOUNDED_EVIDENCE_PACK_SOURCE_IDS = frozenset({"malwarebazaar_hash_reputation"})
+_FORBIDDEN_READINESS_CLAIM_FIELDS = frozenset(
+    {
+        "release_readiness_claim",
+        "rc_readiness_claim",
+        "gate_readiness_claim",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -219,6 +227,7 @@ def assert_phase63_evidence_pack_contract_aligned(
         backend.supported_source_ids,
         ui.supported_source_ids,
         ai.supported_source_ids,
+        _BOUNDED_EVIDENCE_PACK_SOURCE_IDS,
     )
     _assert_equal(
         "freshness window",
@@ -250,6 +259,7 @@ def assert_phase63_evidence_pack_contract_aligned(
         backend.authoritative_workflow_truth,
         ui.authoritative_workflow_truth,
         ai.authoritative_workflow_truth,
+        False,
     )
     _assert_equal(
         "confidence posture",
@@ -272,6 +282,8 @@ def assert_phase63_evidence_pack_contract_aligned(
         "readiness claim fields",
         backend.forbidden_readiness_claim_fields,
         ui.forbidden_readiness_claim_fields,
+        ai.forbidden_readiness_claim_fields,
+        _FORBIDDEN_READINESS_CLAIM_FIELDS,
     )
     _assert_equal(
         "AI authority truth denial posture",
@@ -490,7 +502,10 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
         ),
         forbidden_projection_sources=frozenset(),
         cache_boolean_false_fields=frozenset(),
-        forbidden_readiness_claim_fields=frozenset(),
+        forbidden_readiness_claim_fields=_py_ai_forbidden_readiness_claim_rejection(
+            validator_source,
+            ai_grounding_validation,
+        ),
         authority_truth_denials=_py_ai_authority_truth_denials(
             validator_source,
             ai_grounding_validation,
@@ -499,6 +514,11 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
 
 
 def _operator_ui_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
+    _ensure_control_plane_path(repo_root)
+    from aegisops.control_plane.evidence.evidence_source_registry import (  # noqa: WPS433
+        PHASE63_EVIDENCE_SOURCE_REGISTRY,
+    )
+
     source = (
         repo_root
         / "apps"
@@ -507,10 +527,21 @@ def _operator_ui_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContrac
         / "operatorDataProvider"
         / "linkedEvidencePackValidator.ts"
     ).read_text(encoding="utf-8")
-    return _operator_ui_contract_from_source(source)
+    supported_source_id = _ts_rejected_pack_string_field(source, "source_id")
+    registry_entry = PHASE63_EVIDENCE_SOURCE_REGISTRY.get(supported_source_id)
+    if registry_entry is None:
+        raise AssertionError("operator UI supported evidence-pack source is unregistered")
+    return _operator_ui_contract_from_source(
+        source,
+        source_registry_status=registry_entry.status,
+    )
 
 
-def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContract:
+def _operator_ui_contract_from_source(
+    source: str,
+    *,
+    source_registry_status: str = "enabled",
+) -> Phase63EvidencePackContract:
     labels = _ts_allowed_labels(source)
     metadata_fields = _ts_enforced_metadata_fields(source)
     reason_sets = _ts_enforced_reason_sets(source)
@@ -548,7 +579,10 @@ def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContrac
         freshness_window_milliseconds=_ts_enforced_freshness_window_milliseconds(
             source
         ),
-        state_reason_consistency_rules=_ts_state_reason_consistency_rules(source),
+        state_reason_consistency_rules=_ts_state_reason_consistency_rules(
+            source,
+            source_registry_status=source_registry_status,
+        ),
         forbidden_projection_sources=_ts_forbidden_projection_sources_rejection(source),
         cache_boolean_false_fields=_ts_cache_boolean_rejections(source),
         forbidden_readiness_claim_fields=_ts_forbidden_defined_pack_fields(
@@ -1148,6 +1182,23 @@ def _py_backend_forbidden_readiness_claim_rejection(
         "backend readiness-claim rejection",
     )
     return frozenset(getattr(namespace, "_EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS"))
+
+
+def _py_ai_forbidden_readiness_claim_rejection(
+    source: str,
+    namespace: object,
+) -> frozenset[str]:
+    body = _py_function_source(source, "_projection_reasons")
+    _require_substrings(
+        body,
+        (
+            "claim_name in projection",
+            "for claim_name in _FORBIDDEN_READINESS_CLAIMS",
+            'reasons.append("grounding_authority_promotion_attempt")',
+        ),
+        "AI readiness-claim rejection",
+    )
+    return frozenset(getattr(namespace, "_FORBIDDEN_READINESS_CLAIMS"))
 
 
 def _py_backend_provenance_binding_rules(source: str) -> frozenset[str]:
@@ -1843,7 +1894,11 @@ def _ts_enforced_freshness_window_milliseconds(source: str) -> int:
     return _ts_number_expression(source, "EVIDENCE_PACK_FRESHNESS_WINDOW_MS")
 
 
-def _ts_state_reason_consistency_rules(source: str) -> frozenset[str]:
+def _ts_state_reason_consistency_rules(
+    source: str,
+    *,
+    source_registry_status: str = "enabled",
+) -> frozenset[str]:
     function_body = _ts_function_body(source, "validateEvidencePackReasonConsistency")
     _ts_require_call(
         source,
@@ -1854,6 +1909,7 @@ def _ts_state_reason_consistency_rules(source: str) -> frozenset[str]:
             "{\n      status,\n      freshnessState,\n      conflictState,\n      sourceState,\n      uncertaintyLabel,\n    }",
         ),
     )
+    _ts_source_reason_registry_status_check(function_body, source_registry_status)
     return _state_reason_consistency_rules_from_requirements(
         {
             "available_status_has_no_reasons": (
@@ -1903,6 +1959,34 @@ def _ts_state_reason_consistency_rules(source: str) -> frozenset[str]:
         function_body,
         "operator UI state/reason consistency",
     )
+
+
+def _ts_source_reason_registry_status_check(
+    function_body: str,
+    source_registry_status: str,
+) -> None:
+    rejects_registry_transition_reasons = all(
+        substring in function_body
+        for substring in (
+            'degradedReasons.includes("source_stale")',
+            'unavailableReasons.includes("source_denied")',
+            "throw new OperatorDataProviderContractError(inconsistentMessage)",
+        )
+    )
+    if source_registry_status == "enabled":
+        if not rejects_registry_transition_reasons:
+            raise AssertionError(
+                "operator UI enabled-source reason rejection is not discoverable"
+            )
+        return
+    if source_registry_status in {"degraded", "disabled"}:
+        if rejects_registry_transition_reasons:
+            raise AssertionError(
+                "operator UI source-state registry-status enforcement rejects "
+                "valid source-state reasons"
+            )
+        return
+    raise AssertionError("operator UI source registry status is unsupported")
 
 
 def _ts_rejected_pack_string_field(source: str, field_name: str) -> str:

--- a/scripts/phase63_evidence_pack_contract_guard.py
+++ b/scripts/phase63_evidence_pack_contract_guard.py
@@ -346,7 +346,10 @@ def _operator_ui_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContrac
             source,
             "EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE",
         ),
-        no_workflow_authority="none",
+        no_workflow_authority=_ts_rejected_pack_string_field(
+            source,
+            "workflow_authority",
+        ),
         confidence_posture=_ts_string_constant(
             source,
             "EVIDENCE_PACK_CONFIDENCE_POSTURE",
@@ -356,12 +359,9 @@ def _operator_ui_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContrac
             source,
             "EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES",
         ),
-        forbidden_readiness_claim_fields=frozenset(
-            {
-                "release_readiness_claim",
-                "rc_readiness_claim",
-                "gate_readiness_claim",
-            }
+        forbidden_readiness_claim_fields=_ts_forbidden_defined_pack_fields(
+            source,
+            "cannot claim release readiness",
         ),
         authority_truth_denials=frozenset(),
     )
@@ -412,6 +412,93 @@ def _ts_number_expression(source: str, name: str) -> int:
     if not re.fullmatch(r"[0-9\s*+/()-]+", expression):
         raise AssertionError(f"operator UI constant {name} is not a safe expression")
     return _safe_integer_expression(expression)
+
+
+def _ts_rejected_pack_string_field(source: str, field_name: str) -> str:
+    variable_name = _ts_pack_string_variable(source, field_name)
+    match = re.search(
+        rf"\b{re.escape(variable_name)}\s*!==\s*\"([^\"]+)\"",
+        source,
+    )
+    if match is None:
+        raise AssertionError(
+            f"operator UI pack field {field_name} rejection is not discoverable"
+        )
+    return match.group(1)
+
+
+def _ts_pack_string_variable(source: str, field_name: str) -> str:
+    match = re.search(
+        rf"\bconst\s+(\w+)\s*=\s*asString\(pack\.{re.escape(field_name)}\);",
+        source,
+    )
+    if match is None:
+        raise AssertionError(f"operator UI pack field {field_name} is not discoverable")
+    return match.group(1)
+
+
+def _ts_forbidden_defined_pack_fields(source: str, error_message: str) -> frozenset[str]:
+    condition = _ts_condition_for_error(source, error_message)
+    fields = frozenset(
+        re.findall(r"\bpack\.([A-Za-z0-9_]+)\s*!==\s*undefined", condition)
+    )
+    if not fields:
+        raise AssertionError(
+            f"operator UI forbidden pack fields for {error_message} are not discoverable"
+        )
+    return fields
+
+
+def _ts_condition_for_error(source: str, error_message: str) -> str:
+    message_index = source.find(error_message)
+    if message_index == -1:
+        raise AssertionError(
+            f"operator UI rejection message {error_message} is not discoverable"
+        )
+    throw_index = source.rfind(
+        "throw new OperatorDataProviderContractError",
+        0,
+        message_index,
+    )
+    if throw_index == -1:
+        raise AssertionError(
+            f"operator UI rejection for {error_message} is not discoverable"
+        )
+    if_index = source.rfind("if (", 0, throw_index)
+    if if_index == -1:
+        raise AssertionError(
+            f"operator UI rejection condition for {error_message} is not discoverable"
+        )
+    return _extract_parenthesized(source, if_index + len("if "))
+
+
+def _extract_parenthesized(source: str, open_index: int) -> str:
+    if open_index >= len(source) or source[open_index] != "(":
+        raise AssertionError("operator UI condition is not parenthesized")
+    depth = 0
+    string_quote: str | None = None
+    escaped = False
+    condition_start = open_index + 1
+    for index in range(open_index, len(source)):
+        character = source[index]
+        if string_quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == string_quote:
+                string_quote = None
+            continue
+        if character in {'"', "'", "`"}:
+            string_quote = character
+            continue
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth == 0:
+                return source[condition_start:index]
+    raise AssertionError("operator UI condition is not closed")
 
 
 def _safe_integer_expression(expression: str) -> int:

--- a/scripts/phase63_evidence_pack_contract_guard.py
+++ b/scripts/phase63_evidence_pack_contract_guard.py
@@ -72,6 +72,28 @@ _STATE_REASON_CONSISTENCY_RULES = frozenset(
         "confidence_ambiguity_badge_matches_conflict",
     }
 )
+_PROVENANCE_BINDING_RULES = frozenset(
+    {
+        "case_binding",
+        "request_binding",
+        "source_id",
+        "reviewed_file_hash",
+        "enrichment_request_id",
+        "collection_timestamp",
+        "response_digest",
+        "custody_reference",
+        "evidence_record_id",
+    }
+)
+_METADATA_FORMAT_RULES = frozenset(
+    {
+        "reviewed_file_hash",
+        "response_digest",
+        "custody_collection_timestamp",
+        "provenance_collection_timestamp",
+    }
+)
+_CACHE_BOOLEAN_FALSE_FIELDS = frozenset({"cache_sourced", "stale_cache"})
 
 
 @dataclass(frozen=True)
@@ -82,6 +104,8 @@ class Phase63EvidencePackContract:
     required_custody_fields: frozenset[str]
     required_provenance_fields: frozenset[str]
     required_confidence_fields: frozenset[str]
+    provenance_binding_rules: frozenset[str]
+    metadata_format_rules: frozenset[str]
     contract_fields: frozenset[str]
     recognized_fields: frozenset[str]
     supported_source_ids: frozenset[str]
@@ -93,6 +117,7 @@ class Phase63EvidencePackContract:
     freshness_window_milliseconds: int
     state_reason_consistency_rules: frozenset[str]
     forbidden_projection_sources: frozenset[str]
+    cache_boolean_false_fields: frozenset[str]
     forbidden_readiness_claim_fields: frozenset[str]
     authority_truth_denials: frozenset[str]
 
@@ -167,6 +192,20 @@ def assert_phase63_evidence_pack_contract_aligned(
         ui.required_confidence_fields,
         ai.required_confidence_fields,
     )
+    _assert_equal(
+        "provenance binding rules",
+        backend.provenance_binding_rules,
+        ui.provenance_binding_rules,
+        ai.provenance_binding_rules,
+        _PROVENANCE_BINDING_RULES,
+    )
+    _assert_equal(
+        "metadata format rules",
+        backend.metadata_format_rules,
+        ui.metadata_format_rules,
+        ai.metadata_format_rules,
+        _METADATA_FORMAT_RULES,
+    )
     _assert_equal("contract fields", backend.contract_fields, ui.contract_fields)
     _assert_equal("recognized fields", backend.recognized_fields, ui.recognized_fields)
     _assert_equal(
@@ -222,6 +261,12 @@ def assert_phase63_evidence_pack_contract_aligned(
         "forbidden projection sources",
         backend.forbidden_projection_sources,
         ui.forbidden_projection_sources,
+    )
+    _assert_equal(
+        "cache-sourced boolean denials",
+        backend.cache_boolean_false_fields,
+        ui.cache_boolean_false_fields,
+        _CACHE_BOOLEAN_FALSE_FIELDS,
     )
     _assert_equal(
         "readiness claim fields",
@@ -298,6 +343,10 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
         required_custody_fields=metadata_fields["custody"],
         required_provenance_fields=metadata_fields["provenance"],
         required_confidence_fields=metadata_fields["confidence"],
+        provenance_binding_rules=_py_backend_provenance_binding_rules(
+            validator_source
+        ),
+        metadata_format_rules=_py_backend_metadata_format_rules(validator_source),
         contract_fields=frozenset(
             inspection_projection._EVIDENCE_PACK_PROJECTION_CONTRACT_FIELDS
         ),
@@ -338,6 +387,9 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
         forbidden_projection_sources=_py_backend_forbidden_projection_sources_rejection(
             validator_source,
             inspection_projection,
+        ),
+        cache_boolean_false_fields=_py_backend_cache_boolean_rejections(
+            validator_source
         ),
         forbidden_readiness_claim_fields=_py_backend_forbidden_readiness_claim_rejection(
             validator_source,
@@ -405,9 +457,14 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
         required_custody_fields=metadata_fields["custody"],
         required_provenance_fields=metadata_fields["provenance"],
         required_confidence_fields=metadata_fields["confidence"],
+        provenance_binding_rules=_py_ai_provenance_binding_rules(validator_source),
+        metadata_format_rules=_py_ai_metadata_format_rules(validator_source),
         contract_fields=frozenset(),
         recognized_fields=frozenset(),
-        supported_source_ids=source_ids,
+        supported_source_ids=_py_ai_supported_source_ids_rejection(
+            validator_source,
+            ai_grounding_validation,
+        ),
         subordinate_authority_posture=_ai_subordinate_authority_posture_rejection(
             validator_source
         ),
@@ -432,11 +489,11 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
             validator_source
         ),
         forbidden_projection_sources=frozenset(),
+        cache_boolean_false_fields=frozenset(),
         forbidden_readiness_claim_fields=frozenset(),
-        authority_truth_denials=frozenset(
-            authority
-            for authority in _AUTHORITY_TRUTH_DENIALS
-            if ai_grounding_validation._scan_for_authority_claim(authority)
+        authority_truth_denials=_py_ai_authority_truth_denials(
+            validator_source,
+            ai_grounding_validation,
         ),
     )
 
@@ -464,6 +521,8 @@ def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContrac
         required_custody_fields=metadata_fields["custody"],
         required_provenance_fields=metadata_fields["provenance"],
         required_confidence_fields=metadata_fields["confidence"],
+        provenance_binding_rules=_ts_provenance_binding_rules(source),
+        metadata_format_rules=_ts_metadata_format_rules(source),
         contract_fields=_ts_set(source, "EVIDENCE_PACK_CONTRACT_FIELDS"),
         recognized_fields=_ts_recognized_fields_rejection(
             source,
@@ -491,6 +550,7 @@ def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContrac
         ),
         state_reason_consistency_rules=_ts_state_reason_consistency_rules(source),
         forbidden_projection_sources=_ts_forbidden_projection_sources_rejection(source),
+        cache_boolean_false_fields=_ts_cache_boolean_rejections(source),
         forbidden_readiness_claim_fields=_ts_forbidden_defined_pack_fields(
             source,
             "cannot claim release readiness",
@@ -500,6 +560,7 @@ def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContrac
 
 
 def _ts_allowed_labels(source: str) -> dict[str, frozenset[str]]:
+    _ts_label_validator_semantics(source)
     match = re.search(
         r"const EVIDENCE_PACK_ALLOWED_LABELS = \{(?P<body>.*?)\n\};",
         source,
@@ -534,6 +595,7 @@ def _ts_enforced_label_keys(source: str) -> frozenset[str]:
 
 
 def _ts_enforced_reason_sets(source: str) -> dict[str, frozenset[str]]:
+    _ts_reason_validator_semantics(source)
     reason_sets = {
         field_name: _ts_set(source, constant_name)
         for field_name, constant_name in _ts_validator_call_constants(
@@ -549,6 +611,7 @@ def _ts_enforced_reason_sets(source: str) -> dict[str, frozenset[str]]:
 
 
 def _ts_enforced_metadata_fields(source: str) -> dict[str, frozenset[str]]:
+    _ts_metadata_map_validator_semantics(source)
     metadata_fields = {
         field_name: _ts_set(source, constant_name)
         for field_name, constant_name in _ts_validator_call_constants(
@@ -561,6 +624,109 @@ def _ts_enforced_metadata_fields(source: str) -> dict[str, frozenset[str]]:
     if frozenset(metadata_fields) != expected_fields:
         raise AssertionError("operator UI evidence-pack metadata enforcement drift")
     return metadata_fields
+
+
+def _ts_label_validator_semantics(source: str) -> None:
+    body = _ts_function_body(source, "validateEvidencePackLabel")
+    _require_substrings(
+        body,
+        (
+            "EVIDENCE_PACK_ALLOWED_LABELS[fieldName].has(value)",
+            "unsupported evidence-pack label",
+        ),
+        "operator UI label validator semantics",
+    )
+
+
+def _ts_reason_validator_semantics(source: str) -> None:
+    body = _ts_function_body(source, "validateEvidencePackReasons")
+    _require_substrings(
+        body,
+        (
+            "Array.isArray(value)",
+            "allowedReasons.has(asString(reason) ?? \"\")",
+            "unsupported evidence-pack reasons",
+        ),
+        "operator UI reason validator semantics",
+    )
+
+
+def _ts_metadata_map_validator_semantics(source: str) -> None:
+    body = _ts_function_body(source, "validateEvidencePackMetadataMap")
+    _require_substrings(
+        body,
+        (
+            "fieldNames.length !== requiredFields.size",
+            "fieldNames.some((fieldName) => !requiredFields.has(fieldName))",
+            "Array.from(requiredFields).some((fieldName) => asString(value[fieldName]) === null)",
+            "missing required evidence-pack metadata",
+        ),
+        "operator UI metadata-map validator semantics",
+    )
+
+
+def _ts_provenance_binding_rules(source: str) -> frozenset[str]:
+    condition = _ts_condition_for_error(
+        source,
+        "must keep provenance bound to the evidence request and case",
+    )
+    _require_substrings(
+        condition,
+        (
+            "evidenceRecordId === null",
+            "asString(provenance.request_binding) !== evidenceRequestId",
+            "asString(provenance.case_binding) !== requestedCaseId",
+            "asString(provenance.source_id) !== sourceId",
+            "asString(provenance.target_binding) !== asString(custody.reviewed_file_hash)",
+            "asString(provenance.enrichment_request_id) !==",
+            "asString(custody.enrichment_request_id)",
+            "asString(provenance.collection_timestamp) !==",
+            "asString(custody.collection_timestamp)",
+            "asString(provenance.response_digest) !== asString(custody.response_digest)",
+            "asString(provenance.custody_reference) !==",
+            "linkedEvidenceRecordCustodyReference(",
+        ),
+        "operator UI provenance binding enforcement",
+    )
+    return _PROVENANCE_BINDING_RULES
+
+
+def _ts_metadata_format_rules(source: str) -> frozenset[str]:
+    body = _ts_function_body(source, "validateEvidencePackMetadataFormats")
+    _require_substrings(
+        body,
+        (
+            "isSupportedReviewedHash(asString(custody.reviewed_file_hash))",
+            "isSha256Digest(asString(custody.response_digest))",
+            "isAwareTimestamp(asString(custody.collection_timestamp))",
+            "isAwareTimestamp(asString(provenance.collection_timestamp))",
+            "invalid evidence-pack metadata",
+        ),
+        "operator UI metadata format enforcement",
+    )
+    _ts_require_call(
+        source,
+        "validateEvidencePackMetadataFormats",
+        ("custody", "provenance", "evidenceRequestId"),
+    )
+    return _METADATA_FORMAT_RULES
+
+
+def _ts_cache_boolean_rejections(source: str) -> frozenset[str]:
+    condition = _ts_condition_for_error(
+        source,
+        "rejects cache or browser sourced evidence-pack truth",
+    )
+    fields = frozenset(
+        re.findall(
+            r"\bpack\.([A-Za-z0-9_]+)\s*!==\s*undefined\s*&&\s*"
+            r"pack\.\1\s*!==\s*false",
+            condition,
+        )
+    )
+    if fields != _CACHE_BOOLEAN_FALSE_FIELDS:
+        raise AssertionError("operator UI cache-sourced boolean rejection drift")
+    return fields
 
 
 def _ts_validator_call_constants(
@@ -982,6 +1148,216 @@ def _py_backend_forbidden_readiness_claim_rejection(
         "backend readiness-claim rejection",
     )
     return frozenset(getattr(namespace, "_EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS"))
+
+
+def _py_backend_provenance_binding_rules(source: str) -> frozenset[str]:
+    validator_body = _py_function_source(
+        source,
+        "_validated_linked_evidence_pack_projection",
+    )
+    binding_body = _py_function_source(
+        source,
+        "_validate_linked_evidence_pack_provenance_bindings",
+    )
+    _require_substrings(
+        validator_body,
+        (
+            "_validate_linked_evidence_pack_provenance_bindings(",
+            "_optional_string_from_mapping(provenance,",
+            '"request_binding"',
+            'typed_values["evidence_request_id"]',
+            '"case_binding"',
+            "case_id",
+            '"source_id"',
+            'typed_values["source_id"]',
+            '"aegisops_evidence_record_id"',
+            "evidence_record_id",
+        ),
+        "backend provenance binding enforcement",
+    )
+    _require_substrings(
+        binding_body,
+        (
+            '"target_binding"',
+            '"reviewed_file_hash"',
+            '"enrichment_request_id"',
+            '"collection_timestamp"',
+            '"response_digest"',
+            '"custody_reference"',
+            "record_custody_reference",
+        ),
+        "backend provenance binding enforcement",
+    )
+    return _PROVENANCE_BINDING_RULES
+
+
+def _py_ai_provenance_binding_rules(source: str) -> frozenset[str]:
+    projection_body = _py_function_source(source, "_projection_reasons")
+    binding_body = _py_function_source(source, "_provenance_binding_reasons")
+    _require_substrings(
+        projection_body,
+        (
+            "_provenance_binding_reasons(",
+            "_reviewed_hash_reasons(custody, expected_reviewed_file_hash)",
+            "_response_digest_reasons(custody, expected_response_digest)",
+            "_evidence_record_binding_reasons(",
+            "expected_custody_reference=expected_custody_reference",
+            "expected_collection_timestamp=expected_collection_timestamp",
+        ),
+        "AI provenance binding enforcement",
+    )
+    _require_substrings(
+        binding_body,
+        (
+            '"request_binding"',
+            'projection.get("evidence_request_id")',
+            '"case_binding"',
+            "anchor_id",
+            '"source_id"',
+            'projection.get("source_id")',
+            '"target_binding"',
+            'custody.get("reviewed_file_hash")',
+            '"enrichment_request_id"',
+            'custody.get("enrichment_request_id")',
+            '"collection_timestamp"',
+            "expected_collection_timestamp",
+            '"response_digest"',
+            'custody.get("response_digest")',
+            '"custody_reference"',
+            "expected_custody_reference",
+        ),
+        "AI provenance binding enforcement",
+    )
+    return _PROVENANCE_BINDING_RULES
+
+
+def _py_backend_metadata_format_rules(source: str) -> frozenset[str]:
+    validator_body = _py_function_source(
+        source,
+        "_validated_linked_evidence_pack_projection",
+    )
+    format_body = _py_function_source(
+        source,
+        "_validate_linked_evidence_pack_metadata_formats",
+    )
+    _require_substrings(
+        validator_body,
+        ("_validate_linked_evidence_pack_metadata_formats(",),
+        "backend metadata format enforcement call",
+    )
+    _require_substrings(
+        format_body,
+        (
+            "_is_supported_reviewed_hash(",
+            '"reviewed_file_hash"',
+            "_is_sha256_digest(",
+            '"response_digest"',
+            '_datetime_from_evidence_pack_content(custody, "collection_timestamp")',
+            '_datetime_from_evidence_pack_content(provenance, "collection_timestamp")',
+        ),
+        "backend metadata format enforcement",
+    )
+    return _METADATA_FORMAT_RULES
+
+
+def _py_ai_metadata_format_rules(source: str) -> frozenset[str]:
+    projection_body = _py_function_source(source, "_projection_reasons")
+    reviewed_hash_body = _py_function_source(source, "_reviewed_hash_reasons")
+    response_digest_body = _py_function_source(source, "_response_digest_reasons")
+    provenance_body = _py_function_source(source, "_provenance_binding_reasons")
+    _require_substrings(
+        projection_body,
+        (
+            "_reviewed_hash_reasons(custody, expected_reviewed_file_hash)",
+            "_response_digest_reasons(custody, expected_response_digest)",
+            "_provenance_binding_reasons(",
+        ),
+        "AI metadata format enforcement call",
+    )
+    _require_substrings(
+        reviewed_hash_body,
+        ("_normalized_supported_hash(", '"unsupported_grounding_reviewed_hash"'),
+        "AI reviewed-hash format enforcement",
+    )
+    _require_substrings(
+        response_digest_body,
+        ("_SHA256_DIGEST_PATTERN.fullmatch(response_digest)",),
+        "AI response-digest format enforcement",
+    )
+    _require_substrings(
+        provenance_body,
+        (
+            '_aware_datetime(\n            custody.get("collection_timestamp")',
+            '_aware_datetime(\n            provenance.get("collection_timestamp")',
+        ),
+        "AI metadata timestamp format enforcement",
+    )
+    return _METADATA_FORMAT_RULES
+
+
+def _py_backend_cache_boolean_rejections(source: str) -> frozenset[str]:
+    body = _py_function_source(source, "_validated_linked_evidence_pack_projection")
+    _require_substrings(
+        body,
+        (
+            "cache_sourced = projection.get(\"cache_sourced\")",
+            "stale_cache = projection.get(\"stale_cache\")",
+            "(cache_sourced is not None and cache_sourced is not False)",
+            "(stale_cache is not None and stale_cache is not False)",
+            'raise ValueError("linked evidence-pack projection cannot be cache sourced")',
+        ),
+        "backend cache-sourced boolean rejection",
+    )
+    return _CACHE_BOOLEAN_FALSE_FIELDS
+
+
+def _py_ai_supported_source_ids_rejection(
+    source: str,
+    namespace: object,
+) -> frozenset[str]:
+    body = _py_function_source(source, "_grounding_source_reasons")
+    _require_substrings(
+        body,
+        (
+            "registry_entry = PHASE63_EVIDENCE_SOURCE_REGISTRY.get(source_id)",
+            "source_id not in _SUPPORTED_GROUNDING_SOURCE_IDS",
+            'return ("unsupported_grounding_source",)',
+        ),
+        "AI source-id enforcement",
+    )
+    return frozenset(getattr(namespace, "_SUPPORTED_GROUNDING_SOURCE_IDS"))
+
+
+def _py_ai_authority_truth_denials(source: str, namespace: object) -> frozenset[str]:
+    projection_body = _py_function_source(source, "_projection_reasons")
+    metadata_body = _py_function_source(source, "_metadata_contract_reasons")
+    _require_substrings(
+        projection_body,
+        (
+            "_metadata_contract_reasons(",
+            "_ALLOWED_CUSTODY_FIELDS",
+            "_ALLOWED_PROVENANCE_FIELDS",
+            "_ALLOWED_CONFIDENCE_FIELDS",
+        ),
+        "AI metadata authority-scan call",
+    )
+    _require_substrings(
+        metadata_body,
+        (
+            "for field_name, item in value.items():",
+            "field_name not in authority_scanned_fields",
+            "_metadata_authority_values(field_name, item)",
+            "_scan_for_authority_claim(",
+            "_scan_for_endpoint_command_language(",
+            '"grounding_metadata_authority_claim"',
+        ),
+        "AI metadata authority-scan enforcement",
+    )
+    return frozenset(
+        authority
+        for authority in _AUTHORITY_TRUTH_DENIALS
+        if namespace._scan_for_authority_claim(authority)
+    )
 
 
 def _py_backend_enforced_freshness_window_milliseconds(

--- a/scripts/phase63_evidence_pack_contract_guard.py
+++ b/scripts/phase63_evidence_pack_contract_guard.py
@@ -255,6 +255,11 @@ def _ensure_control_plane_path(repo_root: pathlib.Path) -> None:
         sys.path.insert(0, str(control_plane_root))
 
 
+def _main() -> None:
+    assert_phase63_evidence_pack_contract_aligned()
+    print("Phase 63 evidence-pack contract guard passed")
+
+
 def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
     _ensure_control_plane_path(repo_root)
     from aegisops.control_plane.evidence import (  # noqa: WPS433
@@ -322,9 +327,10 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
             validator_source,
             registry_entry.confidence_posture,
         ),
-        freshness_window_milliseconds=(
-            source_projection._parse_duration_seconds(registry_entry.freshness_window)
-            * 1000
+        freshness_window_milliseconds=_py_backend_enforced_freshness_window_milliseconds(
+            validator_source,
+            registry_entry.freshness_window,
+            source_projection,
         ),
         state_reason_consistency_rules=_py_backend_state_reason_consistency_rules(
             validator_source
@@ -417,9 +423,10 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
             validator_source,
             registry_entry.confidence_posture,
         ),
-        freshness_window_milliseconds=(
-            source_projection._parse_duration_seconds(registry_entry.freshness_window)
-            * 1000
+        freshness_window_milliseconds=_py_ai_enforced_freshness_window_milliseconds(
+            validator_source,
+            registry_entry.freshness_window,
+            source_projection,
         ),
         state_reason_consistency_rules=_py_ai_state_reason_consistency_rules(
             validator_source
@@ -975,6 +982,72 @@ def _py_backend_forbidden_readiness_claim_rejection(
         "backend readiness-claim rejection",
     )
     return frozenset(getattr(namespace, "_EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS"))
+
+
+def _py_backend_enforced_freshness_window_milliseconds(
+    source: str,
+    registry_freshness_window: str,
+    source_projection: object,
+) -> int:
+    call_body = _py_function_source(source, "_validated_linked_evidence_pack_projection")
+    _require_substrings(
+        call_body,
+        (
+            "_validate_linked_evidence_pack_freshness_window(",
+            "values=typed_values",
+            "custody=custody",
+        ),
+        "backend freshness-window enforcement call",
+    )
+    freshness_body = _py_function_source(
+        source,
+        "_validate_linked_evidence_pack_freshness_window",
+    )
+    _require_substrings(
+        freshness_body,
+        (
+            'PHASE63_EVIDENCE_SOURCE_REGISTRY.get(values["source_id"])',
+            "_parse_duration_seconds(registry_entry.freshness_window)",
+            'values["freshness_state"] == "fresh"',
+            'values["freshness_state"] == "stale"',
+            '"linked evidence-pack projection freshness window mismatch"',
+        ),
+        "backend freshness-window enforcement",
+    )
+    return source_projection._parse_duration_seconds(registry_freshness_window) * 1000
+
+
+def _py_ai_enforced_freshness_window_milliseconds(
+    source: str,
+    registry_freshness_window: str,
+    source_projection: object,
+) -> int:
+    projection_body = _py_function_source(source, "_projection_reasons")
+    _require_substrings(
+        projection_body,
+        (
+            "reasons.extend(",
+            "_freshness_recomputation_reasons(",
+            "projection",
+            "grounded_at",
+            "expected_collection_timestamp",
+        ),
+        "AI freshness recomputation enforcement call",
+    )
+    freshness_body = _py_function_source(source, "_freshness_recomputation_reasons")
+    _require_substrings(
+        freshness_body,
+        (
+            'source_id = _string(projection.get("source_id"))',
+            "PHASE63_EVIDENCE_SOURCE_REGISTRY.get(source_id)",
+            "_parse_duration_seconds(registry_entry.freshness_window)",
+            '"stale" if age_seconds > freshness_window_seconds else "fresh"',
+            'projection.get("freshness_state") != expected_freshness',
+            'confidence.get("freshness") != expected_freshness',
+        ),
+        "AI freshness recomputation enforcement",
+    )
+    return source_projection._parse_duration_seconds(registry_freshness_window) * 1000
 
 
 def _py_ai_enforced_reason_sets(
@@ -1808,3 +1881,7 @@ def contract_with_label_drift(
     labels = dict(contract.labels)
     labels[label_name] = values
     return replace(contract, labels=MappingProxyType(labels))
+
+
+if __name__ == "__main__":
+    _main()

--- a/scripts/phase63_evidence_pack_contract_guard.py
+++ b/scripts/phase63_evidence_pack_contract_guard.py
@@ -52,6 +52,7 @@ class Phase63EvidencePackContract:
     required_provenance_fields: frozenset[str]
     required_confidence_fields: frozenset[str]
     contract_fields: frozenset[str]
+    recognized_fields: frozenset[str]
     supported_source_ids: frozenset[str]
     subordinate_authority_posture: str
     no_workflow_authority: str
@@ -128,6 +129,7 @@ def assert_phase63_evidence_pack_contract_aligned(
         ai.required_confidence_fields,
     )
     _assert_equal("contract fields", backend.contract_fields, ui.contract_fields)
+    _assert_equal("recognized fields", backend.recognized_fields, ui.recognized_fields)
     _assert_equal(
         "source IDs",
         backend.supported_source_ids,
@@ -248,6 +250,9 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
         contract_fields=frozenset(
             inspection_projection._EVIDENCE_PACK_PROJECTION_CONTRACT_FIELDS
         ),
+        recognized_fields=frozenset(
+            inspection_projection._EVIDENCE_PACK_PROJECTION_RECOGNIZED_FIELDS
+        ),
         supported_source_ids=frozenset({source_id}),
         subordinate_authority_posture=(
             inspection_projection._EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE
@@ -255,7 +260,10 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
         no_workflow_authority=_backend_no_workflow_authority_rejection(
             validator_source
         ),
-        confidence_posture=registry_entry.confidence_posture,
+        confidence_posture=_backend_confidence_posture_rejection(
+            validator_source,
+            registry_entry.confidence_posture,
+        ),
         freshness_window_milliseconds=(
             source_projection._parse_duration_seconds(registry_entry.freshness_window)
             * 1000
@@ -324,6 +332,7 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
             ai_grounding_validation._REQUIRED_CONFIDENCE_FIELDS
         ),
         contract_fields=frozenset(),
+        recognized_fields=frozenset(),
         supported_source_ids=source_ids,
         subordinate_authority_posture=(
             ai_grounding_validation._SUBORDINATE_AUTHORITY_POSTURE
@@ -362,26 +371,20 @@ def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContrac
         source,
         "EVIDENCE_PACK_FRESHNESS_WINDOW_MS",
     )
+    metadata_fields = _ts_enforced_metadata_fields(source)
+    reason_sets = _ts_enforced_reason_sets(source)
     return Phase63EvidencePackContract(
         labels=MappingProxyType(labels),
-        degraded_reasons=_ts_set(source, "EVIDENCE_PACK_ALLOWED_DEGRADED_REASONS"),
-        unavailable_reasons=_ts_set(
-            source,
-            "EVIDENCE_PACK_ALLOWED_UNAVAILABLE_REASONS",
-        ),
-        required_custody_fields=_ts_set(
-            source,
-            "EVIDENCE_PACK_REQUIRED_CUSTODY_FIELDS",
-        ),
-        required_provenance_fields=_ts_set(
-            source,
-            "EVIDENCE_PACK_REQUIRED_PROVENANCE_FIELDS",
-        ),
-        required_confidence_fields=_ts_set(
-            source,
-            "EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS",
-        ),
+        degraded_reasons=reason_sets["degraded_reasons"],
+        unavailable_reasons=reason_sets["unavailable_reasons"],
+        required_custody_fields=metadata_fields["custody"],
+        required_provenance_fields=metadata_fields["provenance"],
+        required_confidence_fields=metadata_fields["confidence"],
         contract_fields=_ts_set(source, "EVIDENCE_PACK_CONTRACT_FIELDS"),
+        recognized_fields=_ts_set_with_spreads(
+            source,
+            "EVIDENCE_PACK_RECOGNIZED_FIELDS",
+        ),
         supported_source_ids=frozenset(
             {_ts_string_constant(source, "EVIDENCE_PACK_SUPPORTED_SOURCE_ID")}
         ),
@@ -389,10 +392,7 @@ def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContrac
             source,
             "EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE",
         ),
-        no_workflow_authority=_ts_rejected_pack_string_field(
-            source,
-            "workflow_authority",
-        ),
+        no_workflow_authority=_ts_no_workflow_authority_rejection(source),
         confidence_posture=_ts_string_constant(
             source,
             "EVIDENCE_PACK_CONFIDENCE_POSTURE",
@@ -444,6 +444,94 @@ def _ts_enforced_label_keys(source: str) -> frozenset[str]:
     return labels
 
 
+def _ts_enforced_reason_sets(source: str) -> dict[str, frozenset[str]]:
+    reason_sets = {
+        field_name: _ts_set(source, constant_name)
+        for field_name, constant_name in _ts_validator_call_constants(
+            source,
+            "validateEvidencePackReasons",
+            "pack",
+        ).items()
+    }
+    expected_fields = frozenset({"degraded_reasons", "unavailable_reasons"})
+    if frozenset(reason_sets) != expected_fields:
+        raise AssertionError("operator UI evidence-pack reason enforcement drift")
+    return reason_sets
+
+
+def _ts_enforced_metadata_fields(source: str) -> dict[str, frozenset[str]]:
+    metadata_fields = {
+        field_name: _ts_set(source, constant_name)
+        for field_name, constant_name in _ts_validator_call_constants(
+            source,
+            "validateEvidencePackMetadataMap",
+            None,
+        ).items()
+    }
+    expected_fields = frozenset({"custody", "provenance", "confidence"})
+    if frozenset(metadata_fields) != expected_fields:
+        raise AssertionError("operator UI evidence-pack metadata enforcement drift")
+    return metadata_fields
+
+
+def _ts_validator_call_constants(
+    source: str,
+    function_name: str,
+    object_name: str | None,
+) -> dict[str, str]:
+    constants: dict[str, str] = {}
+    for match in re.finditer(rf"\b{re.escape(function_name)}\s*\(", source):
+        arguments = _split_ts_arguments(
+            _extract_parenthesized(source, match.end() - 1)
+        )
+        if len(arguments) < 2:
+            continue
+        value_argument = arguments[0].strip()
+        constant_argument = arguments[1].strip()
+        if not re.fullmatch(r"EVIDENCE_PACK_[A-Z0-9_]+", constant_argument):
+            continue
+        if object_name is None:
+            if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value_argument):
+                constants[value_argument] = constant_argument
+            continue
+        field_match = re.fullmatch(
+            rf"{re.escape(object_name)}\.([A-Za-z0-9_]+)",
+            value_argument,
+        )
+        if field_match is not None:
+            constants[field_match.group(1)] = constant_argument
+    return constants
+
+
+def _split_ts_arguments(arguments_source: str) -> tuple[str, ...]:
+    arguments: list[str] = []
+    depth = 0
+    string_quote: str | None = None
+    escaped = False
+    argument_start = 0
+    for index, character in enumerate(arguments_source):
+        if string_quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == string_quote:
+                string_quote = None
+            continue
+        if character in {'"', "'", "`"}:
+            string_quote = character
+            continue
+        if character in "([{":
+            depth += 1
+        elif character in ")]}":
+            depth -= 1
+        elif character == "," and depth == 0:
+            arguments.append(arguments_source[argument_start:index])
+            argument_start = index + 1
+    arguments.append(arguments_source[argument_start:])
+    return tuple(arguments)
+
+
 def _backend_no_workflow_authority_rejection(source: str) -> str:
     values = frozenset(
         value
@@ -455,6 +543,43 @@ def _backend_no_workflow_authority_rejection(source: str) -> str:
             "backend workflow authority rejection is not consistently discoverable"
         )
     return next(iter(values))
+
+
+def _backend_confidence_posture_rejection(
+    source: str,
+    registry_confidence_posture: str,
+) -> str:
+    values: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Compare):
+            continue
+        if len(node.ops) != 1 or not isinstance(node.ops[0], ast.NotEq):
+            continue
+        if len(node.comparators) != 1:
+            continue
+        if _py_rejection_target(node.left) != ("optional", "confidence", "posture"):
+            continue
+        compared_value = _py_string_constant(node.comparators[0])
+        if compared_value is None and _py_registry_confidence_posture_reference(
+            node.comparators[0]
+        ):
+            compared_value = registry_confidence_posture
+        if compared_value is not None:
+            values.add(compared_value)
+    if len(values) != 1:
+        raise AssertionError(
+            "backend confidence posture rejection is not consistently discoverable"
+        )
+    return next(iter(values))
+
+
+def _py_registry_confidence_posture_reference(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "confidence_posture"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "registry_entry"
+    )
 
 
 def _py_projection_get_string_rejection_labels(
@@ -548,6 +673,30 @@ def _ts_set(source: str, name: str) -> frozenset[str]:
     return frozenset(_string_literals(match.group("body")))
 
 
+def _ts_set_with_spreads(
+    source: str,
+    name: str,
+    *,
+    seen: frozenset[str] = frozenset(),
+) -> frozenset[str]:
+    if name in seen:
+        raise AssertionError(f"operator UI constant {name} has recursive spread")
+    match = re.search(
+        rf"const {re.escape(name)} = new Set\(\[(?P<body>.*?)\]\);",
+        source,
+        re.S,
+    )
+    if match is None:
+        raise AssertionError(f"operator UI constant {name} is not discoverable")
+    body = match.group("body")
+    values = set(_string_literals(body))
+    for spread_name in re.findall(r"\.\.\.(EVIDENCE_PACK_[A-Z0-9_]+)", body):
+        values.update(
+            _ts_set_with_spreads(source, spread_name, seen=seen | frozenset({name}))
+        )
+    return frozenset(values)
+
+
 def _ts_string_constant(source: str, name: str) -> str:
     match = re.search(rf'const {re.escape(name)} =\s*"([^"]+)";', source)
     if match is None:
@@ -574,6 +723,42 @@ def _ts_rejected_pack_string_field(source: str, field_name: str) -> str:
     if match is None:
         raise AssertionError(
             f"operator UI pack field {field_name} rejection is not discoverable"
+        )
+    return match.group(1)
+
+
+def _ts_no_workflow_authority_rejection(source: str) -> str:
+    values = frozenset(
+        {
+            _ts_rejected_pack_string_field(source, "workflow_authority"),
+            _ts_rejected_mapping_string_field(
+                source,
+                "confidence",
+                "source_native_score_authority",
+            ),
+        }
+    )
+    if len(values) != 1:
+        raise AssertionError(
+            "operator UI workflow authority rejection is not consistently discoverable"
+        )
+    return next(iter(values))
+
+
+def _ts_rejected_mapping_string_field(
+    source: str,
+    mapping_name: str,
+    field_name: str,
+) -> str:
+    match = re.search(
+        rf"\basString\({re.escape(mapping_name)}\.{re.escape(field_name)}\)"
+        r"\s*!==\s*\"([^\"]+)\"",
+        source,
+    )
+    if match is None:
+        raise AssertionError(
+            "operator UI mapping field "
+            f"{mapping_name}.{field_name} rejection is not discoverable"
         )
     return match.group(1)
 

--- a/scripts/phase63_evidence_pack_contract_guard.py
+++ b/scripts/phase63_evidence_pack_contract_guard.py
@@ -56,6 +56,7 @@ class Phase63EvidencePackContract:
     supported_source_ids: frozenset[str]
     subordinate_authority_posture: str
     no_workflow_authority: str
+    authoritative_workflow_truth: bool
     confidence_posture: str
     freshness_window_milliseconds: int
     forbidden_projection_sources: frozenset[str]
@@ -153,6 +154,12 @@ def assert_phase63_evidence_pack_contract_aligned(
         backend.no_workflow_authority,
         ui.no_workflow_authority,
         ai.no_workflow_authority,
+    )
+    _assert_equal(
+        "authoritative workflow truth denial",
+        backend.authoritative_workflow_truth,
+        ui.authoritative_workflow_truth,
+        ai.authoritative_workflow_truth,
     )
     _assert_equal(
         "confidence posture",
@@ -260,6 +267,10 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
         no_workflow_authority=_backend_no_workflow_authority_rejection(
             validator_source
         ),
+        authoritative_workflow_truth=_py_rejected_boolean_value(
+            validator_source,
+            ("get", "projection", "authoritative_workflow_truth"),
+        ),
         confidence_posture=_backend_confidence_posture_rejection(
             validator_source,
             registry_entry.confidence_posture,
@@ -305,6 +316,10 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
         validator_source,
         _AI_GROUNDING_SINGLETON_LABEL_FIELDS,
     )
+    metadata_fields = _py_enforced_metadata_fields(
+        validator_source,
+        ai_grounding_validation,
+    )
     labels = {
         "consumer": frozenset({"ai_grounding"}),
         "status": frozenset(ai_grounding_validation._ALLOWED_STATUS),
@@ -322,23 +337,26 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
         unavailable_reasons=frozenset(
             ai_grounding_validation._ALLOWED_UNAVAILABLE_REASONS
         ),
-        required_custody_fields=frozenset(
-            ai_grounding_validation._REQUIRED_CUSTODY_FIELDS
-        ),
-        required_provenance_fields=frozenset(
-            ai_grounding_validation._REQUIRED_PROVENANCE_FIELDS
-        ),
-        required_confidence_fields=frozenset(
-            ai_grounding_validation._REQUIRED_CONFIDENCE_FIELDS
-        ),
+        required_custody_fields=metadata_fields["custody"],
+        required_provenance_fields=metadata_fields["provenance"],
+        required_confidence_fields=metadata_fields["confidence"],
         contract_fields=frozenset(),
         recognized_fields=frozenset(),
         supported_source_ids=source_ids,
         subordinate_authority_posture=(
             ai_grounding_validation._SUBORDINATE_AUTHORITY_POSTURE
         ),
-        no_workflow_authority=ai_grounding_validation._NO_WORKFLOW_AUTHORITY,
-        confidence_posture=registry_entry.confidence_posture,
+        no_workflow_authority=_ai_no_workflow_authority_rejection(
+            validator_source
+        ),
+        authoritative_workflow_truth=_py_rejected_boolean_value(
+            validator_source,
+            ("get", "projection", "authoritative_workflow_truth"),
+        ),
+        confidence_posture=_ai_confidence_posture_rejection(
+            validator_source,
+            registry_entry.confidence_posture,
+        ),
         freshness_window_milliseconds=(
             source_projection._parse_duration_seconds(registry_entry.freshness_window)
             * 1000
@@ -393,6 +411,10 @@ def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContrac
             "EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE",
         ),
         no_workflow_authority=_ts_no_workflow_authority_rejection(source),
+        authoritative_workflow_truth=_ts_rejected_pack_boolean_field(
+            source,
+            "authoritative_workflow_truth",
+        ),
         confidence_posture=_ts_string_constant(
             source,
             "EVIDENCE_PACK_CONFIDENCE_POSTURE",
@@ -545,6 +567,23 @@ def _backend_no_workflow_authority_rejection(source: str) -> str:
     return next(iter(values))
 
 
+def _ai_no_workflow_authority_rejection(source: str) -> str:
+    targets = (
+        ("get", "projection", "workflow_authority"),
+        ("get", "confidence", "source_native_score_authority"),
+    )
+    values = frozenset(
+        value
+        for target in targets
+        for value in _py_rejected_string_values(source, target)
+    )
+    if len(values) != 1:
+        raise AssertionError(
+            "AI workflow authority rejection is not consistently discoverable"
+        )
+    return next(iter(values))
+
+
 def _backend_confidence_posture_rejection(
     source: str,
     registry_confidence_posture: str,
@@ -573,6 +612,66 @@ def _backend_confidence_posture_rejection(
     return next(iter(values))
 
 
+def _ai_confidence_posture_rejection(
+    source: str,
+    registry_confidence_posture: str,
+) -> str:
+    values: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.If):
+            continue
+        compared_value = _py_compare_rejection_value(
+            node.test,
+            ("get", "confidence", "posture"),
+            registry_confidence_posture=registry_confidence_posture,
+        )
+        if compared_value is None:
+            continue
+        if not _py_body_contains_string(
+            node.body,
+            "grounding_confidence_posture_mismatch",
+        ):
+            continue
+        values.add(compared_value)
+    if len(values) != 1:
+        raise AssertionError(
+            "AI confidence posture rejection is not consistently discoverable"
+        )
+    return next(iter(values))
+
+
+def _py_compare_rejection_value(
+    node: ast.AST,
+    target: tuple[str, str, str],
+    *,
+    registry_confidence_posture: str | None = None,
+) -> str | None:
+    if not isinstance(node, ast.Compare):
+        return None
+    if len(node.ops) != 1 or not isinstance(node.ops[0], ast.NotEq):
+        return None
+    if len(node.comparators) != 1:
+        return None
+    if _py_rejection_target(node.left) != target:
+        return None
+    compared_value = _py_string_constant(node.comparators[0])
+    if (
+        compared_value is None
+        and registry_confidence_posture is not None
+        and _py_registry_confidence_posture_reference(node.comparators[0])
+    ):
+        compared_value = registry_confidence_posture
+    return compared_value
+
+
+def _py_body_contains_string(body: list[ast.stmt], value: str) -> bool:
+    return any(
+        isinstance(child, ast.Constant) and child.value == value
+        for statement in body
+        for child in ast.walk(statement)
+    )
+
+
 def _py_registry_confidence_posture_reference(node: ast.AST) -> bool:
     return (
         isinstance(node, ast.Attribute)
@@ -597,10 +696,38 @@ def _py_projection_get_string_rejection_labels(
     return labels
 
 
+def _py_enforced_metadata_fields(
+    source: str,
+    namespace: object,
+) -> dict[str, frozenset[str]]:
+    fields: dict[str, frozenset[str]] = {}
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name):
+            continue
+        if node.func.id != "_metadata_contract_reasons" or len(node.args) < 2:
+            continue
+        value_argument = node.args[0]
+        allowed_argument = node.args[1]
+        if not isinstance(value_argument, ast.Name):
+            continue
+        if not isinstance(allowed_argument, ast.Name):
+            continue
+        if value_argument.id not in {"custody", "provenance", "confidence"}:
+            continue
+        fields[value_argument.id] = frozenset(getattr(namespace, allowed_argument.id))
+    expected_fields = frozenset({"custody", "provenance", "confidence"})
+    if frozenset(fields) != expected_fields:
+        raise AssertionError("AI grounding metadata enforcement drift")
+    return fields
+
+
 def _py_rejected_string_values(
     source: str,
     target: tuple[str, str, str],
 ) -> frozenset[str]:
+    string_constants = _py_source_string_constants(source)
     values: set[str] = set()
     for node in ast.walk(ast.parse(source)):
         if not isinstance(node, ast.Compare):
@@ -609,7 +736,7 @@ def _py_rejected_string_values(
             continue
         if len(node.comparators) != 1:
             continue
-        compared_value = _py_string_constant(node.comparators[0])
+        compared_value = _py_string_constant(node.comparators[0], string_constants)
         if compared_value is None:
             continue
         if _py_rejection_target(node.left) == target:
@@ -620,6 +747,31 @@ def _py_rejected_string_values(
             f"Python string rejection for {mapping_name}.{field_name} is not discoverable"
         )
     return frozenset(values)
+
+
+def _py_rejected_boolean_value(
+    source: str,
+    target: tuple[str, str, str],
+) -> bool:
+    values: set[bool] = set()
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Compare):
+            continue
+        if len(node.ops) != 1 or not isinstance(node.ops[0], (ast.IsNot, ast.NotEq)):
+            continue
+        if len(node.comparators) != 1:
+            continue
+        if _py_rejection_target(node.left) != target:
+            continue
+        compared_value = _py_boolean_constant(node.comparators[0])
+        if compared_value is not None:
+            values.add(compared_value)
+    if len(values) != 1:
+        _, mapping_name, field_name = target
+        raise AssertionError(
+            f"Python boolean rejection for {mapping_name}.{field_name} is not discoverable"
+        )
+    return next(iter(values))
 
 
 def _py_rejection_target(node: ast.AST) -> tuple[str, str, str] | None:
@@ -656,10 +808,43 @@ def _py_subscript_key(node: ast.AST) -> str | None:
     return _py_string_constant(node)
 
 
-def _py_string_constant(node: ast.AST) -> str | None:
+def _py_string_constant(
+    node: ast.AST,
+    string_constants: Mapping[str, str] | None = None,
+) -> str | None:
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return node.value
+    if (
+        isinstance(node, ast.Name)
+        and string_constants is not None
+        and node.id in string_constants
+    ):
+        return string_constants[node.id]
     return None
+
+
+def _py_boolean_constant(node: ast.AST) -> bool | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, bool):
+        return node.value
+    return None
+
+
+def _py_source_string_constants(source: str) -> Mapping[str, str]:
+    constants: dict[str, str] = {}
+    if not source:
+        return constants
+    for node in ast.parse(source).body:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name):
+                value = _py_string_constant(node.value)
+                if value is not None:
+                    constants[target.id] = value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            value = _py_string_constant(node.value) if node.value is not None else None
+            if value is not None:
+                constants[node.target.id] = value
+    return constants
 
 
 def _ts_set(source: str, name: str) -> frozenset[str]:
@@ -771,6 +956,18 @@ def _ts_pack_string_variable(source: str, field_name: str) -> str:
     if match is None:
         raise AssertionError(f"operator UI pack field {field_name} is not discoverable")
     return match.group(1)
+
+
+def _ts_rejected_pack_boolean_field(source: str, field_name: str) -> bool:
+    match = re.search(
+        rf"\bpack\.{re.escape(field_name)}\s*!==\s*(true|false)",
+        source,
+    )
+    if match is None:
+        raise AssertionError(
+            f"operator UI pack field {field_name} boolean rejection is not discoverable"
+        )
+    return match.group(1) == "true"
 
 
 def _ts_forbidden_defined_pack_fields(source: str, error_message: str) -> frozenset[str]:

--- a/scripts/phase63_evidence_pack_contract_guard.py
+++ b/scripts/phase63_evidence_pack_contract_guard.py
@@ -32,14 +32,37 @@ _AUTHORITY_TRUTH_DENIALS = frozenset(
 )
 _AI_GROUNDING_SINGLETON_LABEL_FIELDS = MappingProxyType(
     {
+        "consumer": "consumer",
         "custody_state": "custody_state",
         "provenance_state": "provenance_state",
         "confidence_state": "confidence_state",
     }
 )
+_AI_GROUNDING_ALLOWED_LABEL_FIELDS = MappingProxyType(
+    {
+        "status": ("status", "_ALLOWED_STATUS"),
+        "freshness_state": ("freshness_state", "_ALLOWED_FRESHNESS"),
+        "conflict_state": ("conflict_state", "_ALLOWED_CONFLICT"),
+        "source_state": ("source_state", "_ALLOWED_SOURCE_STATE"),
+        "uncertainty_label": ("uncertainty_label", "_ALLOWED_UNCERTAINTY"),
+    }
+)
 _BACKEND_NO_WORKFLOW_AUTHORITY_TARGETS = (
     ("subscript", "typed_values", "workflow_authority"),
     ("optional", "confidence", "source_native_score_authority"),
+)
+_STATE_REASON_CONSISTENCY_RULES = frozenset(
+    {
+        "available_status_has_no_reasons",
+        "degraded_status_has_degraded_reasons_only",
+        "unavailable_status_has_unavailable_reasons",
+        "freshness_state_matches_stale_reputation",
+        "conflict_state_matches_conflicting_enrichment",
+        "source_state_matches_availability_reasons",
+        "uncertainty_label_matches_state",
+        "confidence_freshness_matches_freshness_state",
+        "confidence_ambiguity_badge_matches_conflict",
+    }
 )
 
 
@@ -59,6 +82,7 @@ class Phase63EvidencePackContract:
     authoritative_workflow_truth: bool
     confidence_posture: str
     freshness_window_milliseconds: int
+    state_reason_consistency_rules: frozenset[str]
     forbidden_projection_sources: frozenset[str]
     forbidden_readiness_claim_fields: frozenset[str]
     authority_truth_denials: frozenset[str]
@@ -142,6 +166,13 @@ def assert_phase63_evidence_pack_contract_aligned(
         backend.freshness_window_milliseconds,
         ui.freshness_window_milliseconds,
         ai.freshness_window_milliseconds,
+    )
+    _assert_equal(
+        "state/reason consistency rules",
+        backend.state_reason_consistency_rules,
+        ui.state_reason_consistency_rules,
+        ai.state_reason_consistency_rules,
+        _STATE_REASON_CONSISTENCY_RULES,
     )
     _assert_equal(
         "subordinate authority posture",
@@ -279,6 +310,9 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
             source_projection._parse_duration_seconds(registry_entry.freshness_window)
             * 1000
         ),
+        state_reason_consistency_rules=_py_backend_state_reason_consistency_rules(
+            validator_source
+        ),
         forbidden_projection_sources=frozenset(
             inspection_projection._EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES
         ),
@@ -316,20 +350,25 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
         validator_source,
         _AI_GROUNDING_SINGLETON_LABEL_FIELDS,
     )
+    membership_labels = _py_projection_get_membership_labels(
+        validator_source,
+        _AI_GROUNDING_ALLOWED_LABEL_FIELDS,
+        ai_grounding_validation,
+    )
     metadata_fields = _py_enforced_metadata_fields(
         validator_source,
         ai_grounding_validation,
     )
     labels = {
-        "consumer": frozenset({"ai_grounding"}),
-        "status": frozenset(ai_grounding_validation._ALLOWED_STATUS),
-        "freshness_state": frozenset(ai_grounding_validation._ALLOWED_FRESHNESS),
+        "consumer": singleton_labels["consumer"],
+        "status": membership_labels["status"],
+        "freshness_state": membership_labels["freshness_state"],
         "custody_state": singleton_labels["custody_state"],
         "confidence_state": singleton_labels["confidence_state"],
         "provenance_state": singleton_labels["provenance_state"],
-        "conflict_state": frozenset(ai_grounding_validation._ALLOWED_CONFLICT),
-        "source_state": frozenset(ai_grounding_validation._ALLOWED_SOURCE_STATE),
-        "uncertainty_label": frozenset(ai_grounding_validation._ALLOWED_UNCERTAINTY),
+        "conflict_state": membership_labels["conflict_state"],
+        "source_state": membership_labels["source_state"],
+        "uncertainty_label": membership_labels["uncertainty_label"],
     }
     return Phase63EvidencePackContract(
         labels=MappingProxyType(labels),
@@ -361,6 +400,9 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
             source_projection._parse_duration_seconds(registry_entry.freshness_window)
             * 1000
         ),
+        state_reason_consistency_rules=_py_ai_state_reason_consistency_rules(
+            validator_source
+        ),
         forbidden_projection_sources=frozenset(),
         forbidden_readiness_claim_fields=frozenset(),
         authority_truth_denials=frozenset(
@@ -385,10 +427,6 @@ def _operator_ui_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContrac
 
 def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContract:
     labels = _ts_allowed_labels(source)
-    freshness_window_ms = _ts_number_expression(
-        source,
-        "EVIDENCE_PACK_FRESHNESS_WINDOW_MS",
-    )
     metadata_fields = _ts_enforced_metadata_fields(source)
     reason_sets = _ts_enforced_reason_sets(source)
     return Phase63EvidencePackContract(
@@ -415,11 +453,15 @@ def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContrac
             source,
             "authoritative_workflow_truth",
         ),
-        confidence_posture=_ts_string_constant(
+        confidence_posture=_ts_rejected_mapping_string_field(
             source,
-            "EVIDENCE_PACK_CONFIDENCE_POSTURE",
+            "confidence",
+            "posture",
         ),
-        freshness_window_milliseconds=freshness_window_ms,
+        freshness_window_milliseconds=_ts_enforced_freshness_window_milliseconds(
+            source
+        ),
+        state_reason_consistency_rules=_ts_state_reason_consistency_rules(source),
         forbidden_projection_sources=_ts_set(
             source,
             "EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES",
@@ -696,31 +738,68 @@ def _py_projection_get_string_rejection_labels(
     return labels
 
 
+def _py_projection_get_membership_labels(
+    source: str,
+    label_fields: Mapping[str, tuple[str, str]],
+    namespace: object,
+) -> dict[str, frozenset[str]]:
+    labels: dict[str, frozenset[str]] = {}
+    for label_key, (field_name, constant_name) in label_fields.items():
+        values = _py_rejected_membership_values(
+            source,
+            ("get", "projection", field_name),
+            constant_name,
+            namespace,
+        )
+        if not values:
+            raise AssertionError(
+                f"Python projection label {field_name} membership check is not discoverable"
+            )
+        labels[label_key] = values
+    return labels
+
+
 def _py_enforced_metadata_fields(
     source: str,
     namespace: object,
 ) -> dict[str, frozenset[str]]:
-    fields: dict[str, frozenset[str]] = {}
+    required_fields: dict[str, frozenset[str]] = {}
+    allowed_fields: dict[str, frozenset[str]] = {}
     for node in ast.walk(ast.parse(source)):
         if not isinstance(node, ast.Call):
             continue
         if not isinstance(node.func, ast.Name):
             continue
-        if node.func.id != "_metadata_contract_reasons" or len(node.args) < 2:
-            continue
-        value_argument = node.args[0]
-        allowed_argument = node.args[1]
-        if not isinstance(value_argument, ast.Name):
-            continue
-        if not isinstance(allowed_argument, ast.Name):
-            continue
-        if value_argument.id not in {"custody", "provenance", "confidence"}:
-            continue
-        fields[value_argument.id] = frozenset(getattr(namespace, allowed_argument.id))
+        if node.func.id == "_mapping_has_non_empty_fields" and len(node.args) >= 2:
+            value_argument = node.args[0]
+            required_argument = node.args[1]
+            if (
+                isinstance(value_argument, ast.Name)
+                and value_argument.id in {"custody", "provenance", "confidence"}
+                and isinstance(required_argument, ast.Name)
+            ):
+                required_fields[value_argument.id] = frozenset(
+                    getattr(namespace, required_argument.id)
+                )
+        if node.func.id == "_metadata_contract_reasons" and len(node.args) >= 2:
+            value_argument = node.args[0]
+            allowed_argument = node.args[1]
+            if (
+                isinstance(value_argument, ast.Name)
+                and value_argument.id in {"custody", "provenance", "confidence"}
+                and isinstance(allowed_argument, ast.Name)
+            ):
+                allowed_fields[value_argument.id] = frozenset(
+                    getattr(namespace, allowed_argument.id)
+                )
     expected_fields = frozenset({"custody", "provenance", "confidence"})
-    if frozenset(fields) != expected_fields:
+    if (
+        frozenset(required_fields) != expected_fields
+        or frozenset(allowed_fields) != expected_fields
+        or required_fields != allowed_fields
+    ):
         raise AssertionError("AI grounding metadata enforcement drift")
-    return fields
+    return required_fields
 
 
 def _py_rejected_string_values(
@@ -745,6 +824,40 @@ def _py_rejected_string_values(
         _, mapping_name, field_name = target
         raise AssertionError(
             f"Python string rejection for {mapping_name}.{field_name} is not discoverable"
+        )
+    return frozenset(values)
+
+
+def _py_rejected_membership_values(
+    source: str,
+    target: tuple[str, str, str],
+    expected_constant_name: str,
+    namespace: object,
+) -> frozenset[str]:
+    values: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Compare):
+            continue
+        if len(node.ops) != 1 or not isinstance(node.ops[0], ast.NotIn):
+            continue
+        if len(node.comparators) != 1:
+            continue
+        if _py_rejection_target(node.left) != target:
+            continue
+        comparator = node.comparators[0]
+        if not isinstance(comparator, ast.Name):
+            continue
+        if comparator.id != expected_constant_name:
+            raise AssertionError(
+                f"Python membership rejection for {target[1]}.{target[2]} "
+                "uses an unexpected constant"
+            )
+        values.update(getattr(namespace, comparator.id))
+    if not values:
+        _, mapping_name, field_name = target
+        raise AssertionError(
+            f"Python membership rejection for {mapping_name}.{field_name} "
+            "is not discoverable"
         )
     return frozenset(values)
 
@@ -847,6 +960,131 @@ def _py_source_string_constants(source: str) -> Mapping[str, str]:
     return constants
 
 
+def _py_backend_state_reason_consistency_rules(source: str) -> frozenset[str]:
+    body = _py_function_source(source, "_validate_linked_evidence_pack_reason_consistency")
+    call_source = _py_function_source(source, "_validated_linked_evidence_pack_projection")
+    _require_substrings(
+        call_source,
+        ("_validate_linked_evidence_pack_reason_consistency(",),
+        "backend state/reason consistency call",
+    )
+    return _state_reason_consistency_rules_from_requirements(
+        {
+            "available_status_has_no_reasons": (
+                'values["status"] == "available"',
+                "degraded_reasons or unavailable_reasons",
+            ),
+            "degraded_status_has_degraded_reasons_only": (
+                'values["status"] == "degraded"',
+                "not degraded_reasons or unavailable_reasons",
+            ),
+            "unavailable_status_has_unavailable_reasons": (
+                'values["status"] == "unavailable"',
+                "not unavailable_reasons",
+            ),
+            "freshness_state_matches_stale_reputation": (
+                '"stale_reputation" in degraded_reasons',
+                'values["freshness_state"] == "stale"',
+            ),
+            "conflict_state_matches_conflicting_enrichment": (
+                "expected_conflict_state =",
+                '"conflicting" if "conflicting_enrichment" in degraded_reasons else "none"',
+            ),
+            "source_state_matches_availability_reasons": (
+                "expected_source_state =",
+                '"source_stale" in degraded_reasons',
+            ),
+            "uncertainty_label_matches_state": (
+                '_linked_evidence_pack_expected_uncertainty_label(',
+                '"uncertainty_label"',
+            ),
+            "confidence_freshness_matches_freshness_state": (
+                '"freshness",',
+                'values["freshness_state"]',
+            ),
+            "confidence_ambiguity_badge_matches_conflict": (
+                '"ambiguity_badge",',
+                '"unresolved"',
+                '"related-entity"',
+            ),
+        },
+        body,
+        "backend state/reason consistency",
+    )
+
+
+def _py_ai_state_reason_consistency_rules(source: str) -> frozenset[str]:
+    projection_body = _py_function_source(source, "_projection_reasons")
+    state_body = _py_function_source(source, "_state_consistency_reasons")
+    uncertainty_body = _py_function_source(source, "_expected_uncertainty_label")
+    _require_substrings(
+        projection_body,
+        (
+            "reasons.extend(_uncertainty_state_reasons(projection))",
+            "reasons.extend(_state_consistency_reasons(projection))",
+        ),
+        "AI state/reason consistency calls",
+    )
+    combined = state_body + "\n" + uncertainty_body
+    return _state_reason_consistency_rules_from_requirements(
+        {
+            "available_status_has_no_reasons": (
+                'status == "available"',
+                "bool(degraded_reasons)",
+                "bool(unavailable_reasons)",
+            ),
+            "degraded_status_has_degraded_reasons_only": (
+                'status == "degraded"',
+                "not degraded_reasons",
+                "bool(unavailable_reasons)",
+            ),
+            "unavailable_status_has_unavailable_reasons": (
+                'status == "unavailable"',
+                "not unavailable_reasons",
+            ),
+            "freshness_state_matches_stale_reputation": (
+                'freshness_state == "stale"',
+                '"stale_reputation" not in degraded_reasons',
+            ),
+            "conflict_state_matches_conflicting_enrichment": (
+                'conflict_state == "conflicting"',
+                '"conflicting_enrichment" not in degraded_reasons',
+            ),
+            "source_state_matches_availability_reasons": (
+                'source_state == "unavailable"',
+                'source_state == "degraded"',
+                '"source_stale" not in degraded_reasons',
+            ),
+            "uncertainty_label_matches_state": (
+                'return "source_unavailable"',
+                'return "unresolved_conflict"',
+                'return "stale_review_required"',
+                'return "related_entity_not_authoritative"',
+            ),
+            "confidence_freshness_matches_freshness_state": (
+                'confidence.get("freshness") != freshness_state',
+            ),
+            "confidence_ambiguity_badge_matches_conflict": (
+                "expected_badge =",
+                '"unresolved"',
+                '"related-entity"',
+            ),
+        },
+        combined,
+        "AI state/reason consistency",
+    )
+
+
+def _py_function_source(source: str, function_name: str) -> str:
+    pattern = rf"^def {re.escape(function_name)}\("
+    match = re.search(pattern, source, re.M)
+    if match is None:
+        raise AssertionError(f"Python function {function_name} is not discoverable")
+    next_match = re.search(r"^def \w+\(", source[match.end() :], re.M)
+    end = len(source) if next_match is None else match.end() + next_match.start()
+    return source[match.start() : end]
+
+
 def _ts_set(source: str, name: str) -> frozenset[str]:
     match = re.search(
         rf"const {re.escape(name)} = new Set\(\[(?P<body>.*?)\]\);",
@@ -899,6 +1137,87 @@ def _ts_number_expression(source: str, name: str) -> int:
     return _safe_integer_expression(expression)
 
 
+def _ts_enforced_freshness_window_milliseconds(source: str) -> int:
+    function_body = _ts_function_body(source, "validateEvidencePackFreshnessWindow")
+    _require_substrings(
+        function_body,
+        (
+            "EVIDENCE_PACK_FRESHNESS_WINDOW_MS",
+            'freshnessState === "fresh"',
+            'freshnessState === "stale"',
+        ),
+        "operator UI freshness-window enforcement",
+    )
+    _ts_require_call(
+        source,
+        "validateEvidencePackFreshnessWindow",
+        ("custody", "freshnessState", "evidenceRequestId"),
+    )
+    return _ts_number_expression(source, "EVIDENCE_PACK_FRESHNESS_WINDOW_MS")
+
+
+def _ts_state_reason_consistency_rules(source: str) -> frozenset[str]:
+    function_body = _ts_function_body(source, "validateEvidencePackReasonConsistency")
+    _ts_require_call(
+        source,
+        "validateEvidencePackReasonConsistency",
+        (
+            "pack",
+            "confidence",
+            "{\n      status,\n      freshnessState,\n      conflictState,\n      sourceState,\n      uncertaintyLabel,\n    }",
+        ),
+    )
+    return _state_reason_consistency_rules_from_requirements(
+        {
+            "available_status_has_no_reasons": (
+                'labels.status === "available"',
+                "degradedReasons.length > 0",
+                "unavailableReasons.length > 0",
+            ),
+            "degraded_status_has_degraded_reasons_only": (
+                'labels.status === "degraded"',
+                "degradedReasons.length === 0",
+                "unavailableReasons.length > 0",
+            ),
+            "unavailable_status_has_unavailable_reasons": (
+                'labels.status === "unavailable"',
+                "unavailableReasons.length === 0",
+            ),
+            "freshness_state_matches_stale_reputation": (
+                'degradedReasons.includes("stale_reputation")',
+                'labels.freshnessState === "stale"',
+            ),
+            "conflict_state_matches_conflicting_enrichment": (
+                "expectedConflictState =",
+                'degradedReasons.includes("conflicting_enrichment")',
+                '"conflicting"',
+                '"none"',
+            ),
+            "source_state_matches_availability_reasons": (
+                "expectedSourceState =",
+                'degradedReasons.includes("source_stale")',
+                '"unavailable"',
+                '"degraded"',
+                '"available"',
+            ),
+            "uncertainty_label_matches_state": (
+                "expectedEvidencePackUncertaintyLabel(",
+                "labels.uncertaintyLabel",
+            ),
+            "confidence_freshness_matches_freshness_state": (
+                "asString(confidence.freshness) !== labels.freshnessState",
+            ),
+            "confidence_ambiguity_badge_matches_conflict": (
+                "asString(confidence.ambiguity_badge)",
+                '"unresolved"',
+                '"related-entity"',
+            ),
+        },
+        function_body,
+        "operator UI state/reason consistency",
+    )
+
+
 def _ts_rejected_pack_string_field(source: str, field_name: str) -> str:
     variable_name = _ts_pack_string_variable(source, field_name)
     match = re.search(
@@ -937,7 +1256,7 @@ def _ts_rejected_mapping_string_field(
 ) -> str:
     match = re.search(
         rf"\basString\({re.escape(mapping_name)}\.{re.escape(field_name)}\)"
-        r"\s*!==\s*\"([^\"]+)\"",
+        r'\s*!==\s*(?:"([^\"]+)"|(EVIDENCE_PACK_[A-Z0-9_]+))',
         source,
     )
     if match is None:
@@ -945,7 +1264,10 @@ def _ts_rejected_mapping_string_field(
             "operator UI mapping field "
             f"{mapping_name}.{field_name} rejection is not discoverable"
         )
-    return match.group(1)
+    literal_value, constant_name = match.groups()
+    if literal_value is not None:
+        return literal_value
+    return _ts_string_constant(source, constant_name)
 
 
 def _ts_pack_string_variable(source: str, field_name: str) -> str:
@@ -1005,6 +1327,40 @@ def _ts_condition_for_error(source: str, error_message: str) -> str:
     return _extract_parenthesized(source, if_index + len("if "))
 
 
+def _ts_function_body(source: str, function_name: str) -> str:
+    match = re.search(rf"\bfunction\s+{re.escape(function_name)}\s*\(", source)
+    if match is None:
+        raise AssertionError(f"operator UI function {function_name} is not discoverable")
+    arguments_source = _extract_parenthesized(source, source.find("(", match.start()))
+    body_start = source.find("{", match.end() + len(arguments_source))
+    if body_start == -1:
+        raise AssertionError(f"operator UI function {function_name} body is not discoverable")
+    return _extract_braced(source, body_start)
+
+
+def _ts_require_call(
+    source: str,
+    function_name: str,
+    expected_arguments: tuple[str, ...],
+) -> None:
+    expected_normalized = tuple(_normalize_ts_argument(arg) for arg in expected_arguments)
+    for match in re.finditer(rf"\b{re.escape(function_name)}\s*\(", source):
+        arguments = tuple(
+            _normalize_ts_argument(argument)
+            for argument in _split_ts_arguments(
+                _extract_parenthesized(source, match.end() - 1)
+            )
+            if argument.strip()
+        )
+        if arguments == expected_normalized:
+            return
+    raise AssertionError(f"operator UI {function_name} call is not discoverable")
+
+
+def _normalize_ts_argument(argument: str) -> str:
+    return re.sub(r"\s+", " ", argument.strip())
+
+
 def _extract_parenthesized(source: str, open_index: int) -> str:
     if open_index >= len(source) or source[open_index] != "(":
         raise AssertionError("operator UI condition is not parenthesized")
@@ -1032,6 +1388,55 @@ def _extract_parenthesized(source: str, open_index: int) -> str:
             if depth == 0:
                 return source[condition_start:index]
     raise AssertionError("operator UI condition is not closed")
+
+
+def _extract_braced(source: str, open_index: int) -> str:
+    if open_index >= len(source) or source[open_index] != "{":
+        raise AssertionError("operator UI block is not braced")
+    depth = 0
+    string_quote: str | None = None
+    escaped = False
+    body_start = open_index + 1
+    for index in range(open_index, len(source)):
+        character = source[index]
+        if string_quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == string_quote:
+                string_quote = None
+            continue
+        if character in {'"', "'", "`"}:
+            string_quote = character
+            continue
+        if character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                return source[body_start:index]
+    raise AssertionError("operator UI block is not closed")
+
+
+def _state_reason_consistency_rules_from_requirements(
+    requirements: Mapping[str, tuple[str, ...]],
+    source: str,
+    label: str,
+) -> frozenset[str]:
+    rules = {
+        rule_name
+        for rule_name, substrings in requirements.items()
+        if all(substring in source for substring in substrings)
+    }
+    if frozenset(rules) != _STATE_REASON_CONSISTENCY_RULES:
+        raise AssertionError(f"{label} drift")
+    return frozenset(rules)
+
+
+def _require_substrings(source: str, substrings: tuple[str, ...], label: str) -> None:
+    if not all(substring in source for substring in substrings):
+        raise AssertionError(f"{label} drift")
 
 
 def _safe_integer_expression(expression: str) -> int:

--- a/scripts/phase63_evidence_pack_contract_guard.py
+++ b/scripts/phase63_evidence_pack_contract_guard.py
@@ -30,6 +30,17 @@ _AUTHORITY_TRUTH_DENIALS = frozenset(
         "workflow_truth",
     }
 )
+_AI_GROUNDING_SINGLETON_LABEL_FIELDS = MappingProxyType(
+    {
+        "custody_state": "custody_state",
+        "provenance_state": "provenance_state",
+        "confidence_state": "confidence_state",
+    }
+)
+_BACKEND_NO_WORKFLOW_AUTHORITY_TARGETS = (
+    ("subscript", "typed_values", "workflow_authority"),
+    ("optional", "confidence", "source_native_score_authority"),
+)
 
 
 @dataclass(frozen=True)
@@ -203,6 +214,14 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
 
     source_id = inspection_projection._EVIDENCE_PACK_SUPPORTED_SOURCE_ID
     registry_entry = PHASE63_EVIDENCE_SOURCE_REGISTRY[source_id]
+    validator_source = (
+        repo_root
+        / "control-plane"
+        / "aegisops"
+        / "control_plane"
+        / "inspection"
+        / "evidence_pack_projection.py"
+    ).read_text(encoding="utf-8")
     labels = {
         key: frozenset(
             inspection_projection._EVIDENCE_PACK_ALLOWED_PROJECTION_LABELS[key]
@@ -233,7 +252,9 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
         subordinate_authority_posture=(
             inspection_projection._EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE
         ),
-        no_workflow_authority=source_projection._NO_WORKFLOW_AUTHORITY,
+        no_workflow_authority=_backend_no_workflow_authority_rejection(
+            validator_source
+        ),
         confidence_posture=registry_entry.confidence_posture,
         freshness_window_seconds=source_projection._parse_duration_seconds(
             registry_entry.freshness_window
@@ -263,13 +284,25 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
         raise AssertionError("AI grounding source IDs must stay explicit")
     source_id = next(iter(source_ids))
     registry_entry = PHASE63_EVIDENCE_SOURCE_REGISTRY[source_id]
+    validator_source = (
+        repo_root
+        / "control-plane"
+        / "aegisops"
+        / "control_plane"
+        / "assistant"
+        / "ai_grounding_validation.py"
+    ).read_text(encoding="utf-8")
+    singleton_labels = _py_projection_get_string_rejection_labels(
+        validator_source,
+        _AI_GROUNDING_SINGLETON_LABEL_FIELDS,
+    )
     labels = {
         "consumer": frozenset({"ai_grounding"}),
         "status": frozenset(ai_grounding_validation._ALLOWED_STATUS),
         "freshness_state": frozenset(ai_grounding_validation._ALLOWED_FRESHNESS),
-        "custody_state": frozenset({"complete"}),
-        "confidence_state": frozenset({"present"}),
-        "provenance_state": frozenset({"bound"}),
+        "custody_state": singleton_labels["custody_state"],
+        "confidence_state": singleton_labels["confidence_state"],
+        "provenance_state": singleton_labels["provenance_state"],
         "conflict_state": frozenset(ai_grounding_validation._ALLOWED_CONFLICT),
         "source_state": frozenset(ai_grounding_validation._ALLOWED_SOURCE_STATE),
         "uncertainty_label": frozenset(ai_grounding_validation._ALLOWED_UNCERTAINTY),
@@ -301,7 +334,11 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
         ),
         forbidden_projection_sources=frozenset(),
         forbidden_readiness_claim_fields=frozenset(),
-        authority_truth_denials=frozenset(ai_grounding_validation._NEGATIVE_AUTHORITY),
+        authority_truth_denials=frozenset(
+            authority
+            for authority in _AUTHORITY_TRUTH_DENIALS
+            if ai_grounding_validation._scan_for_authority_claim(authority)
+        ),
     )
 
 
@@ -384,6 +421,100 @@ def _ts_allowed_labels(source: str) -> dict[str, frozenset[str]]:
             re.S,
         )
     }
+
+
+def _backend_no_workflow_authority_rejection(source: str) -> str:
+    values = frozenset(
+        value
+        for target in _BACKEND_NO_WORKFLOW_AUTHORITY_TARGETS
+        for value in _py_rejected_string_values(source, target)
+    )
+    if len(values) != 1:
+        raise AssertionError(
+            "backend workflow authority rejection is not consistently discoverable"
+        )
+    return next(iter(values))
+
+
+def _py_projection_get_string_rejection_labels(
+    source: str,
+    label_fields: Mapping[str, str],
+) -> dict[str, frozenset[str]]:
+    labels: dict[str, frozenset[str]] = {}
+    for label_key, field_name in label_fields.items():
+        values = _py_rejected_string_values(source, ("get", "projection", field_name))
+        if len(values) != 1:
+            raise AssertionError(
+                f"Python projection label {field_name} rejection is not singleton"
+            )
+        labels[label_key] = values
+    return labels
+
+
+def _py_rejected_string_values(
+    source: str,
+    target: tuple[str, str, str],
+) -> frozenset[str]:
+    values: set[str] = set()
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Compare):
+            continue
+        if len(node.ops) != 1 or not isinstance(node.ops[0], ast.NotEq):
+            continue
+        if len(node.comparators) != 1:
+            continue
+        compared_value = _py_string_constant(node.comparators[0])
+        if compared_value is None:
+            continue
+        if _py_rejection_target(node.left) == target:
+            values.add(compared_value)
+    if not values:
+        _, mapping_name, field_name = target
+        raise AssertionError(
+            f"Python string rejection for {mapping_name}.{field_name} is not discoverable"
+        )
+    return frozenset(values)
+
+
+def _py_rejection_target(node: ast.AST) -> tuple[str, str, str] | None:
+    if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+        field_name = _py_subscript_key(node.slice)
+        if field_name is not None:
+            return ("subscript", node.value.id, field_name)
+    if isinstance(node, ast.Call):
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and isinstance(node.func.value, ast.Name)
+            and node.args
+        ):
+            field_name = _py_string_constant(node.args[0])
+            if field_name is not None:
+                return ("get", node.func.value.id, field_name)
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "_optional_string_from_mapping"
+            and len(node.args) >= 2
+            and isinstance(node.args[0], ast.Name)
+        ):
+            field_name = _py_string_constant(node.args[1])
+            if field_name is not None:
+                return ("optional", node.args[0].id, field_name)
+    return None
+
+
+def _py_subscript_key(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Index):
+        node = node.value
+    return _py_string_constant(node)
+
+
+def _py_string_constant(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Str):
+        return node.s
+    return None
 
 
 def _ts_set(source: str, name: str) -> frozenset[str]:

--- a/scripts/phase63_evidence_pack_contract_guard.py
+++ b/scripts/phase63_evidence_pack_contract_guard.py
@@ -51,6 +51,14 @@ _BACKEND_NO_WORKFLOW_AUTHORITY_TARGETS = (
     ("subscript", "typed_values", "workflow_authority"),
     ("optional", "confidence", "source_native_score_authority"),
 )
+_BACKEND_SUBORDINATE_AUTHORITY_POSTURE_TARGETS = (
+    ("subscript", "typed_values", "authority_posture"),
+    ("optional", "provenance", "authority_posture"),
+)
+_AI_SUBORDINATE_AUTHORITY_POSTURE_TARGETS = (
+    ("get", "projection", "authority_posture"),
+    ("get", "provenance", "authority_posture"),
+)
 _STATE_REASON_CONSISTENCY_RULES = frozenset(
     {
         "available_status_has_no_reasons",
@@ -80,6 +88,7 @@ class Phase63EvidencePackContract:
     subordinate_authority_posture: str
     no_workflow_authority: str
     authoritative_workflow_truth: bool
+    operator_visible_truth: bool
     confidence_posture: str
     freshness_window_milliseconds: int
     state_reason_consistency_rules: frozenset[str]
@@ -155,6 +164,12 @@ def assert_phase63_evidence_pack_contract_aligned(
     )
     _assert_equal("contract fields", backend.contract_fields, ui.contract_fields)
     _assert_equal("recognized fields", backend.recognized_fields, ui.recognized_fields)
+    _assert_equal(
+        "operator-visible truth boundary",
+        backend.operator_visible_truth,
+        ui.operator_visible_truth,
+        True,
+    )
     _assert_equal(
         "source IDs",
         backend.supported_source_ids,
@@ -263,33 +278,34 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
         / "evidence_pack_projection.py"
     ).read_text(encoding="utf-8")
     labels = _py_backend_enforced_label_sets(validator_source, inspection_projection)
+    reason_sets = _py_backend_enforced_reason_sets(
+        validator_source,
+        inspection_projection,
+    )
     metadata_fields = _py_backend_enforced_metadata_fields(
         validator_source,
         inspection_projection,
     )
     return Phase63EvidencePackContract(
         labels=MappingProxyType(labels),
-        degraded_reasons=frozenset(
-            inspection_projection._EVIDENCE_PACK_ALLOWED_DEGRADED_REASONS
-        ),
-        unavailable_reasons=frozenset(
-            inspection_projection._EVIDENCE_PACK_ALLOWED_UNAVAILABLE_REASONS
-        ),
+        degraded_reasons=reason_sets["degraded_reasons"],
+        unavailable_reasons=reason_sets["unavailable_reasons"],
         required_custody_fields=metadata_fields["custody"],
         required_provenance_fields=metadata_fields["provenance"],
         required_confidence_fields=metadata_fields["confidence"],
         contract_fields=frozenset(
             inspection_projection._EVIDENCE_PACK_PROJECTION_CONTRACT_FIELDS
         ),
-        recognized_fields=frozenset(
-            inspection_projection._EVIDENCE_PACK_PROJECTION_RECOGNIZED_FIELDS
+        recognized_fields=_py_backend_recognized_fields_rejection(
+            validator_source,
+            inspection_projection,
         ),
         supported_source_ids=_py_rejected_string_values(
             validator_source,
             ("subscript", "values", "source_id"),
         ),
-        subordinate_authority_posture=(
-            inspection_projection._EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE
+        subordinate_authority_posture=_backend_subordinate_authority_posture_rejection(
+            validator_source
         ),
         no_workflow_authority=_backend_no_workflow_authority_rejection(
             validator_source
@@ -297,6 +313,10 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
         authoritative_workflow_truth=_py_rejected_boolean_value(
             validator_source,
             ("get", "projection", "authoritative_workflow_truth"),
+        ),
+        operator_visible_truth=_py_rejected_optional_boolean_value(
+            validator_source,
+            ("get", "projection", "operator_visible"),
         ),
         confidence_posture=_backend_confidence_posture_rejection(
             validator_source,
@@ -309,11 +329,13 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
         state_reason_consistency_rules=_py_backend_state_reason_consistency_rules(
             validator_source
         ),
-        forbidden_projection_sources=frozenset(
-            inspection_projection._EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES
+        forbidden_projection_sources=_py_backend_forbidden_projection_sources_rejection(
+            validator_source,
+            inspection_projection,
         ),
-        forbidden_readiness_claim_fields=frozenset(
-            inspection_projection._EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS
+        forbidden_readiness_claim_fields=_py_backend_forbidden_readiness_claim_rejection(
+            validator_source,
+            inspection_projection,
         ),
         authority_truth_denials=frozenset(),
     )
@@ -355,6 +377,10 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
         validator_source,
         ai_grounding_validation,
     )
+    reason_sets = _py_ai_enforced_reason_sets(
+        validator_source,
+        ai_grounding_validation,
+    )
     labels = {
         "consumer": singleton_labels["consumer"],
         "status": membership_labels["status"],
@@ -368,18 +394,16 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
     }
     return Phase63EvidencePackContract(
         labels=MappingProxyType(labels),
-        degraded_reasons=frozenset(ai_grounding_validation._ALLOWED_DEGRADED_REASONS),
-        unavailable_reasons=frozenset(
-            ai_grounding_validation._ALLOWED_UNAVAILABLE_REASONS
-        ),
+        degraded_reasons=reason_sets["degraded_reasons"],
+        unavailable_reasons=reason_sets["unavailable_reasons"],
         required_custody_fields=metadata_fields["custody"],
         required_provenance_fields=metadata_fields["provenance"],
         required_confidence_fields=metadata_fields["confidence"],
         contract_fields=frozenset(),
         recognized_fields=frozenset(),
         supported_source_ids=source_ids,
-        subordinate_authority_posture=(
-            ai_grounding_validation._SUBORDINATE_AUTHORITY_POSTURE
+        subordinate_authority_posture=_ai_subordinate_authority_posture_rejection(
+            validator_source
         ),
         no_workflow_authority=_ai_no_workflow_authority_rejection(
             validator_source
@@ -388,6 +412,7 @@ def _ai_grounding_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContra
             validator_source,
             ("get", "projection", "authoritative_workflow_truth"),
         ),
+        operator_visible_truth=True,
         confidence_posture=_ai_confidence_posture_rejection(
             validator_source,
             registry_entry.confidence_posture,
@@ -433,21 +458,21 @@ def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContrac
         required_provenance_fields=metadata_fields["provenance"],
         required_confidence_fields=metadata_fields["confidence"],
         contract_fields=_ts_set(source, "EVIDENCE_PACK_CONTRACT_FIELDS"),
-        recognized_fields=_ts_set_with_spreads(
+        recognized_fields=_ts_recognized_fields_rejection(
             source,
-            "EVIDENCE_PACK_RECOGNIZED_FIELDS",
         ),
         supported_source_ids=frozenset(
             {_ts_rejected_pack_string_field(source, "source_id")}
         ),
-        subordinate_authority_posture=_ts_rejected_pack_string_field(
-            source,
-            "authority_posture",
-        ),
+        subordinate_authority_posture=_ts_subordinate_authority_posture_rejection(source),
         no_workflow_authority=_ts_no_workflow_authority_rejection(source),
         authoritative_workflow_truth=_ts_rejected_pack_boolean_field(
             source,
             "authoritative_workflow_truth",
+        ),
+        operator_visible_truth=_ts_rejected_optional_pack_boolean_field(
+            source,
+            "operator_visible",
         ),
         confidence_posture=_ts_rejected_mapping_string_field(
             source,
@@ -602,6 +627,22 @@ def _backend_no_workflow_authority_rejection(source: str) -> str:
     return next(iter(values))
 
 
+def _backend_subordinate_authority_posture_rejection(source: str) -> str:
+    values: set[str] = set()
+    try:
+        for target in _BACKEND_SUBORDINATE_AUTHORITY_POSTURE_TARGETS:
+            values.update(_py_rejected_string_values(source, target))
+    except AssertionError as exc:
+        raise AssertionError(
+            "backend authority posture rejection is not consistently discoverable"
+        ) from exc
+    if len(values) != 1:
+        raise AssertionError(
+            "backend authority posture rejection is not consistently discoverable"
+        )
+    return next(iter(values))
+
+
 def _ai_no_workflow_authority_rejection(source: str) -> str:
     targets = (
         ("get", "projection", "workflow_authority"),
@@ -615,6 +656,22 @@ def _ai_no_workflow_authority_rejection(source: str) -> str:
     if len(values) != 1:
         raise AssertionError(
             "AI workflow authority rejection is not consistently discoverable"
+        )
+    return next(iter(values))
+
+
+def _ai_subordinate_authority_posture_rejection(source: str) -> str:
+    values: set[str] = set()
+    try:
+        for target in _AI_SUBORDINATE_AUTHORITY_POSTURE_TARGETS:
+            values.update(_py_rejected_string_values(source, target))
+    except AssertionError as exc:
+        raise AssertionError(
+            "AI authority posture rejection is not consistently discoverable"
+        ) from exc
+    if len(values) != 1:
+        raise AssertionError(
+            "AI authority posture rejection is not consistently discoverable"
         )
     return next(iter(values))
 
@@ -815,6 +872,31 @@ def _py_backend_enforced_label_sets(
     return {key: frozenset(labels[key]) for key in _LABEL_KEYS}
 
 
+def _py_backend_enforced_reason_sets(
+    source: str,
+    namespace: object,
+) -> dict[str, frozenset[str]]:
+    body = _py_function_source(source, "_validated_linked_evidence_pack_projection")
+    _require_substrings(
+        body,
+        (
+            "reason not in _EVIDENCE_PACK_ALLOWED_DEGRADED_REASONS",
+            "for reason in degraded_reasons",
+            "reason not in _EVIDENCE_PACK_ALLOWED_UNAVAILABLE_REASONS",
+            "for reason in unavailable_reasons",
+        ),
+        "backend evidence-pack reason enforcement",
+    )
+    return {
+        "degraded_reasons": frozenset(
+            getattr(namespace, "_EVIDENCE_PACK_ALLOWED_DEGRADED_REASONS")
+        ),
+        "unavailable_reasons": frozenset(
+            getattr(namespace, "_EVIDENCE_PACK_ALLOWED_UNAVAILABLE_REASONS")
+        ),
+    }
+
+
 def _py_backend_enforced_metadata_fields(
     source: str,
     namespace: object,
@@ -841,6 +923,87 @@ def _py_backend_enforced_metadata_fields(
     if frozenset(metadata_fields) != expected_fields:
         raise AssertionError("backend evidence-pack metadata enforcement drift")
     return metadata_fields
+
+
+def _py_backend_recognized_fields_rejection(
+    source: str,
+    namespace: object,
+) -> frozenset[str]:
+    body = _py_function_source(source, "_validated_linked_evidence_pack_projection")
+    _require_substrings(
+        body,
+        (
+            "missing_fields = _EVIDENCE_PACK_PROJECTION_CONTRACT_FIELDS - frozenset(projection)",
+            "if missing_fields:",
+            "unexpected_fields =",
+            "frozenset(projection) - _EVIDENCE_PACK_PROJECTION_RECOGNIZED_FIELDS",
+            "if unexpected_fields:",
+        ),
+        "backend recognized-field rejection",
+    )
+    return frozenset(getattr(namespace, "_EVIDENCE_PACK_PROJECTION_RECOGNIZED_FIELDS"))
+
+
+def _py_backend_forbidden_projection_sources_rejection(
+    source: str,
+    namespace: object,
+) -> frozenset[str]:
+    body = _py_function_source(source, "_validated_linked_evidence_pack_projection")
+    _require_substrings(
+        body,
+        (
+            "projection_source in _EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES",
+            'raise ValueError("linked evidence-pack projection cannot be cache sourced")',
+        ),
+        "backend forbidden projection-source enforcement",
+    )
+    return frozenset(getattr(namespace, "_EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES"))
+
+
+def _py_backend_forbidden_readiness_claim_rejection(
+    source: str,
+    namespace: object,
+) -> frozenset[str]:
+    body = _py_function_source(source, "_validated_linked_evidence_pack_projection")
+    _require_substrings(
+        body,
+        (
+            "claim_name in projection",
+            "for claim_name in _EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS",
+            'raise ValueError("linked evidence-pack projection cannot claim release readiness")',
+        ),
+        "backend readiness-claim rejection",
+    )
+    return frozenset(getattr(namespace, "_EVIDENCE_PACK_FORBIDDEN_READINESS_CLAIMS"))
+
+
+def _py_ai_enforced_reason_sets(
+    source: str,
+    namespace: object,
+) -> dict[str, frozenset[str]]:
+    grounding_body = _py_function_source(source, "_grounding_source_reasons")
+    unsupported_body = _py_function_source(source, "_unsupported_projection_reason_reasons")
+    _require_substrings(
+        grounding_body,
+        ("reasons.extend(_unsupported_projection_reason_reasons(projection))",),
+        "AI reason vocabulary enforcement call",
+    )
+    _require_substrings(
+        unsupported_body,
+        (
+            "reason not in _ALLOWED_DEGRADED_REASONS",
+            "for reason in degraded_reasons",
+            "reason not in _ALLOWED_UNAVAILABLE_REASONS",
+            "for reason in unavailable_reasons",
+        ),
+        "AI reason vocabulary enforcement",
+    )
+    return {
+        "degraded_reasons": frozenset(getattr(namespace, "_ALLOWED_DEGRADED_REASONS")),
+        "unavailable_reasons": frozenset(
+            getattr(namespace, "_ALLOWED_UNAVAILABLE_REASONS")
+        ),
+    }
 
 
 def _py_rejected_string_values(
@@ -924,6 +1087,40 @@ def _py_rejected_boolean_value(
         _, mapping_name, field_name = target
         raise AssertionError(
             f"Python boolean rejection for {mapping_name}.{field_name} is not discoverable"
+        )
+    return next(iter(values))
+
+
+def _py_rejected_optional_boolean_value(
+    source: str,
+    target: tuple[str, str, str],
+) -> bool:
+    values: set[bool] = set()
+    has_none_guard = False
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Compare):
+            continue
+        if len(node.comparators) != 1 or _py_rejection_target(node.left) != target:
+            continue
+        comparator = node.comparators[0]
+        if (
+            len(node.ops) == 1
+            and isinstance(node.ops[0], (ast.IsNot, ast.NotEq))
+            and isinstance(comparator, ast.Constant)
+            and comparator.value is None
+        ):
+            has_none_guard = True
+            continue
+        if len(node.ops) != 1 or not isinstance(node.ops[0], (ast.IsNot, ast.NotEq)):
+            continue
+        compared_value = _py_boolean_constant(comparator)
+        if compared_value is not None:
+            values.add(compared_value)
+    if len(values) != 1 or not has_none_guard:
+        _, mapping_name, field_name = target
+        raise AssertionError(
+            "Python optional boolean rejection for "
+            f"{mapping_name}.{field_name} is not discoverable"
         )
     return next(iter(values))
 
@@ -1294,6 +1491,29 @@ def _ts_no_workflow_authority_rejection(source: str) -> str:
     return next(iter(values))
 
 
+def _ts_subordinate_authority_posture_rejection(source: str) -> str:
+    try:
+        values = frozenset(
+            {
+                _ts_rejected_pack_string_field(source, "authority_posture"),
+                _ts_rejected_mapping_string_field(
+                    source,
+                    "provenance",
+                    "authority_posture",
+                ),
+            }
+        )
+    except AssertionError as exc:
+        raise AssertionError(
+            "operator UI authority_posture rejection is not consistently discoverable"
+        ) from exc
+    if len(values) != 1:
+        raise AssertionError(
+            "operator UI authority_posture rejection is not consistently discoverable"
+        )
+    return next(iter(values))
+
+
 def _ts_rejected_mapping_string_field(
     source: str,
     mapping_name: str,
@@ -1337,6 +1557,18 @@ def _ts_rejected_pack_boolean_field(source: str, field_name: str) -> bool:
     return match.group(1) == "true"
 
 
+def _ts_rejected_optional_pack_boolean_field(source: str, field_name: str) -> bool:
+    variable = f"pack.{field_name}"
+    condition = _ts_condition_for_error(source, "must stay operator visible")
+    undefined_check = f"{variable} !== undefined"
+    match = re.search(rf"\b{re.escape(variable)}\s*!==\s*(true|false)", condition)
+    if undefined_check not in condition or match is None:
+        raise AssertionError(
+            f"operator UI pack field {field_name} optional boolean rejection is not discoverable"
+        )
+    return match.group(1) == "true"
+
+
 def _ts_forbidden_defined_pack_fields(source: str, error_message: str) -> frozenset[str]:
     condition = _ts_condition_for_error(source, error_message)
     fields = frozenset(
@@ -1347,6 +1579,22 @@ def _ts_forbidden_defined_pack_fields(source: str, error_message: str) -> frozen
             f"operator UI forbidden pack fields for {error_message} are not discoverable"
         )
     return fields
+
+
+def _ts_recognized_fields_rejection(source: str) -> frozenset[str]:
+    try:
+        condition = _ts_condition_for_error(source, "unexpected evidence-pack fields")
+        _require_substrings(
+            condition,
+            (
+                "Object.keys(pack).some(",
+                "(fieldName) => !EVIDENCE_PACK_RECOGNIZED_FIELDS.has(fieldName)",
+            ),
+            "operator UI recognized-field rejection",
+        )
+    except AssertionError as exc:
+        raise AssertionError("operator UI recognized-field rejection drift") from exc
+    return _ts_set_with_spreads(source, "EVIDENCE_PACK_RECOGNIZED_FIELDS")
 
 
 def _ts_forbidden_projection_sources_rejection(source: str) -> frozenset[str]:

--- a/scripts/phase63_evidence_pack_contract_guard.py
+++ b/scripts/phase63_evidence_pack_contract_guard.py
@@ -97,6 +97,11 @@ class Phase63EvidencePackContract:
     authority_truth_denials: frozenset[str]
 
 
+def _main() -> None:
+    assert_phase63_evidence_pack_contract_aligned()
+    print("Phase 63 evidence-pack contract guard passed")
+
+
 def assert_phase63_evidence_pack_contract_aligned(
     repo_root: pathlib.Path | str | None = None,
     *,
@@ -253,11 +258,6 @@ def _ensure_control_plane_path(repo_root: pathlib.Path) -> None:
     control_plane_root = repo_root / "control-plane"
     if str(control_plane_root) not in sys.path:
         sys.path.insert(0, str(control_plane_root))
-
-
-def _main() -> None:
-    assert_phase63_evidence_pack_contract_aligned()
-    print("Phase 63 evidence-pack contract guard passed")
 
 
 def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:

--- a/scripts/phase63_evidence_pack_contract_guard.py
+++ b/scripts/phase63_evidence_pack_contract_guard.py
@@ -262,12 +262,11 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
         / "inspection"
         / "evidence_pack_projection.py"
     ).read_text(encoding="utf-8")
-    labels = {
-        key: frozenset(
-            inspection_projection._EVIDENCE_PACK_ALLOWED_PROJECTION_LABELS[key]
-        )
-        for key in _LABEL_KEYS
-    }
+    labels = _py_backend_enforced_label_sets(validator_source, inspection_projection)
+    metadata_fields = _py_backend_enforced_metadata_fields(
+        validator_source,
+        inspection_projection,
+    )
     return Phase63EvidencePackContract(
         labels=MappingProxyType(labels),
         degraded_reasons=frozenset(
@@ -276,22 +275,19 @@ def _backend_contract(repo_root: pathlib.Path) -> Phase63EvidencePackContract:
         unavailable_reasons=frozenset(
             inspection_projection._EVIDENCE_PACK_ALLOWED_UNAVAILABLE_REASONS
         ),
-        required_custody_fields=frozenset(
-            inspection_projection._EVIDENCE_PACK_REQUIRED_CUSTODY_FIELDS
-        ),
-        required_provenance_fields=frozenset(
-            inspection_projection._EVIDENCE_PACK_REQUIRED_PROVENANCE_FIELDS
-        ),
-        required_confidence_fields=frozenset(
-            inspection_projection._EVIDENCE_PACK_REQUIRED_CONFIDENCE_FIELDS
-        ),
+        required_custody_fields=metadata_fields["custody"],
+        required_provenance_fields=metadata_fields["provenance"],
+        required_confidence_fields=metadata_fields["confidence"],
         contract_fields=frozenset(
             inspection_projection._EVIDENCE_PACK_PROJECTION_CONTRACT_FIELDS
         ),
         recognized_fields=frozenset(
             inspection_projection._EVIDENCE_PACK_PROJECTION_RECOGNIZED_FIELDS
         ),
-        supported_source_ids=frozenset({source_id}),
+        supported_source_ids=_py_rejected_string_values(
+            validator_source,
+            ("subscript", "values", "source_id"),
+        ),
         subordinate_authority_posture=(
             inspection_projection._EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE
         ),
@@ -442,11 +438,11 @@ def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContrac
             "EVIDENCE_PACK_RECOGNIZED_FIELDS",
         ),
         supported_source_ids=frozenset(
-            {_ts_string_constant(source, "EVIDENCE_PACK_SUPPORTED_SOURCE_ID")}
+            {_ts_rejected_pack_string_field(source, "source_id")}
         ),
-        subordinate_authority_posture=_ts_string_constant(
+        subordinate_authority_posture=_ts_rejected_pack_string_field(
             source,
-            "EVIDENCE_PACK_SUBORDINATE_AUTHORITY_POSTURE",
+            "authority_posture",
         ),
         no_workflow_authority=_ts_no_workflow_authority_rejection(source),
         authoritative_workflow_truth=_ts_rejected_pack_boolean_field(
@@ -462,10 +458,7 @@ def _operator_ui_contract_from_source(source: str) -> Phase63EvidencePackContrac
             source
         ),
         state_reason_consistency_rules=_ts_state_reason_consistency_rules(source),
-        forbidden_projection_sources=_ts_set(
-            source,
-            "EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES",
-        ),
+        forbidden_projection_sources=_ts_forbidden_projection_sources_rejection(source),
         forbidden_readiness_claim_fields=_ts_forbidden_defined_pack_fields(
             source,
             "cannot claim release readiness",
@@ -800,6 +793,54 @@ def _py_enforced_metadata_fields(
     ):
         raise AssertionError("AI grounding metadata enforcement drift")
     return required_fields
+
+
+def _py_backend_enforced_label_sets(
+    source: str,
+    namespace: object,
+) -> dict[str, frozenset[str]]:
+    body = _py_function_source(source, "_validated_linked_evidence_pack_projection")
+    _require_substrings(
+        body,
+        (
+            "for field_name, allowed_values in "
+            "_EVIDENCE_PACK_ALLOWED_PROJECTION_LABELS.items():",
+            "values[field_name] not in allowed_values",
+        ),
+        "backend evidence-pack label enforcement",
+    )
+    labels = getattr(namespace, "_EVIDENCE_PACK_ALLOWED_PROJECTION_LABELS")
+    if frozenset(labels) != frozenset(_LABEL_KEYS):
+        raise AssertionError("backend evidence-pack label enforcement drift")
+    return {key: frozenset(labels[key]) for key in _LABEL_KEYS}
+
+
+def _py_backend_enforced_metadata_fields(
+    source: str,
+    namespace: object,
+) -> dict[str, frozenset[str]]:
+    metadata_fields: dict[str, frozenset[str]] = {}
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name):
+            continue
+        if node.func.id != "_required_metadata_map_fields" or len(node.args) < 2:
+            continue
+        value_argument = node.args[0]
+        required_argument = node.args[1]
+        if (
+            isinstance(value_argument, ast.Name)
+            and value_argument.id in {"custody", "provenance", "confidence"}
+            and isinstance(required_argument, ast.Name)
+        ):
+            metadata_fields[value_argument.id] = frozenset(
+                getattr(namespace, required_argument.id)
+            )
+    expected_fields = frozenset({"custody", "provenance", "confidence"})
+    if frozenset(metadata_fields) != expected_fields:
+        raise AssertionError("backend evidence-pack metadata enforcement drift")
+    return metadata_fields
 
 
 def _py_rejected_string_values(
@@ -1221,14 +1262,18 @@ def _ts_state_reason_consistency_rules(source: str) -> frozenset[str]:
 def _ts_rejected_pack_string_field(source: str, field_name: str) -> str:
     variable_name = _ts_pack_string_variable(source, field_name)
     match = re.search(
-        rf"\b{re.escape(variable_name)}\s*!==\s*\"([^\"]+)\"",
+        rf"\b{re.escape(variable_name)}\s*!==\s*"
+        r'(?:"([^\"]+)"|(EVIDENCE_PACK_[A-Z0-9_]+))',
         source,
     )
     if match is None:
         raise AssertionError(
             f"operator UI pack field {field_name} rejection is not discoverable"
         )
-    return match.group(1)
+    literal_value, constant_name = match.groups()
+    if literal_value is not None:
+        return literal_value
+    return _ts_string_constant(source, constant_name)
 
 
 def _ts_no_workflow_authority_rejection(source: str) -> str:
@@ -1302,6 +1347,24 @@ def _ts_forbidden_defined_pack_fields(source: str, error_message: str) -> frozen
             f"operator UI forbidden pack fields for {error_message} are not discoverable"
         )
     return fields
+
+
+def _ts_forbidden_projection_sources_rejection(source: str) -> frozenset[str]:
+    projection_source_variable = _ts_pack_string_variable(source, "projection_source")
+    condition = _ts_condition_for_error(
+        source,
+        "rejects cache or browser sourced evidence-pack truth",
+    )
+    expected_check = (
+        "EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES.has("
+        f'{projection_source_variable} ?? ""'
+        ")"
+    )
+    if expected_check not in condition:
+        raise AssertionError(
+            "operator UI forbidden projection-source enforcement is not discoverable"
+        )
+    return _ts_set(source, "EVIDENCE_PACK_FORBIDDEN_PROJECTION_SOURCES")
 
 
 def _ts_condition_for_error(source: str, error_message: str) -> str:

--- a/scripts/verify-phase-63-r-closeout-evaluation.sh
+++ b/scripts/verify-phase-63-r-closeout-evaluation.sh
@@ -61,6 +61,7 @@ This addendum does not claim new product behavior, evidence-source breadth, work
 | Evidence source registry catalogs | `evidence_source_registry.py` | Registry data and validation catalog rules lived with registry entrypoints. | Registry data and validation catalog helpers are split while preserving the bounded `osquery_host_state` and `malwarebazaar_hash_reputation` registry. |
 `python3 -m unittest control-plane.tests.test_phase63_5_evidence_freshness_provenance_projection`
 `python3 -m unittest control-plane.tests.test_phase63_7_ai_grounding_adapter`
+`python3 -m unittest control-plane.tests.test_phase63_evidence_pack_contract_drift_guard`
 `python3 -m unittest control-plane.tests.test_phase63_evidence_source_registry`
 `npm run test --workspace @aegisops/operator-ui -- detailReaders.evidence-pack-extraction.test.ts OperatorRoutes.casework.evidence-pack.test.tsx`
 `npm run typecheck --workspace @aegisops/operator-ui`


### PR DESCRIPTION
## Summary
- add a repo-owned Phase 63 evidence-pack contract drift verifier across backend projection, operator-ui validation, and AI grounding validation
- add focused self-tests that inject representative contract mismatches and fail closed
- document the guard in the Phase 63 closeout verification list without changing product behavior

## Verification
- python3 -m unittest control-plane.tests.test_phase63_5_evidence_freshness_provenance_projection control-plane.tests.test_phase63_7_ai_grounding_adapter control-plane.tests.test_phase63_evidence_pack_contract_drift_guard
- npm run test --workspace @aegisops/operator-ui -- detailReaders.evidence-pack-extraction.test.ts OperatorRoutes.casework.evidence-pack.test.tsx
- bash scripts/verify-publishable-path-hygiene.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1362 --config <supervisor-config-path>