### PR TITLE
Add operator limitation ownership surface

### DIFF
--- a/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
@@ -32,6 +32,22 @@ const normalLimitationOwnership = {
   workflow_truth: false,
 };
 
+const normalLimitationOwnershipListRecord = {
+  affected_surface: normalLimitationOwnership.affected_surface,
+  authority_boundary: normalLimitationOwnership.authority_boundary,
+  due_date: normalLimitationOwnership.due_date,
+  evidence_references: normalLimitationOwnership.evidence_references,
+  limitation_id: normalLimitationOwnership.limitation_id,
+  mitigation: normalLimitationOwnership.mitigation,
+  owner: normalLimitationOwnership.owner,
+  phase66_handoff_posture: normalLimitationOwnership.phase66_handoff_posture,
+  readiness_claim: null,
+  review_cadence: normalLimitationOwnership.review_cadence,
+  review_state: normalLimitationOwnership.review_state,
+  severity: normalLimitationOwnership.severity,
+  title: normalLimitationOwnership.title,
+};
+
 export function registerOperatorRoutesLimitationOwnershipTests() {
   describe("limitation ownership route", () => {
     it("renders reviewed limitation ownership as subordinate backend context", async () => {
@@ -90,17 +106,59 @@ export function registerOperatorRoutesLimitationOwnershipTests() {
       );
     });
 
+    it("requires operators to choose a concrete limitation before detail inspection", async () => {
+      const fetchFn = createAuthorizedFetch({
+        "/inspect-records?family=known_limitation_ownership": {
+          records: [normalLimitationOwnershipListRecord],
+          total_records: 1,
+        },
+      });
+      const dependencies = createDefaultDependencies({
+        fetchFn,
+      });
+
+      renderOperatorRoute("/operator/limitations", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Limitation ownership" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(
+          "Limitation ownership detail remains subordinate backend context and requires a concrete reviewed limitation id.",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", {
+          name: "Support bundle evidence remains separately tracked.",
+        }),
+      ).toHaveAttribute(
+        "href",
+        "/operator/limitations?limitation_id=limitation-phase64-support-bundle-001",
+      );
+      expect(
+        fetchFn.mock.calls.some(([url]) =>
+          String(url).startsWith("/inspect-limitation-ownership"),
+        ),
+      ).toBe(false);
+    });
+
     it("fails closed on browser or cache sourced limitation ownership truth", async () => {
       const dependencies = createDefaultDependencies({
         fetchFn: createAuthorizedFetch({
-          "/inspect-limitation-ownership": {
+          "/inspect-limitation-ownership?limitation_id=limitation-phase64-support-bundle-001": {
             ...normalLimitationOwnership,
             projection_source: "browser_cache",
           },
         }),
       });
 
-      renderOperatorRoute("/operator/limitations", dependencies);
+      renderOperatorRoute(
+        "/operator/limitations?limitation_id=limitation-phase64-support-bundle-001",
+        dependencies,
+      );
 
       await waitFor(() => {
         expect(
@@ -128,14 +186,17 @@ export function registerOperatorRoutesLimitationOwnershipTests() {
       delete payloadWithoutReviewTiming.review_cadence;
       const dependencies = createDefaultDependencies({
         fetchFn: createAuthorizedFetch({
-          "/inspect-limitation-ownership": {
+          "/inspect-limitation-ownership?limitation_id=limitation-phase64-support-bundle-001": {
             ...payloadWithoutReviewTiming,
             review_due_date_status: "not_specified",
           },
         }),
       });
 
-      renderOperatorRoute("/operator/limitations", dependencies);
+      renderOperatorRoute(
+        "/operator/limitations?limitation_id=limitation-phase64-support-bundle-001",
+        dependencies,
+      );
 
       await waitFor(() => {
         expect(

--- a/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
@@ -26,7 +26,6 @@ const normalLimitationOwnership = {
   review_due_date_status: "current",
   review_state: "accepted_risk",
   severity: "material",
-  stale_cache: false,
   title: "Support bundle evidence remains separately tracked.",
   affected_surface: "supportability_evidence",
   workflow_authority: "none",
@@ -105,6 +104,36 @@ export function registerOperatorRoutesLimitationOwnershipTests() {
           "The backend limitation ownership projection was stale, malformed, or claimed authority the browser cannot hold.",
         ),
       ).toBeInTheDocument();
+    });
+
+    it("fails closed when limitation ownership omits review timing", async () => {
+      const payloadWithoutReviewTiming: Record<string, unknown> = {
+        ...normalLimitationOwnership,
+      };
+      delete payloadWithoutReviewTiming.due_date;
+      delete payloadWithoutReviewTiming.review_cadence;
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-limitation-ownership": {
+            ...payloadWithoutReviewTiming,
+            review_due_date_status: "not_specified",
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/limitations", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", {
+            name: "Limitation ownership unavailable",
+          }),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText("Support bundle evidence remains separately tracked."),
+      ).toBeNull();
     });
   });
 }

--- a/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
@@ -117,7 +117,7 @@ export function registerOperatorRoutesLimitationOwnershipTests() {
         fetchFn,
       });
 
-      renderOperatorRoute("/operator/limitations", dependencies);
+      renderOperatorRoute("/operator/limitations?view=selection", dependencies);
 
       await waitFor(() => {
         expect(
@@ -137,6 +137,10 @@ export function registerOperatorRoutesLimitationOwnershipTests() {
       ).toHaveAttribute(
         "href",
         "/operator/limitations?limitation_id=limitation-phase64-support-bundle-001",
+      );
+      expect(screen.getByRole("menuitem", { name: "Limitations" })).toHaveAttribute(
+        "href",
+        expect.stringContaining("/operator/limitations?view=selection"),
       );
       expect(
         fetchFn.mock.calls.some(([url]) =>

--- a/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
@@ -39,6 +39,7 @@ const normalLimitationOwnershipListRecord = {
   due_date: normalLimitationOwnership.due_date,
   evidence_references: normalLimitationOwnership.evidence_references,
   limitation_id: normalLimitationOwnership.limitation_id,
+  lifecycle_state: normalLimitationOwnership.review_state,
   mitigation: normalLimitationOwnership.mitigation,
   owner: normalLimitationOwnership.owner,
   phase66_handoff_posture: normalLimitationOwnership.phase66_handoff_posture,

--- a/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
@@ -35,13 +35,18 @@ const normalLimitationOwnership = {
 export function registerOperatorRoutesLimitationOwnershipTests() {
   describe("limitation ownership route", () => {
     it("renders reviewed limitation ownership as subordinate backend context", async () => {
+      const fetchFn = createAuthorizedFetch({
+        "/inspect-limitation-ownership?limitation_id=limitation-phase64-support-bundle-001":
+          normalLimitationOwnership,
+      });
       const dependencies = createDefaultDependencies({
-        fetchFn: createAuthorizedFetch({
-          "/inspect-limitation-ownership": normalLimitationOwnership,
-        }),
+        fetchFn,
       });
 
-      renderOperatorRoute("/operator/limitations", dependencies);
+      renderOperatorRoute(
+        "/operator/limitations?limitation_id=limitation-phase64-support-bundle-001",
+        dependencies,
+      );
 
       await waitFor(() => {
         expect(
@@ -74,6 +79,15 @@ export function registerOperatorRoutesLimitationOwnershipTests() {
       expect(screen.queryByRole("button", { name: /resolve/i })).toBeNull();
       expect(screen.queryByRole("button", { name: /approve/i })).toBeNull();
       expect(screen.queryByText(/ready for rc/i)).toBeNull();
+      expect(fetchFn).toHaveBeenCalledWith(
+        "/inspect-limitation-ownership?limitation_id=limitation-phase64-support-bundle-001",
+        {
+          credentials: "include",
+          headers: {
+            Accept: "application/json",
+          },
+        },
+      );
     });
 
     it("fails closed on browser or cache sourced limitation ownership truth", async () => {

--- a/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
@@ -7,6 +7,7 @@ import {
 } from "./OperatorRoutes.testSupport";
 
 const normalLimitationOwnership = {
+  accepted_risk_posture: "bounded_pre_rc_limitation",
   authority_boundary: "reviewed_evidence_input_only",
   authority_posture: "subordinate_limitation_context_only",
   consumer: "inspection",
@@ -84,6 +85,9 @@ export function registerOperatorRoutesLimitationOwnershipTests() {
       ).toBeInTheDocument();
       expect(screen.getByText("Affected surface: supportability evidence")).toBeInTheDocument();
       expect(screen.getByText("Phase 66 handoff: handoff required")).toBeInTheDocument();
+      expect(
+        screen.getByText("Accepted risk posture: Bounded Pre Rc Limitation"),
+      ).toBeInTheDocument();
       expect(screen.getByText("Due date: 2026-06-15")).toBeInTheDocument();
       expect(screen.getByText("Cadence: weekly")).toBeInTheDocument();
       expect(screen.getByText("Subordinate limitation context only")).toBeInTheDocument();
@@ -141,6 +145,15 @@ export function registerOperatorRoutesLimitationOwnershipTests() {
       expect(screen.getByRole("menuitem", { name: "Limitations" })).toHaveAttribute(
         "href",
         expect.stringContaining("/operator/limitations?view=selection"),
+      );
+      expect(fetchFn).toHaveBeenCalledWith(
+        "/inspect-records?family=known_limitation_ownership&order=ASC&sort=limitation_id",
+        {
+          credentials: "include",
+          headers: {
+            Accept: "application/json",
+          },
+        },
       );
       expect(
         fetchFn.mock.calls.some(([url]) =>

--- a/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx
@@ -1,0 +1,110 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createDefaultDependencies } from "./OperatorRoutes";
+import {
+  createAuthorizedFetch,
+  renderOperatorRoute,
+} from "./OperatorRoutes.testSupport";
+
+const normalLimitationOwnership = {
+  authority_boundary: "reviewed_evidence_input_only",
+  authority_posture: "subordinate_limitation_context_only",
+  consumer: "inspection",
+  due_date: "2026-06-15",
+  evidence_references: [
+    "docs/phase-63-closeout-evaluation.md#support-bundle-gap-disposition",
+  ],
+  gate_truth: false,
+  limitation_id: "limitation-phase64-support-bundle-001",
+  mitigation: "Track the support bundle slice before Phase 66 RC proof.",
+  owner: "supportability-owner",
+  phase66_handoff_posture: "handoff_required",
+  readiness_truth: false,
+  release_truth: false,
+  review_cadence: "weekly",
+  review_due_date_expired: false,
+  review_due_date_status: "current",
+  review_state: "accepted_risk",
+  severity: "material",
+  stale_cache: false,
+  title: "Support bundle evidence remains separately tracked.",
+  affected_surface: "supportability_evidence",
+  workflow_authority: "none",
+  workflow_truth: false,
+};
+
+export function registerOperatorRoutesLimitationOwnershipTests() {
+  describe("limitation ownership route", () => {
+    it("renders reviewed limitation ownership as subordinate backend context", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-limitation-ownership": normalLimitationOwnership,
+        }),
+      });
+
+      renderOperatorRoute("/operator/limitations", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Limitation ownership" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText("Support bundle evidence remains separately tracked."),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Owner: supportability-owner")).toBeInTheDocument();
+      expect(
+        screen.getByText("Track the support bundle slice before Phase 66 RC proof."),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "docs/phase-63-closeout-evaluation.md#support-bundle-gap-disposition",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Affected surface: supportability evidence")).toBeInTheDocument();
+      expect(screen.getByText("Phase 66 handoff: handoff required")).toBeInTheDocument();
+      expect(screen.getByText("Due date: 2026-06-15")).toBeInTheDocument();
+      expect(screen.getByText("Cadence: weekly")).toBeInTheDocument();
+      expect(screen.getByText("Subordinate limitation context only")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "This surface cannot satisfy readiness, release, gate, workflow, or limitation resolution truth.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /resolve/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /approve/i })).toBeNull();
+      expect(screen.queryByText(/ready for rc/i)).toBeNull();
+    });
+
+    it("fails closed on browser or cache sourced limitation ownership truth", async () => {
+      const dependencies = createDefaultDependencies({
+        fetchFn: createAuthorizedFetch({
+          "/inspect-limitation-ownership": {
+            ...normalLimitationOwnership,
+            projection_source: "browser_cache",
+          },
+        }),
+      });
+
+      renderOperatorRoute("/operator/limitations", dependencies);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", {
+            name: "Limitation ownership unavailable",
+          }),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByText("Support bundle evidence remains separately tracked."),
+      ).toBeNull();
+      expect(
+        screen.getByText(
+          "The backend limitation ownership projection was stale, malformed, or claimed authority the browser cannot hold.",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+}

--- a/apps/operator-ui/src/app/OperatorRoutes.test.tsx
+++ b/apps/operator-ui/src/app/OperatorRoutes.test.tsx
@@ -9,6 +9,7 @@ import { registerOperatorRoutesCaseworkTests } from "./OperatorRoutes.casework.t
 import { registerOperatorRoutesControlPlaneTests } from "./OperatorRoutes.controlPlane.testSuite";
 import { registerOperatorRoutesDetectorActivationReviewTests } from "./OperatorRoutes.detectorActivationReview.testSuite";
 import { registerOperatorRoutesFirstLoginChecklistTests } from "./OperatorRoutes.firstLoginChecklist.testSuite";
+import { registerOperatorRoutesLimitationOwnershipTests } from "./OperatorRoutes.limitationOwnership.testSuite";
 import { registerOperatorRoutesRecordSearchTests } from "./OperatorRoutes.recordSearch.testSuite";
 import { registerOperatorRoutesSourceHealthDashboardTests } from "./OperatorRoutes.sourceHealthDashboard.testSuite";
 import { registerOperatorRoutesTodayTests } from "./OperatorRoutes.today.testSuite";
@@ -30,4 +31,5 @@ describe("OperatorRoutes", () => {
   registerOperatorRoutesFirstLoginChecklistTests();
   registerOperatorRoutesTodayTests();
   registerOperatorRoutesBusinessHoursHandoffTests();
+  registerOperatorRoutesLimitationOwnershipTests();
 });

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -265,7 +265,7 @@ function OperatorMenu({
       <Menu.Item
         leftIcon={<ReportProblemOutlinedIcon />}
         primaryText="Limitations"
-        to={buildOperatorShellPath(basePath, "limitations")}
+        to={buildOperatorShellPath(basePath, "limitations?view=selection")}
       />
       <Menu.Item
         leftIcon={<WarningAmberOutlinedIcon />}

--- a/apps/operator-ui/src/app/OperatorShell.tsx
+++ b/apps/operator-ui/src/app/OperatorShell.tsx
@@ -18,6 +18,7 @@ import InsightsOutlinedIcon from "@mui/icons-material/InsightsOutlined";
 import HandshakeOutlinedIcon from "@mui/icons-material/HandshakeOutlined";
 import LinkOutlinedIcon from "@mui/icons-material/LinkOutlined";
 import PlaylistAddCheckOutlinedIcon from "@mui/icons-material/PlaylistAddCheckOutlined";
+import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import RuleFolderOutlinedIcon from "@mui/icons-material/RuleFolderOutlined";
 import SearchOutlinedIcon from "@mui/icons-material/SearchOutlined";
 import SecurityOutlinedIcon from "@mui/icons-material/SecurityOutlined";
@@ -112,6 +113,8 @@ const TodayPage =
   lazyOperatorConsolePage("TodayPage") as unknown as typeof import("./operatorConsolePages").TodayPage;
 const BusinessHoursHandoffPage =
   lazyOperatorConsolePage("BusinessHoursHandoffPage") as unknown as typeof import("./operatorConsolePages").BusinessHoursHandoffPage;
+const LimitationOwnershipPage =
+  lazyOperatorConsolePage("LimitationOwnershipPage") as unknown as typeof import("./operatorConsolePages").LimitationOwnershipPage;
 const UserRoleAdminPage =
   lazyOperatorConsolePage("UserRoleAdminPage") as unknown as typeof import("./operatorConsolePages").UserRoleAdminPage;
 
@@ -258,6 +261,11 @@ function OperatorMenu({
         leftIcon={<HandshakeOutlinedIcon />}
         primaryText="Handoff"
         to={buildOperatorShellPath(basePath, "handoff")}
+      />
+      <Menu.Item
+        leftIcon={<ReportProblemOutlinedIcon />}
+        primaryText="Limitations"
+        to={buildOperatorShellPath(basePath, "limitations")}
       />
       <Menu.Item
         leftIcon={<WarningAmberOutlinedIcon />}
@@ -555,6 +563,7 @@ function OperatorShellContent({
           <Route element={<OverviewPage operatorRoles={operatorRoles} />} index />
           <Route element={<TodayPage />} path="today" />
           <Route element={<BusinessHoursHandoffPage />} path="handoff" />
+          <Route element={<LimitationOwnershipPage />} path="limitations" />
           <Route element={<QueuePage />} path="queue" />
           <Route element={<AlertIndexPage />} path="alerts" />
           <Route

--- a/apps/operator-ui/src/app/operatorConsolePages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages.tsx
@@ -1,6 +1,7 @@
 export { QueuePage } from "./operatorConsolePages/queuePages";
 export { TodayPage } from "./operatorConsolePages/todayPages";
 export { BusinessHoursHandoffPage } from "./operatorConsolePages/handoffPages";
+export { LimitationOwnershipPage } from "./operatorConsolePages/limitationOwnershipPages";
 export {
   AlertDetailPage,
   CaseDetailPage,

--- a/apps/operator-ui/src/app/operatorConsolePages/limitationOwnershipPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/limitationOwnershipPages.tsx
@@ -1,0 +1,156 @@
+import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
+import { Alert, Chip, Grid, Stack, Typography } from "@mui/material";
+import { useMemo } from "react";
+import {
+  asString,
+  asStringArray,
+  LoadingState,
+  PageFrame,
+  SectionCard,
+  formatLabel,
+  statusTone,
+  useOperatorRecord,
+} from "./shared";
+
+function lowerLabel(value: string | null) {
+  return formatLabel(value ?? "unknown").toLowerCase();
+}
+
+function LimitationOwnershipUnavailable() {
+  return (
+    <PageFrame
+      subtitle="The browser refuses stale, malformed, or authority-promoting limitation projections."
+      title="Limitation ownership unavailable"
+    >
+      <Alert severity="error" variant="outlined">
+        The backend limitation ownership projection was stale, malformed, or
+        claimed authority the browser cannot hold.
+      </Alert>
+    </PageFrame>
+  );
+}
+
+export function LimitationOwnershipPage() {
+  const meta = useMemo(() => ({}), []);
+  const { data, error, loading } = useOperatorRecord(
+    "limitationOwnership",
+    "current",
+    meta,
+  );
+  const title = asString(data?.title) ?? "Reviewed limitation";
+  const severity = asString(data?.severity);
+  const reviewState = asString(data?.review_state);
+  const owner = asString(data?.owner);
+  const mitigation = asString(data?.mitigation);
+  const affectedSurface = asString(data?.affected_surface);
+  const handoffPosture = asString(data?.phase66_handoff_posture);
+  const dueDate = asString(data?.due_date);
+  const reviewCadence = asString(data?.review_cadence);
+  const dueDateStatus = asString(data?.review_due_date_status);
+  const authorityPosture = asString(data?.authority_posture);
+  const evidenceReferences = asStringArray(data?.evidence_references);
+
+  if (loading && !data) {
+    return (
+      <PageFrame
+        subtitle="Loading the backend-reviewed limitation ownership projection."
+        title="Limitation ownership"
+      >
+        <LoadingState label="Loading limitation ownership" />
+      </PageFrame>
+    );
+  }
+
+  if (error || !data) {
+    return <LimitationOwnershipUnavailable />;
+  }
+
+  return (
+    <PageFrame
+      subtitle="Reviewed ownership context for known limitations; backend records remain authoritative."
+      title="Limitation ownership"
+    >
+      <Stack spacing={3}>
+        <Alert severity="info" variant="outlined">
+          This surface cannot satisfy readiness, release, gate, workflow, or
+          limitation resolution truth.
+        </Alert>
+        <SectionCard
+          subtitle="Owner, mitigation, evidence, review posture, and handoff posture are rendered from the backend projection."
+          title={title}
+        >
+          <Stack spacing={2}>
+            <Stack direction="row" flexWrap="wrap" gap={1}>
+              {severity ? (
+                <Chip
+                  color={statusTone(severity)}
+                  icon={<ReportProblemOutlinedIcon />}
+                  label={formatLabel(severity)}
+                  size="small"
+                  variant="filled"
+                />
+              ) : null}
+              {reviewState ? (
+                <Chip
+                  color={statusTone(reviewState)}
+                  label={formatLabel(reviewState)}
+                  size="small"
+                  variant="outlined"
+                />
+              ) : null}
+              {dueDateStatus ? (
+                <Chip
+                  color={statusTone(dueDateStatus)}
+                  label={`Review ${formatLabel(dueDateStatus)}`}
+                  size="small"
+                  variant="outlined"
+                />
+              ) : null}
+              <Chip
+                color="info"
+                label="Subordinate limitation context only"
+                size="small"
+                variant="outlined"
+              />
+            </Stack>
+            <Grid container spacing={2}>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <Stack spacing={1}>
+                  <Typography variant="body2">Owner: {owner}</Typography>
+                  <Typography color="text.secondary" variant="body2">
+                    Affected surface: {lowerLabel(affectedSurface)}
+                  </Typography>
+                  <Typography color="text.secondary" variant="body2">
+                    Phase 66 handoff: {lowerLabel(handoffPosture)}
+                  </Typography>
+                  <Typography color="text.secondary" variant="body2">
+                    Due date: {dueDate ?? "Not specified"}
+                  </Typography>
+                  <Typography color="text.secondary" variant="body2">
+                    Cadence: {reviewCadence ?? "Not specified"}
+                  </Typography>
+                </Stack>
+              </Grid>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <Stack spacing={1}>
+                  <Typography variant="body2">{mitigation}</Typography>
+                  <Typography color="text.secondary" variant="caption">
+                    Authority posture: {formatLabel(authorityPosture ?? "unknown")}
+                  </Typography>
+                </Stack>
+              </Grid>
+            </Grid>
+            <Stack spacing={0.75}>
+              <Typography variant="caption">Evidence references</Typography>
+              {evidenceReferences.map((reference) => (
+                <Typography color="text.secondary" key={reference} variant="body2">
+                  {reference}
+                </Typography>
+              ))}
+            </Stack>
+          </Stack>
+        </SectionCard>
+      </Stack>
+    </PageFrame>
+  );
+}

--- a/apps/operator-ui/src/app/operatorConsolePages/limitationOwnershipPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/limitationOwnershipPages.tsx
@@ -121,7 +121,7 @@ function LimitationOwnershipSelectionPage() {
     "limitationOwnership",
     filter,
     LIMITATION_OWNERSHIP_LIST_SORT,
-    25,
+    null,
   );
 
   if (results.loading && results.data === null) {
@@ -172,6 +172,7 @@ function LimitationOwnershipDetailPage({ limitationId }: { limitationId: string 
   const owner = asString(data?.owner);
   const mitigation = asString(data?.mitigation);
   const affectedSurface = asString(data?.affected_surface);
+  const acceptedRiskPosture = asString(data?.accepted_risk_posture);
   const handoffPosture = asString(data?.phase66_handoff_posture);
   const dueDate = asString(data?.due_date);
   const reviewCadence = asString(data?.review_cadence);
@@ -252,6 +253,12 @@ function LimitationOwnershipDetailPage({ limitationId }: { limitationId: string 
                   <Typography color="text.secondary" variant="body2">
                     Phase 66 handoff: {lowerLabel(handoffPosture)}
                   </Typography>
+                  {reviewState === "accepted_risk" ? (
+                    <Typography color="text.secondary" variant="body2">
+                      Accepted risk posture:{" "}
+                      {formatLabel(acceptedRiskPosture ?? "unknown")}
+                    </Typography>
+                  ) : null}
                   <Typography color="text.secondary" variant="body2">
                     Due date: {dueDate ?? "Not specified"}
                   </Typography>

--- a/apps/operator-ui/src/app/operatorConsolePages/limitationOwnershipPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/limitationOwnershipPages.tsx
@@ -1,17 +1,39 @@
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
-import { Alert, Chip, Grid, Stack, Typography } from "@mui/material";
+import {
+  Alert,
+  Chip,
+  Grid,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
 import { useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   asString,
   asStringArray,
+  AuditedRouteLink,
+  EmptyState,
+  ErrorState,
   LoadingState,
   PageFrame,
+  QueryStateNotice,
   SectionCard,
   formatLabel,
   statusTone,
+  useOperatorList,
   useOperatorRecord,
+  type UnknownRecord,
 } from "./shared";
+
+const LIMITATION_OWNERSHIP_LIST_SORT = {
+  field: "limitation_id",
+  order: "ASC",
+} as const;
 
 function lowerLabel(value: string | null) {
   return formatLabel(value ?? "unknown").toLowerCase();
@@ -32,13 +54,116 @@ function LimitationOwnershipUnavailable() {
 }
 
 export function LimitationOwnershipPage() {
-  const meta = useMemo(() => ({}), []);
   const [searchParams] = useSearchParams();
-  const requestedLimitationId =
-    searchParams.get("limitation_id")?.trim() || "current";
+  const requestedLimitationId = searchParams.get("limitation_id")?.trim();
+
+  if (!requestedLimitationId) {
+    return <LimitationOwnershipSelectionPage />;
+  }
+
+  return <LimitationOwnershipDetailPage limitationId={requestedLimitationId} />;
+}
+
+function limitationOwnershipRoute(recordId: string) {
+  const params = new URLSearchParams({ limitation_id: recordId });
+
+  return `/operator/limitations?${params.toString()}`;
+}
+
+function LimitationOwnershipSelectionTable({ records }: { records: UnknownRecord[] }) {
+  if (records.length === 0) {
+    return <EmptyState message="No reviewed limitation ownership records are available." />;
+  }
+
+  return (
+    <Table size="small">
+      <TableHead>
+        <TableRow>
+          <TableCell>Limitation</TableCell>
+          <TableCell>Owner</TableCell>
+          <TableCell>Severity</TableCell>
+          <TableCell>Review</TableCell>
+          <TableCell>Handoff</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {records.map((record) => {
+          const limitationId = asString(record.limitation_id) ?? String(record.id);
+          const title = asString(record.title) ?? limitationId;
+
+          return (
+            <TableRow hover key={limitationId}>
+              <TableCell>
+                <AuditedRouteLink
+                  label="Open reviewed limitation ownership"
+                  to={limitationOwnershipRoute(limitationId)}
+                >
+                  {title}
+                </AuditedRouteLink>
+              </TableCell>
+              <TableCell>{asString(record.owner)}</TableCell>
+              <TableCell>{formatLabel(asString(record.severity) ?? "unknown")}</TableCell>
+              <TableCell>{formatLabel(asString(record.review_state) ?? "unknown")}</TableCell>
+              <TableCell>
+                {formatLabel(asString(record.phase66_handoff_posture) ?? "unknown")}
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+function LimitationOwnershipSelectionPage() {
+  const filter = useMemo(() => ({}), []);
+  const results = useOperatorList(
+    "limitationOwnership",
+    filter,
+    LIMITATION_OWNERSHIP_LIST_SORT,
+    25,
+  );
+
+  if (results.loading && results.data === null) {
+    return (
+      <PageFrame
+        subtitle="Loading backend-reviewed limitation ownership records before detail inspection."
+        title="Limitation ownership"
+      >
+        <LoadingState label="Loading limitation ownership records" />
+      </PageFrame>
+    );
+  }
+
+  return (
+    <PageFrame
+      subtitle="Choose a reviewed limitation record before loading the backend projection; detail inspection requires an explicit limitation id."
+      title="Limitation ownership"
+    >
+      {results.error && results.data === null ? (
+        <ErrorState error={results.error} />
+      ) : (
+        <Stack spacing={2}>
+          <Alert severity="info" variant="outlined">
+            Limitation ownership detail remains subordinate backend context and
+            requires a concrete reviewed limitation id.
+          </Alert>
+          <QueryStateNotice
+            error={results.error}
+            refreshing={results.refreshing}
+          />
+          <LimitationOwnershipSelectionTable records={results.data ?? []} />
+        </Stack>
+      )}
+    </PageFrame>
+  );
+}
+
+function LimitationOwnershipDetailPage({ limitationId }: { limitationId: string }) {
+  const meta = useMemo(() => ({}), []);
   const { data, error, loading } = useOperatorRecord(
     "limitationOwnership",
-    requestedLimitationId,
+    limitationId,
     meta,
   );
   const title = asString(data?.title) ?? "Reviewed limitation";

--- a/apps/operator-ui/src/app/operatorConsolePages/limitationOwnershipPages.tsx
+++ b/apps/operator-ui/src/app/operatorConsolePages/limitationOwnershipPages.tsx
@@ -1,6 +1,7 @@
 import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import { Alert, Chip, Grid, Stack, Typography } from "@mui/material";
 import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 import {
   asString,
   asStringArray,
@@ -32,9 +33,12 @@ function LimitationOwnershipUnavailable() {
 
 export function LimitationOwnershipPage() {
   const meta = useMemo(() => ({}), []);
+  const [searchParams] = useSearchParams();
+  const requestedLimitationId =
+    searchParams.get("limitation_id")?.trim() || "current";
   const { data, error, loading } = useOperatorRecord(
     "limitationOwnership",
-    "current",
+    requestedLimitationId,
     meta,
   );
   const title = asString(data?.title) ?? "Reviewed limitation";

--- a/apps/operator-ui/src/dataProvider.test.ts
+++ b/apps/operator-ui/src/dataProvider.test.ts
@@ -459,6 +459,52 @@ describe("createOperatorDataProvider", () => {
     );
   });
 
+  it("passes requested limitation ownership ids to the backend projection endpoint", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        authority_posture: "subordinate_limitation_context_only",
+        due_date: "2026-06-15",
+        evidence_references: ["docs/phase-63-closeout-evaluation.md"],
+        gate_truth: false,
+        limitation_id: "limitation-phase64-support-bundle-001",
+        mitigation: "Track the support bundle slice before Phase 66 RC proof.",
+        owner: "supportability-owner",
+        phase66_handoff_posture: "handoff_required",
+        readiness_truth: false,
+        release_truth: false,
+        review_due_date_status: "current",
+        review_state: "accepted_risk",
+        severity: "material",
+        title: "Support bundle evidence remains separately tracked.",
+        affected_surface: "supportability_evidence",
+        workflow_authority: "none",
+        workflow_truth: false,
+      }),
+    );
+    const dataProvider = createOperatorDataProvider({ fetchFn });
+
+    await expect(
+      dataProvider.getOne("limitationOwnership", {
+        id: "limitation-phase64-support-bundle-001",
+      }),
+    ).resolves.toEqual({
+      data: expect.objectContaining({
+        id: "limitation-phase64-support-bundle-001",
+        limitation_id: "limitation-phase64-support-bundle-001",
+      }),
+    });
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "/inspect-limitation-ownership?limitation_id=limitation-phase64-support-bundle-001",
+      {
+        credentials: "include",
+        headers: {
+          Accept: "application/json",
+        },
+      },
+    );
+  });
+
   it("rejects action-review detail payloads whose selected review is missing or mismatched", async () => {
     const missingSelectedReviewId = createOperatorDataProvider({
       fetchFn: vi.fn<typeof fetch>().mockResolvedValue(

--- a/apps/operator-ui/src/dataProvider.test.ts
+++ b/apps/operator-ui/src/dataProvider.test.ts
@@ -630,7 +630,7 @@ describe("createOperatorDataProvider", () => {
     );
   });
 
-  it("requires accepted-risk limitation ownership detail to include reviewed risk posture", async () => {
+  it("requires every limitation ownership detail to include reviewed risk posture", async () => {
     const dataProvider = createOperatorDataProvider({
       fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
         jsonResponse({
@@ -646,7 +646,7 @@ describe("createOperatorDataProvider", () => {
           readiness_truth: false,
           release_truth: false,
           review_due_date_status: "current",
-          review_state: "accepted_risk",
+          review_state: "under_review",
           severity: "material",
           title: "Support bundle evidence remains separately tracked.",
           affected_surface: "supportability_evidence",
@@ -661,7 +661,7 @@ describe("createOperatorDataProvider", () => {
         id: "limitation-phase64-support-bundle-001",
       }),
     ).rejects.toThrow(
-      "Resource limitationOwnership accepted-risk detail requires accepted_risk_posture.",
+      "Resource limitationOwnership detail payload is missing reviewed ownership fields.",
     );
   });
 
@@ -675,6 +675,7 @@ describe("createOperatorDataProvider", () => {
             due_date: "2026-06-15",
             evidence_references: ["docs/phase-63-closeout-evaluation.md"],
             limitation_id: "limitation-phase64-support-bundle-001",
+            lifecycle_state: "accepted_risk",
             mitigation: "Track the support bundle slice before Phase 66 RC proof.",
             owner: "supportability-owner",
             phase66_handoff_posture: "handoff_required",
@@ -714,6 +715,83 @@ describe("createOperatorDataProvider", () => {
           Accept: "application/json",
         },
       },
+    );
+  });
+
+  it("rejects malformed cache markers in limitation ownership list records", async () => {
+    const dataProvider = createOperatorDataProvider({
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
+        jsonResponse({
+          records: [
+            {
+              affected_surface: "supportability_evidence",
+              authority_boundary: "reviewed_evidence_input_only",
+              cache_sourced: "true",
+              due_date: "2026-06-15",
+              evidence_references: ["docs/phase-63-closeout-evaluation.md"],
+              limitation_id: "limitation-phase64-support-bundle-001",
+              lifecycle_state: "accepted_risk",
+              mitigation: "Track the support bundle slice before Phase 66 RC proof.",
+              owner: "supportability-owner",
+              phase66_handoff_posture: "handoff_required",
+              readiness_claim: null,
+              review_cadence: "weekly",
+              review_state: "accepted_risk",
+              severity: "material",
+              title: "Support bundle evidence remains separately tracked.",
+            },
+          ],
+          total_records: 1,
+        }),
+      ),
+    });
+
+    await expect(
+      dataProvider.getList("limitationOwnership", {
+        filter: {},
+        pagination: { page: 1, perPage: 25 },
+        sort: { field: "limitation_id", order: "ASC" },
+      }),
+    ).rejects.toThrow(
+      "Resource limitationOwnership list record rejects stale-cache limitation truth.",
+    );
+  });
+
+  it("rejects lifecycle drift in limitation ownership list records", async () => {
+    const dataProvider = createOperatorDataProvider({
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
+        jsonResponse({
+          records: [
+            {
+              affected_surface: "supportability_evidence",
+              authority_boundary: "reviewed_evidence_input_only",
+              due_date: "2026-06-15",
+              evidence_references: ["docs/phase-63-closeout-evaluation.md"],
+              limitation_id: "limitation-phase64-support-bundle-001",
+              lifecycle_state: "under_review",
+              mitigation: "Track the support bundle slice before Phase 66 RC proof.",
+              owner: "supportability-owner",
+              phase66_handoff_posture: "handoff_required",
+              readiness_claim: null,
+              review_cadence: "weekly",
+              review_state: "accepted_risk",
+              severity: "material",
+              title: "Support bundle evidence remains separately tracked.",
+            },
+          ],
+          total_records: 1,
+        }),
+      ),
+    });
+
+    await expect(
+      dataProvider.getList("limitationOwnership", {
+        filter: {},
+        pagination: { page: 1, perPage: 25 },
+        sort: { field: "limitation_id", order: "ASC" },
+      }),
+    ).rejects.toThrow(
+      "Resource limitationOwnership list record requires lifecycle_state to match review_state.",
     );
   });
 

--- a/apps/operator-ui/src/dataProvider.test.ts
+++ b/apps/operator-ui/src/dataProvider.test.ts
@@ -463,6 +463,7 @@ describe("createOperatorDataProvider", () => {
     const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
       jsonResponse({
         authority_posture: "subordinate_limitation_context_only",
+        authority_boundary: "reviewed_evidence_input_only",
         due_date: "2026-06-15",
         evidence_references: ["docs/phase-63-closeout-evaluation.md"],
         gate_truth: false,
@@ -502,6 +503,90 @@ describe("createOperatorDataProvider", () => {
           Accept: "application/json",
         },
       },
+    );
+  });
+
+  it("requires a concrete limitation ownership id before detail inspection", async () => {
+    const fetchFn = vi.fn<typeof fetch>();
+    const dataProvider = createOperatorDataProvider({ fetchFn });
+
+    await expect(
+      dataProvider.getOne("limitationOwnership", {
+        id: "current",
+      }),
+    ).rejects.toThrow(
+      "Resource limitationOwnership getOne requires a non-empty limitation identifier.",
+    );
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("rejects limitation ownership detail payloads whose id does not match the request", async () => {
+    const dataProvider = createOperatorDataProvider({
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
+        jsonResponse({
+          authority_posture: "subordinate_limitation_context_only",
+          authority_boundary: "reviewed_evidence_input_only",
+          due_date: "2026-06-15",
+          evidence_references: ["docs/phase-63-closeout-evaluation.md"],
+          gate_truth: false,
+          limitation_id: "limitation-phase64-support-bundle-999",
+          mitigation: "Track the support bundle slice before Phase 66 RC proof.",
+          owner: "supportability-owner",
+          phase66_handoff_posture: "handoff_required",
+          readiness_truth: false,
+          release_truth: false,
+          review_due_date_status: "current",
+          review_state: "accepted_risk",
+          severity: "material",
+          title: "Support bundle evidence remains separately tracked.",
+          affected_surface: "supportability_evidence",
+          workflow_authority: "none",
+          workflow_truth: false,
+        }),
+      ),
+    });
+
+    await expect(
+      dataProvider.getOne("limitationOwnership", {
+        id: "limitation-phase64-support-bundle-001",
+      }),
+    ).rejects.toThrow(
+      "Resource limitationOwnership requires limitation_id to match limitation-phase64-support-bundle-001.",
+    );
+  });
+
+  it("rejects limitation ownership detail payloads with authority boundary drift", async () => {
+    const dataProvider = createOperatorDataProvider({
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
+        jsonResponse({
+          authority_posture: "subordinate_limitation_context_only",
+          authority_boundary: "workflow_authority",
+          due_date: "2026-06-15",
+          evidence_references: ["docs/phase-63-closeout-evaluation.md"],
+          gate_truth: false,
+          limitation_id: "limitation-phase64-support-bundle-001",
+          mitigation: "Track the support bundle slice before Phase 66 RC proof.",
+          owner: "supportability-owner",
+          phase66_handoff_posture: "handoff_required",
+          readiness_truth: false,
+          release_truth: false,
+          review_due_date_status: "current",
+          review_state: "accepted_risk",
+          severity: "material",
+          title: "Support bundle evidence remains separately tracked.",
+          affected_surface: "supportability_evidence",
+          workflow_authority: "none",
+          workflow_truth: false,
+        }),
+      ),
+    });
+
+    await expect(
+      dataProvider.getOne("limitationOwnership", {
+        id: "limitation-phase64-support-bundle-001",
+      }),
+    ).rejects.toThrow(
+      "Resource limitationOwnership must remain subordinate and cannot claim readiness, release, gate, or workflow truth.",
     );
   });
 

--- a/apps/operator-ui/src/dataProvider.test.ts
+++ b/apps/operator-ui/src/dataProvider.test.ts
@@ -505,6 +505,58 @@ describe("createOperatorDataProvider", () => {
     );
   });
 
+  it("lists reviewed limitation ownership records before detail inspection", async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        records: [
+          {
+            affected_surface: "supportability_evidence",
+            authority_boundary: "reviewed_evidence_input_only",
+            due_date: "2026-06-15",
+            evidence_references: ["docs/phase-63-closeout-evaluation.md"],
+            limitation_id: "limitation-phase64-support-bundle-001",
+            mitigation: "Track the support bundle slice before Phase 66 RC proof.",
+            owner: "supportability-owner",
+            phase66_handoff_posture: "handoff_required",
+            readiness_claim: null,
+            review_cadence: "weekly",
+            review_state: "accepted_risk",
+            severity: "material",
+            title: "Support bundle evidence remains separately tracked.",
+          },
+        ],
+        total_records: 1,
+      }),
+    );
+    const dataProvider = createOperatorDataProvider({ fetchFn });
+
+    await expect(
+      dataProvider.getList("limitationOwnership", {
+        filter: {},
+        pagination: { page: 1, perPage: 25 },
+        sort: { field: "limitation_id", order: "ASC" },
+      }),
+    ).resolves.toEqual({
+      data: [
+        expect.objectContaining({
+          id: "limitation-phase64-support-bundle-001",
+          limitation_id: "limitation-phase64-support-bundle-001",
+        }),
+      ],
+      total: 1,
+    });
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "/inspect-records?family=known_limitation_ownership&order=ASC&page=1&per_page=25&sort=limitation_id",
+      {
+        credentials: "include",
+        headers: {
+          Accept: "application/json",
+        },
+      },
+    );
+  });
+
   it("rejects action-review detail payloads whose selected review is missing or mismatched", async () => {
     const missingSelectedReviewId = createOperatorDataProvider({
       fetchFn: vi.fn<typeof fetch>().mockResolvedValue(

--- a/apps/operator-ui/src/dataProvider.test.ts
+++ b/apps/operator-ui/src/dataProvider.test.ts
@@ -464,6 +464,7 @@ describe("createOperatorDataProvider", () => {
       jsonResponse({
         authority_posture: "subordinate_limitation_context_only",
         authority_boundary: "reviewed_evidence_input_only",
+        accepted_risk_posture: "bounded_pre_rc_limitation",
         due_date: "2026-06-15",
         evidence_references: ["docs/phase-63-closeout-evaluation.md"],
         gate_truth: false,
@@ -526,6 +527,7 @@ describe("createOperatorDataProvider", () => {
         jsonResponse({
           authority_posture: "subordinate_limitation_context_only",
           authority_boundary: "reviewed_evidence_input_only",
+          accepted_risk_posture: "bounded_pre_rc_limitation",
           due_date: "2026-06-15",
           evidence_references: ["docs/phase-63-closeout-evaluation.md"],
           gate_truth: false,
@@ -561,6 +563,7 @@ describe("createOperatorDataProvider", () => {
         jsonResponse({
           authority_posture: "subordinate_limitation_context_only",
           authority_boundary: "workflow_authority",
+          accepted_risk_posture: "bounded_pre_rc_limitation",
           due_date: "2026-06-15",
           evidence_references: ["docs/phase-63-closeout-evaluation.md"],
           gate_truth: false,
@@ -587,6 +590,41 @@ describe("createOperatorDataProvider", () => {
       }),
     ).rejects.toThrow(
       "Resource limitationOwnership must remain subordinate and cannot claim readiness, release, gate, or workflow truth.",
+    );
+  });
+
+  it("requires accepted-risk limitation ownership detail to include reviewed risk posture", async () => {
+    const dataProvider = createOperatorDataProvider({
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
+        jsonResponse({
+          authority_posture: "subordinate_limitation_context_only",
+          authority_boundary: "reviewed_evidence_input_only",
+          due_date: "2026-06-15",
+          evidence_references: ["docs/phase-63-closeout-evaluation.md"],
+          gate_truth: false,
+          limitation_id: "limitation-phase64-support-bundle-001",
+          mitigation: "Track the support bundle slice before Phase 66 RC proof.",
+          owner: "supportability-owner",
+          phase66_handoff_posture: "handoff_required",
+          readiness_truth: false,
+          release_truth: false,
+          review_due_date_status: "current",
+          review_state: "accepted_risk",
+          severity: "material",
+          title: "Support bundle evidence remains separately tracked.",
+          affected_surface: "supportability_evidence",
+          workflow_authority: "none",
+          workflow_truth: false,
+        }),
+      ),
+    });
+
+    await expect(
+      dataProvider.getOne("limitationOwnership", {
+        id: "limitation-phase64-support-bundle-001",
+      }),
+    ).rejects.toThrow(
+      "Resource limitationOwnership accepted-risk detail requires accepted_risk_posture.",
     );
   });
 

--- a/apps/operator-ui/src/dataProvider.test.ts
+++ b/apps/operator-ui/src/dataProvider.test.ts
@@ -593,6 +593,43 @@ describe("createOperatorDataProvider", () => {
     );
   });
 
+  it("rejects limitation ownership detail payloads with malformed cache markers", async () => {
+    const dataProvider = createOperatorDataProvider({
+      fetchFn: vi.fn<typeof fetch>().mockResolvedValue(
+        jsonResponse({
+          authority_posture: "subordinate_limitation_context_only",
+          authority_boundary: "reviewed_evidence_input_only",
+          cache_sourced: "true",
+          accepted_risk_posture: "bounded_pre_rc_limitation",
+          due_date: "2026-06-15",
+          evidence_references: ["docs/phase-63-closeout-evaluation.md"],
+          gate_truth: false,
+          limitation_id: "limitation-phase64-support-bundle-001",
+          mitigation: "Track the support bundle slice before Phase 66 RC proof.",
+          owner: "supportability-owner",
+          phase66_handoff_posture: "handoff_required",
+          readiness_truth: false,
+          release_truth: false,
+          review_due_date_status: "current",
+          review_state: "accepted_risk",
+          severity: "material",
+          title: "Support bundle evidence remains separately tracked.",
+          affected_surface: "supportability_evidence",
+          workflow_authority: "none",
+          workflow_truth: false,
+        }),
+      ),
+    });
+
+    await expect(
+      dataProvider.getOne("limitationOwnership", {
+        id: "limitation-phase64-support-bundle-001",
+      }),
+    ).rejects.toThrow(
+      "Resource limitationOwnership rejects browser or cache sourced limitation truth.",
+    );
+  });
+
   it("requires accepted-risk limitation ownership detail to include reviewed risk posture", async () => {
     const dataProvider = createOperatorDataProvider({
       fetchFn: vi.fn<typeof fetch>().mockResolvedValue(

--- a/apps/operator-ui/src/dataProvider.ts
+++ b/apps/operator-ui/src/dataProvider.ts
@@ -74,7 +74,7 @@ export function createOperatorDataProvider({
       }
 
       if (resource === "limitationOwnership") {
-        return getOneForLimitationOwnership(fetchFn);
+        return getOneForLimitationOwnership(fetchFn, params);
       }
 
       if (!isStandardResource(resource)) {

--- a/apps/operator-ui/src/dataProvider.ts
+++ b/apps/operator-ui/src/dataProvider.ts
@@ -36,8 +36,7 @@ export function createOperatorDataProvider({
     getList(resource, params) {
       if (
         resource === "advisoryOutput" ||
-        resource === "actionReview" ||
-        resource === "limitationOwnership"
+        resource === "actionReview"
       ) {
         return rejectUnsupported("getList", resource);
       }

--- a/apps/operator-ui/src/dataProvider.ts
+++ b/apps/operator-ui/src/dataProvider.ts
@@ -3,6 +3,7 @@ import {
   getOneForActionReview,
   getOneForAdvisoryOutput,
   getOneForBusinessHoursHandoff,
+  getOneForLimitationOwnership,
   getOneForStandardResource,
   getOneForTodayView,
 } from "./operatorDataProvider/detailReaders";
@@ -33,7 +34,11 @@ export function createOperatorDataProvider({
     delete: (_resource) => rejectUnsupported("delete", _resource),
     deleteMany: (_resource) => rejectUnsupported("deleteMany", _resource),
     getList(resource, params) {
-      if (resource === "advisoryOutput" || resource === "actionReview") {
+      if (
+        resource === "advisoryOutput" ||
+        resource === "actionReview" ||
+        resource === "limitationOwnership"
+      ) {
         return rejectUnsupported("getList", resource);
       }
 
@@ -66,6 +71,10 @@ export function createOperatorDataProvider({
 
       if (resource === "businessHoursHandoff") {
         return getOneForBusinessHoursHandoff(fetchFn);
+      }
+
+      if (resource === "limitationOwnership") {
+        return getOneForLimitationOwnership(fetchFn);
       }
 
       if (!isStandardResource(resource)) {

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -682,7 +682,8 @@ export async function getOneForLimitationOwnership(
     reviewDueDateStatus === null ||
     authorityPosture === null ||
     workflowAuthority === null ||
-    evidenceReferences === null
+    evidenceReferences === null ||
+    (reviewCadence === null && dueDate === null)
   ) {
     throw new OperatorDataProviderContractError(
       "Resource limitationOwnership detail payload is missing reviewed ownership fields.",
@@ -706,11 +707,6 @@ export async function getOneForLimitationOwnership(
   if (!LIMITATION_OWNERSHIP_DUE_DATE_STATUSES.has(reviewDueDateStatus)) {
     throw new OperatorDataProviderContractError(
       "Resource limitationOwnership has unsupported review_due_date_status.",
-    );
-  }
-  if (reviewCadence === null && dueDate === null) {
-    throw new OperatorDataProviderContractError(
-      "Resource limitationOwnership requires review_cadence or due_date.",
     );
   }
   if (evidenceReferences.length === 0) {

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -644,9 +644,12 @@ export async function getOneForLimitationOwnership(
     "/inspect-limitation-ownership",
     "http://operator-ui.local",
   );
-  if (requestedId && requestedId !== "current") {
-    url.searchParams.set("limitation_id", requestedId);
+  if (!requestedId || requestedId === "current") {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership getOne requires a non-empty limitation identifier.",
+    );
   }
+  url.searchParams.set("limitation_id", requestedId);
 
   const payload = asObject(
     await fetchJson(fetchFn, `${url.pathname}${url.search}`),
@@ -661,6 +664,7 @@ export async function getOneForLimitationOwnership(
   const reviewState = asString(payload.review_state);
   const phase66HandoffPosture = asString(payload.phase66_handoff_posture);
   const reviewDueDateStatus = asString(payload.review_due_date_status);
+  const authorityBoundary = asString(payload.authority_boundary);
   const authorityPosture = asString(payload.authority_posture);
   const workflowAuthority = asString(payload.workflow_authority);
   const projectionSource = asString(payload.projection_source);
@@ -680,6 +684,7 @@ export async function getOneForLimitationOwnership(
     reviewState === null ||
     phase66HandoffPosture === null ||
     reviewDueDateStatus === null ||
+    authorityBoundary === null ||
     authorityPosture === null ||
     workflowAuthority === null ||
     evidenceReferences === null ||
@@ -687,6 +692,11 @@ export async function getOneForLimitationOwnership(
   ) {
     throw new OperatorDataProviderContractError(
       "Resource limitationOwnership detail payload is missing reviewed ownership fields.",
+    );
+  }
+  if (limitationId !== requestedId) {
+    throw new OperatorDataProviderContractError(
+      `Resource limitationOwnership requires limitation_id to match ${requestedId}.`,
     );
   }
   if (!LIMITATION_OWNERSHIP_SEVERITIES.has(severity)) {
@@ -731,6 +741,7 @@ export async function getOneForLimitationOwnership(
     );
   }
   if (
+    authorityBoundary !== "reviewed_evidence_input_only" ||
     authorityPosture !== "subordinate_limitation_context_only" ||
     payload.readiness_truth !== false ||
     payload.release_truth !== false ||

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -683,6 +683,7 @@ export async function getOneForLimitationOwnership(
     owner === null ||
     mitigation === null ||
     reviewState === null ||
+    acceptedRiskPosture === null ||
     phase66HandoffPosture === null ||
     reviewDueDateStatus === null ||
     authorityBoundary === null ||
@@ -708,11 +709,6 @@ export async function getOneForLimitationOwnership(
   if (!LIMITATION_OWNERSHIP_REVIEW_STATES.has(reviewState)) {
     throw new OperatorDataProviderContractError(
       "Resource limitationOwnership has unsupported review_state.",
-    );
-  }
-  if (reviewState === "accepted_risk" && acceptedRiskPosture === null) {
-    throw new OperatorDataProviderContractError(
-      "Resource limitationOwnership accepted-risk detail requires accepted_risk_posture.",
     );
   }
   if (!LIMITATION_OWNERSHIP_HANDOFF_POSTURES.has(phase66HandoffPosture)) {

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -62,6 +62,37 @@ const BUSINESS_HOURS_HANDOFF_AI_POSTURES = new Set([
   "rejected_for_reference",
 ]);
 
+const LIMITATION_OWNERSHIP_REVIEW_STATES = new Set([
+  "identified",
+  "under_review",
+  "accepted_risk",
+  "mitigation_planned",
+  "mitigation_in_progress",
+  "closed",
+]);
+
+const LIMITATION_OWNERSHIP_SEVERITIES = new Set([
+  "low",
+  "medium",
+  "material",
+  "high",
+  "blocking",
+]);
+
+const LIMITATION_OWNERSHIP_HANDOFF_POSTURES = new Set([
+  "not_ready_for_handoff",
+  "handoff_required",
+  "handoff_ready_as_subordinate_evidence",
+  "blocked_until_mitigated",
+]);
+
+const LIMITATION_OWNERSHIP_DUE_DATE_STATUSES = new Set([
+  "not_specified",
+  "expired",
+  "due_today",
+  "current",
+]);
+
 export async function getOneForStandardResource(
   fetchFn: typeof fetch,
   resource: StandardOperatorResourceName,
@@ -597,6 +628,109 @@ export async function getOneForBusinessHoursHandoff(
       ...payload,
       id: "current",
       items: items.map(validateBusinessHoursHandoffItem),
+    },
+  };
+}
+
+export async function getOneForLimitationOwnership(
+  fetchFn: typeof fetch,
+): Promise<GetOneResult> {
+  const payload = asObject(
+    await fetchJson(fetchFn, "/inspect-limitation-ownership"),
+    "Resource limitationOwnership returned a malformed detail payload.",
+  );
+  const limitationId = asString(payload.limitation_id);
+  const title = asString(payload.title);
+  const severity = asString(payload.severity);
+  const affectedSurface = asString(payload.affected_surface);
+  const owner = asString(payload.owner);
+  const mitigation = asString(payload.mitigation);
+  const reviewState = asString(payload.review_state);
+  const phase66HandoffPosture = asString(payload.phase66_handoff_posture);
+  const reviewDueDateStatus = asString(payload.review_due_date_status);
+  const authorityPosture = asString(payload.authority_posture);
+  const workflowAuthority = asString(payload.workflow_authority);
+  const projectionSource = asString(payload.projection_source);
+  const evidenceReferences = Array.isArray(payload.evidence_references)
+    ? payload.evidence_references
+    : null;
+
+  if (
+    limitationId === null ||
+    title === null ||
+    severity === null ||
+    affectedSurface === null ||
+    owner === null ||
+    mitigation === null ||
+    reviewState === null ||
+    phase66HandoffPosture === null ||
+    reviewDueDateStatus === null ||
+    authorityPosture === null ||
+    workflowAuthority === null ||
+    evidenceReferences === null
+  ) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership detail payload is missing reviewed ownership fields.",
+    );
+  }
+  if (!LIMITATION_OWNERSHIP_SEVERITIES.has(severity)) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership has unsupported severity.",
+    );
+  }
+  if (!LIMITATION_OWNERSHIP_REVIEW_STATES.has(reviewState)) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership has unsupported review_state.",
+    );
+  }
+  if (!LIMITATION_OWNERSHIP_HANDOFF_POSTURES.has(phase66HandoffPosture)) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership has unsupported phase66_handoff_posture.",
+    );
+  }
+  if (!LIMITATION_OWNERSHIP_DUE_DATE_STATUSES.has(reviewDueDateStatus)) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership has unsupported review_due_date_status.",
+    );
+  }
+  if (evidenceReferences.length === 0) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership requires explicit evidence references.",
+    );
+  }
+  evidenceReferences.forEach((reference) => {
+    if (asString(reference) === null) {
+      throw new OperatorDataProviderContractError(
+        "Resource limitationOwnership has a malformed evidence reference.",
+      );
+    }
+  });
+  if (
+    payload.stale_cache !== false ||
+    ["browser_cache", "ui_cache", "cache"].includes(projectionSource ?? "")
+  ) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership rejects browser or cache sourced limitation truth.",
+    );
+  }
+  if (
+    authorityPosture !== "subordinate_limitation_context_only" ||
+    payload.readiness_truth !== false ||
+    payload.release_truth !== false ||
+    payload.gate_truth !== false ||
+    payload.workflow_truth !== false ||
+    workflowAuthority !== "none"
+  ) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership must remain subordinate and cannot claim readiness, release, gate, or workflow truth.",
+    );
+  }
+
+  return {
+    data: {
+      ...payload,
+      id: limitationId,
+      evidence_references: evidenceReferences,
     },
   };
 }

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -651,6 +651,8 @@ export async function getOneForLimitationOwnership(
   const authorityPosture = asString(payload.authority_posture);
   const workflowAuthority = asString(payload.workflow_authority);
   const projectionSource = asString(payload.projection_source);
+  const reviewCadence = asString(payload.review_cadence);
+  const dueDate = asString(payload.due_date);
   const evidenceReferences = Array.isArray(payload.evidence_references)
     ? payload.evidence_references
     : null;
@@ -693,6 +695,11 @@ export async function getOneForLimitationOwnership(
       "Resource limitationOwnership has unsupported review_due_date_status.",
     );
   }
+  if (reviewCadence === null && dueDate === null) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership requires review_cadence or due_date.",
+    );
+  }
   if (evidenceReferences.length === 0) {
     throw new OperatorDataProviderContractError(
       "Resource limitationOwnership requires explicit evidence references.",
@@ -706,7 +713,8 @@ export async function getOneForLimitationOwnership(
     }
   });
   if (
-    payload.stale_cache !== false ||
+    (payload.stale_cache !== undefined && payload.stale_cache !== false) ||
+    payload.cache_sourced === true ||
     ["browser_cache", "ui_cache", "cache"].includes(projectionSource ?? "")
   ) {
     throw new OperatorDataProviderContractError(

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -739,7 +739,7 @@ export async function getOneForLimitationOwnership(
   });
   if (
     (payload.stale_cache !== undefined && payload.stale_cache !== false) ||
-    payload.cache_sourced === true ||
+    (payload.cache_sourced !== undefined && payload.cache_sourced !== false) ||
     ["browser_cache", "ui_cache", "cache"].includes(projectionSource ?? "")
   ) {
     throw new OperatorDataProviderContractError(

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -634,9 +634,22 @@ export async function getOneForBusinessHoursHandoff(
 
 export async function getOneForLimitationOwnership(
   fetchFn: typeof fetch,
+  params: GetOneParams,
 ): Promise<GetOneResult> {
+  const requestedId =
+    typeof params.id === "string" || typeof params.id === "number"
+      ? String(params.id).trim()
+      : "";
+  const url = new URL(
+    "/inspect-limitation-ownership",
+    "http://operator-ui.local",
+  );
+  if (requestedId && requestedId !== "current") {
+    url.searchParams.set("limitation_id", requestedId);
+  }
+
   const payload = asObject(
-    await fetchJson(fetchFn, "/inspect-limitation-ownership"),
+    await fetchJson(fetchFn, `${url.pathname}${url.search}`),
     "Resource limitationOwnership returned a malformed detail payload.",
   );
   const limitationId = asString(payload.limitation_id);

--- a/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
+++ b/apps/operator-ui/src/operatorDataProvider/detailReaders.ts
@@ -662,6 +662,7 @@ export async function getOneForLimitationOwnership(
   const owner = asString(payload.owner);
   const mitigation = asString(payload.mitigation);
   const reviewState = asString(payload.review_state);
+  const acceptedRiskPosture = asString(payload.accepted_risk_posture);
   const phase66HandoffPosture = asString(payload.phase66_handoff_posture);
   const reviewDueDateStatus = asString(payload.review_due_date_status);
   const authorityBoundary = asString(payload.authority_boundary);
@@ -707,6 +708,11 @@ export async function getOneForLimitationOwnership(
   if (!LIMITATION_OWNERSHIP_REVIEW_STATES.has(reviewState)) {
     throw new OperatorDataProviderContractError(
       "Resource limitationOwnership has unsupported review_state.",
+    );
+  }
+  if (reviewState === "accepted_risk" && acceptedRiskPosture === null) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership accepted-risk detail requires accepted_risk_posture.",
     );
   }
   if (!LIMITATION_OWNERSHIP_HANDOFF_POSTURES.has(phase66HandoffPosture)) {

--- a/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
+++ b/apps/operator-ui/src/operatorDataProvider/listSemantics.ts
@@ -2,6 +2,7 @@ import type { GetListParams, GetListResult } from "react-admin";
 import { OperatorDataProviderContractError, UnsupportedOperatorDataProviderOperationError } from "./errors";
 import {
   validateDetectorActivationReviewRecord,
+  validateLimitationOwnershipListRecord,
   validateRecordSearchResult,
   validateSourceHealthDashboardRecord,
 } from "./phase61ListValidators";
@@ -314,6 +315,9 @@ export async function getListForStandardResource({
     }
     if (resource === "recordSearch") {
       records.forEach(validateRecordSearchResult);
+    }
+    if (resource === "limitationOwnership") {
+      records.forEach(validateLimitationOwnershipListRecord);
     }
     totalRecords =
       typeof response.total_records === "number"

--- a/apps/operator-ui/src/operatorDataProvider/phase61ListValidators.ts
+++ b/apps/operator-ui/src/operatorDataProvider/phase61ListValidators.ts
@@ -89,6 +89,42 @@ const RECORD_SEARCH_REVIEWED_ROUTE_PATTERNS_BY_FAMILY = new Map<string, RegExp[]
   ["source_health", [/^\/operator\/source-health$/]],
 ]);
 
+const LIMITATION_OWNERSHIP_REVIEW_STATES = new Set([
+  "identified",
+  "under_review",
+  "accepted_risk",
+  "mitigation_planned",
+  "mitigation_in_progress",
+  "closed",
+]);
+
+const LIMITATION_OWNERSHIP_SEVERITIES = new Set([
+  "low",
+  "medium",
+  "material",
+  "high",
+  "blocking",
+]);
+
+const LIMITATION_OWNERSHIP_HANDOFF_POSTURES = new Set([
+  "not_ready_for_handoff",
+  "handoff_required",
+  "handoff_ready_as_subordinate_evidence",
+  "blocked_until_mitigated",
+]);
+
+const LIMITATION_OWNERSHIP_REQUIRED_FIELDS = [
+  "limitation_id",
+  "title",
+  "severity",
+  "affected_surface",
+  "owner",
+  "mitigation",
+  "review_state",
+  "phase66_handoff_posture",
+  "authority_boundary",
+] as const;
+
 const REVIEWED_SOURCE_CATALOG_ENTRIES_BY_FAMILY = new Map<string, Set<string>>([
   [
     "wazuh_detection",
@@ -284,6 +320,74 @@ export function validateRecordSearchResult(record: Record<string, unknown>) {
   if (record.stale_cache === true || record.cache_sourced === true) {
     throw new OperatorDataProviderContractError(
       "Resource recordSearch rejects stale-cache results.",
+    );
+  }
+}
+
+export function validateLimitationOwnershipListRecord(record: Record<string, unknown>) {
+  for (const field of LIMITATION_OWNERSHIP_REQUIRED_FIELDS) {
+    if (asString(record[field]) === null) {
+      throw new OperatorDataProviderContractError(
+        "Resource limitationOwnership list record is missing reviewed ownership fields.",
+      );
+    }
+  }
+
+  const severity = asString(record.severity);
+  if (severity === null || !LIMITATION_OWNERSHIP_SEVERITIES.has(severity)) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership list record has unsupported severity.",
+    );
+  }
+
+  const reviewState = asString(record.review_state);
+  if (
+    reviewState === null ||
+    !LIMITATION_OWNERSHIP_REVIEW_STATES.has(reviewState)
+  ) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership list record has unsupported review_state.",
+    );
+  }
+
+  const handoffPosture = asString(record.phase66_handoff_posture);
+  if (
+    handoffPosture === null ||
+    !LIMITATION_OWNERSHIP_HANDOFF_POSTURES.has(handoffPosture)
+  ) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership list record has unsupported phase66_handoff_posture.",
+    );
+  }
+
+  if (asString(record.review_cadence) === null && asString(record.due_date) === null) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership list record requires review_cadence or due_date.",
+    );
+  }
+
+  if (
+    !Array.isArray(record.evidence_references) ||
+    record.evidence_references.length === 0 ||
+    record.evidence_references.some((reference) => asString(reference) === null)
+  ) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership list record requires explicit evidence references.",
+    );
+  }
+
+  if (
+    asString(record.authority_boundary) !== "reviewed_evidence_input_only" ||
+    (record.readiness_claim !== undefined && record.readiness_claim !== null)
+  ) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership list record must remain subordinate and cannot claim readiness truth.",
+    );
+  }
+
+  if (record.stale_cache === true || record.cache_sourced === true) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership list record rejects stale-cache limitation truth.",
     );
   }
 }

--- a/apps/operator-ui/src/operatorDataProvider/phase61ListValidators.ts
+++ b/apps/operator-ui/src/operatorDataProvider/phase61ListValidators.ts
@@ -120,6 +120,7 @@ const LIMITATION_OWNERSHIP_REQUIRED_FIELDS = [
   "affected_surface",
   "owner",
   "mitigation",
+  "lifecycle_state",
   "review_state",
   "phase66_handoff_posture",
   "authority_boundary",
@@ -341,12 +342,18 @@ export function validateLimitationOwnershipListRecord(record: Record<string, unk
   }
 
   const reviewState = asString(record.review_state);
+  const lifecycleState = asString(record.lifecycle_state);
   if (
     reviewState === null ||
     !LIMITATION_OWNERSHIP_REVIEW_STATES.has(reviewState)
   ) {
     throw new OperatorDataProviderContractError(
       "Resource limitationOwnership list record has unsupported review_state.",
+    );
+  }
+  if (lifecycleState !== reviewState) {
+    throw new OperatorDataProviderContractError(
+      "Resource limitationOwnership list record requires lifecycle_state to match review_state.",
     );
   }
 
@@ -385,7 +392,10 @@ export function validateLimitationOwnershipListRecord(record: Record<string, unk
     );
   }
 
-  if (record.stale_cache === true || record.cache_sourced === true) {
+  if (
+    (record.stale_cache !== undefined && record.stale_cache !== false) ||
+    (record.cache_sourced !== undefined && record.cache_sourced !== false)
+  ) {
     throw new OperatorDataProviderContractError(
       "Resource limitationOwnership list record rejects stale-cache limitation truth.",
     );

--- a/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
+++ b/apps/operator-ui/src/operatorDataProvider/resourceBindings.ts
@@ -57,6 +57,12 @@ export const RESOURCE_BINDINGS: Record<
     listPath: "/inspect-first-login-checklist",
     listSemantics: "client",
   },
+  limitationOwnership: {
+    idField: "limitation_id",
+    listPath: "/inspect-records",
+    listSemantics: "client",
+    recordFamily: "known_limitation_ownership",
+  },
   queue: {
     idField: "alert_id",
     listPath: "/inspect-analyst-queue",

--- a/apps/operator-ui/src/operatorDataProvider/types.ts
+++ b/apps/operator-ui/src/operatorDataProvider/types.ts
@@ -13,6 +13,7 @@ export type OperatorResourceName =
   | "reconciliations"
   | "todayView"
   | "businessHoursHandoff"
+  | "limitationOwnership"
   | "advisoryOutput"
   | "actionCatalog"
   | "actionReview";
@@ -44,7 +45,11 @@ export interface StandardListReaderOptions {
 
 export type StandardOperatorResourceName = Exclude<
   OperatorResourceName,
-  "advisoryOutput" | "actionReview" | "businessHoursHandoff" | "todayView"
+  | "advisoryOutput"
+  | "actionReview"
+  | "businessHoursHandoff"
+  | "limitationOwnership"
+  | "todayView"
 >;
 
 export type OperatorRecord = RaRecord;

--- a/apps/operator-ui/src/operatorDataProvider/types.ts
+++ b/apps/operator-ui/src/operatorDataProvider/types.ts
@@ -48,7 +48,6 @@ export type StandardOperatorResourceName = Exclude<
   | "advisoryOutput"
   | "actionReview"
   | "businessHoursHandoff"
-  | "limitationOwnership"
   | "todayView"
 >;
 

--- a/control-plane/aegisops/control_plane/api/http_protected_surface.py
+++ b/control-plane/aegisops/control_plane/api/http_protected_surface.py
@@ -26,6 +26,7 @@ PROTECTED_READ_ROLES_BY_PATH: dict[str, tuple[str, ...]] = {
     "/inspect-alert-detail": READ_ONLY_PROTECTED_ROLES,
     "/inspect-case-detail": READ_ONLY_PROTECTED_ROLES,
     "/inspect-action-review": READ_ONLY_PROTECTED_ROLES,
+    "/inspect-limitation-ownership": READ_ONLY_PROTECTED_ROLES,
     "/inspect-assistant-context": READ_ONLY_PROTECTED_ROLES,
     "/inspect-advisory-output": READ_ONLY_PROTECTED_ROLES,
     "/render-recommendation-draft": READ_ONLY_PROTECTED_ROLES,

--- a/control-plane/aegisops/control_plane/api/http_surface.py
+++ b/control-plane/aegisops/control_plane/api/http_surface.py
@@ -390,6 +390,42 @@ def _handle_inspect_action_review(
     _write_json(handler, HTTPStatus.OK, payload)
 
 
+def _handle_inspect_limitation_ownership(
+    handler: BaseHTTPRequestHandler,
+    context: HttpSurfaceContext,
+    principal: object,
+) -> None:
+    raw_limitation_id = _query_value(handler, "limitation_id")
+    limitation_id = (
+        normalize_record_id(raw_limitation_id) if raw_limitation_id else None
+    )
+    try:
+        payload = context.service.inspect_limitation_ownership_detail(
+            limitation_id
+        )
+    except ValueError as exc:
+        _write_json(
+            handler,
+            HTTPStatus.BAD_REQUEST,
+            {
+                "error": "invalid_request",
+                "message": str(exc),
+            },
+        )
+        return
+    except LookupError as exc:
+        _write_json(
+            handler,
+            HTTPStatus.NOT_FOUND,
+            {
+                "error": "not_found",
+                "message": str(exc),
+            },
+        )
+        return
+    _write_json(handler, HTTPStatus.OK, dict(payload))
+
+
 def _handle_assistant_context_family(
     handler: BaseHTTPRequestHandler,
     context: HttpSurfaceContext,
@@ -466,6 +502,7 @@ HTTP_GET_ROUTES: dict[str, GetRouteHandler] = {
     "/inspect-alert-detail": _handle_inspect_alert_detail,
     "/inspect-case-detail": _handle_inspect_case_detail,
     "/inspect-action-review": _handle_inspect_action_review,
+    "/inspect-limitation-ownership": _handle_inspect_limitation_ownership,
     "/inspect-assistant-context": _handle_assistant_context_family,
     "/inspect-advisory-output": _handle_assistant_context_family,
     "/render-recommendation-draft": _handle_assistant_context_family,

--- a/control-plane/aegisops/control_plane/api/http_surface.py
+++ b/control-plane/aegisops/control_plane/api/http_surface.py
@@ -400,9 +400,8 @@ def _handle_inspect_limitation_ownership(
         normalize_record_id(raw_limitation_id) if raw_limitation_id else None
     )
     try:
-        payload = context.service.inspect_limitation_ownership_detail(
-            limitation_id
-        )
+        read_surface = context.service._operator_inspection_read_surface
+        payload = read_surface.inspect_limitation_ownership_detail(limitation_id)
     except ValueError as exc:
         _write_json(
             handler,

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -1704,14 +1704,9 @@ class OperatorInspectionReadSurface:
                 )
             return project_limitation_ownership_context(record, consumer="inspection")
 
-        records = self._service._store.list(KnownLimitationOwnershipRecord)
-        if not records:
-            raise LookupError("Missing limitation ownership record for inspection")
-        if len(records) > 1:
-            raise LookupError(
-                "Limitation ownership inspection requires an explicit limitation_id"
-            )
-        return project_limitation_ownership_context(records[0], consumer="inspection")
+        raise LookupError(
+            "Limitation ownership inspection requires an explicit limitation_id"
+        )
 
     def _build_alert_external_ticket_reference_surface(
         self,

--- a/control-plane/aegisops/control_plane/operator_inspection.py
+++ b/control-plane/aegisops/control_plane/operator_inspection.py
@@ -5,6 +5,9 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, Protocol, Type, TypeVar
 
 from .inspection.evidence_pack_projection import build_linked_evidence_pack_projections
+from .inspection.limitation_ownership_projection import (
+    project_limitation_ownership_context,
+)
 from .models import (
     ActionExecutionRecord,
     ActionRequestRecord,
@@ -15,6 +18,7 @@ from .models import (
     CaseRecord,
     ControlPlaneRecord,
     EvidenceRecord,
+    KnownLimitationOwnershipRecord,
     LifecycleTransitionRecord,
     ObservationRecord,
     LeadRecord,
@@ -1680,6 +1684,34 @@ class OperatorInspectionReadSurface:
                 self._record_to_dict(alert_record) if alert_record is not None else None
             ),
         )
+
+    def inspect_limitation_ownership_detail(
+        self,
+        limitation_id: str | None = None,
+    ) -> object:
+        if limitation_id is not None:
+            limitation_id = self._service._require_non_empty_string(
+                limitation_id,
+                "limitation_id",
+            )
+            record = self._service._store.get(
+                KnownLimitationOwnershipRecord,
+                limitation_id,
+            )
+            if record is None:
+                raise LookupError(
+                    f"Missing limitation ownership record {limitation_id!r}"
+                )
+            return project_limitation_ownership_context(record, consumer="inspection")
+
+        records = self._service._store.list(KnownLimitationOwnershipRecord)
+        if not records:
+            raise LookupError("Missing limitation ownership record for inspection")
+        if len(records) > 1:
+            raise LookupError(
+                "Limitation ownership inspection requires an explicit limitation_id"
+            )
+        return project_limitation_ownership_context(records[0], consumer="inspection")
 
     def _build_alert_external_ticket_reference_surface(
         self,

--- a/control-plane/aegisops/control_plane/service.py
+++ b/control-plane/aegisops/control_plane/service.py
@@ -906,14 +906,6 @@ class AegisOpsControlPlaneService(CaseWorkflowFacade, ExternalEvidenceFacade):
             action_request_id
         )
 
-    def inspect_limitation_ownership_detail(
-        self,
-        limitation_id: str | None = None,
-    ) -> object:
-        return self._operator_inspection_read_surface.inspect_limitation_ownership_detail(
-            limitation_id
-        )
-
     def record_action_review_manual_fallback(
         self,
         *,

--- a/control-plane/aegisops/control_plane/service.py
+++ b/control-plane/aegisops/control_plane/service.py
@@ -906,6 +906,14 @@ class AegisOpsControlPlaneService(CaseWorkflowFacade, ExternalEvidenceFacade):
             action_request_id
         )
 
+    def inspect_limitation_ownership_detail(
+        self,
+        limitation_id: str | None = None,
+    ) -> object:
+        return self._operator_inspection_read_surface.inspect_limitation_ownership_detail(
+            limitation_id
+        )
+
     def record_action_review_manual_fallback(
         self,
         *,

--- a/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
+++ b/control-plane/tests/test_phase17_first_boot_runtime_artifacts.py
@@ -122,6 +122,7 @@ class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
             "location = /inspect-alert-detail {",
             "location = /inspect-case-detail {",
             "location = /inspect-action-review {",
+            "location = /inspect-limitation-ownership {",
             "location = /inspect-advisory-output {",
             "location = /operator/queue {",
         )
@@ -140,6 +141,9 @@ class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
             ),
             "/inspect-action-review": (
                 "proxy_pass http://aegisops_control_plane/inspect-action-review$is_args$args;"
+            ),
+            "/inspect-limitation-ownership": (
+                "proxy_pass http://aegisops_control_plane/inspect-limitation-ownership$is_args$args;"
             ),
             "/inspect-advisory-output": (
                 "proxy_pass http://aegisops_control_plane/inspect-advisory-output$is_args$args;"
@@ -199,6 +203,7 @@ class Phase17FirstBootRuntimeArtifactTests(unittest.TestCase):
             "/inspect-alert-detail",
             "/inspect-case-detail",
             "/inspect-action-review",
+            "/inspect-limitation-ownership",
             "/inspect-advisory-output",
             "/operator/queue",
         ):

--- a/control-plane/tests/test_phase64_limitation_ownership_control_plane.py
+++ b/control-plane/tests/test_phase64_limitation_ownership_control_plane.py
@@ -12,11 +12,14 @@ if str(CONTROL_PLANE_ROOT) not in sys.path:
 from aegisops.control_plane.inspection.limitation_ownership_projection import (  # noqa: E402
     project_limitation_ownership_context,
 )
+from aegisops.control_plane.config import RuntimeConfig  # noqa: E402
 from aegisops.control_plane.models import KnownLimitationOwnershipRecord  # noqa: E402
 from aegisops.control_plane.record_validation import _validate_record  # noqa: E402
+from aegisops.control_plane.service import AegisOpsControlPlaneService  # noqa: E402
 from aegisops.control_plane.validation.phase64_record_validators import (  # noqa: E402
     validate_known_limitation_current_review,
 )
+from postgres_test_support import make_store  # noqa: E402
 
 
 def _known_limitation_ownership_record(
@@ -128,6 +131,46 @@ class Phase64LimitationOwnershipControlPlaneTests(unittest.TestCase):
                 consumer="inspection",
                 requested_authority="release_truth",
             )
+
+    def test_service_inspects_limitation_ownership_through_backend_projection(
+        self,
+    ) -> None:
+        store, _backend = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        record = _known_limitation_ownership_record()
+
+        service.persist_record(record)
+
+        projection = service.inspect_limitation_ownership_detail(record.limitation_id)
+        self.assertEqual(projection["limitation_id"], record.limitation_id)
+        self.assertEqual(projection["consumer"], "inspection")
+        self.assertEqual(projection["review_cadence"], "weekly")
+        self.assertFalse(projection["readiness_truth"])
+        self.assertFalse(projection["release_truth"])
+        self.assertFalse(projection["gate_truth"])
+        self.assertFalse(projection["workflow_truth"])
+        self.assertNotIn("stale_cache", projection)
+
+    def test_service_requires_explicit_limitation_when_multiple_records_exist(
+        self,
+    ) -> None:
+        store, _backend = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        service.persist_record(
+            _known_limitation_ownership_record(limitation_id="limitation-001")
+        )
+        service.persist_record(
+            _known_limitation_ownership_record(limitation_id="limitation-002")
+        )
+
+        with self.assertRaisesRegex(LookupError, "explicit limitation_id"):
+            service.inspect_limitation_ownership_detail()
 
 
 if __name__ == "__main__":

--- a/control-plane/tests/test_phase64_limitation_ownership_control_plane.py
+++ b/control-plane/tests/test_phase64_limitation_ownership_control_plane.py
@@ -176,6 +176,20 @@ class Phase64LimitationOwnershipControlPlaneTests(unittest.TestCase):
         with self.assertRaisesRegex(LookupError, "explicit limitation_id"):
             read_surface.inspect_limitation_ownership_detail()
 
+    def test_read_surface_requires_explicit_limitation_for_single_record(
+        self,
+    ) -> None:
+        store, _backend = make_store()
+        service = AegisOpsControlPlaneService(
+            RuntimeConfig(postgres_dsn="postgresql://control-plane.local/aegisops"),
+            store=store,
+        )
+        service.persist_record(_known_limitation_ownership_record())
+
+        read_surface = service._operator_inspection_read_surface
+        with self.assertRaisesRegex(LookupError, "explicit limitation_id"):
+            read_surface.inspect_limitation_ownership_detail()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/control-plane/tests/test_phase64_limitation_ownership_control_plane.py
+++ b/control-plane/tests/test_phase64_limitation_ownership_control_plane.py
@@ -132,7 +132,7 @@ class Phase64LimitationOwnershipControlPlaneTests(unittest.TestCase):
                 requested_authority="release_truth",
             )
 
-    def test_service_inspects_limitation_ownership_through_backend_projection(
+    def test_read_surface_inspects_limitation_ownership_through_backend_projection(
         self,
     ) -> None:
         store, _backend = make_store()
@@ -144,7 +144,10 @@ class Phase64LimitationOwnershipControlPlaneTests(unittest.TestCase):
 
         service.persist_record(record)
 
-        projection = service.inspect_limitation_ownership_detail(record.limitation_id)
+        read_surface = service._operator_inspection_read_surface
+        projection = read_surface.inspect_limitation_ownership_detail(
+            record.limitation_id
+        )
         self.assertEqual(projection["limitation_id"], record.limitation_id)
         self.assertEqual(projection["consumer"], "inspection")
         self.assertEqual(projection["review_cadence"], "weekly")
@@ -154,7 +157,7 @@ class Phase64LimitationOwnershipControlPlaneTests(unittest.TestCase):
         self.assertFalse(projection["workflow_truth"])
         self.assertNotIn("stale_cache", projection)
 
-    def test_service_requires_explicit_limitation_when_multiple_records_exist(
+    def test_read_surface_requires_explicit_limitation_when_multiple_records_exist(
         self,
     ) -> None:
         store, _backend = make_store()
@@ -169,8 +172,9 @@ class Phase64LimitationOwnershipControlPlaneTests(unittest.TestCase):
             _known_limitation_ownership_record(limitation_id="limitation-002")
         )
 
+        read_surface = service._operator_inspection_read_surface
         with self.assertRaisesRegex(LookupError, "explicit limitation_id"):
-            service.inspect_limitation_ownership_detail()
+            read_surface.inspect_limitation_ownership_detail()
 
 
 if __name__ == "__main__":

--- a/control-plane/tests/test_runtime_skeleton.py
+++ b/control-plane/tests/test_runtime_skeleton.py
@@ -220,6 +220,7 @@ class RuntimeSkeletonTests(unittest.TestCase):
         from aegisops.control_plane.api import http_surface
 
         self.assertIn("/inspect-records", http_surface.HTTP_GET_ROUTES)
+        self.assertIn("/inspect-limitation-ownership", http_surface.HTTP_GET_ROUTES)
         self.assertIn(
             "/operator/promote-alert-to-case",
             http_surface.HTTP_POST_ROUTES,

--- a/proxy/nginx/conf.d-first-boot/control-plane.conf
+++ b/proxy/nginx/conf.d-first-boot/control-plane.conf
@@ -61,6 +61,11 @@ server {
     proxy_pass http://aegisops_control_plane/inspect-action-review$is_args$args;
   }
 
+  location = /inspect-limitation-ownership {
+    limit_except GET HEAD { deny all; }
+    proxy_pass http://aegisops_control_plane/inspect-limitation-ownership$is_args$args;
+  }
+
   location = /inspect-advisory-output {
     limit_except GET HEAD { deny all; }
     proxy_pass http://aegisops_control_plane/inspect-advisory-output$is_args$args;


### PR DESCRIPTION
Summary:
- Adds a read-only operator Limitations route for reviewed limitation ownership context.
- Validates backend limitation ownership projections fail closed for malformed, cache/browser-sourced, unsupported, or authority-promoting payloads.
- Adds focused operator route coverage for valid display and cache/browser truth rejection.

Verification:
- npm --workspace @aegisops/operator-ui run test -- src/app/OperatorRoutes.test.tsx
- npm --workspace @aegisops/operator-ui run test -- src/dataProvider.test.ts
- npm run typecheck --workspace @aegisops/operator-ui
- bash scripts/verify-publishable-path-hygiene.sh
- node <codex-supervisor-root>/dist/index.js issue-lint 1368 --config <supervisor-config-path>