### PR TITLE
Close out Phase 64 limitation ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Canonical cross-phase boundary reference:
 - [Phase 62.8 closeout evaluation](docs/phase-62-closeout-evaluation.md) records the Minimum SOAR Replacement Breadth outcomes, subordinate authority posture, verifier evidence, accepted limitations, and bounded Phase 63/66 handoff.
 - [Phase 63.8 closeout evaluation](docs/phase-63-closeout-evaluation.md) records the Evidence Expansion v1 outcomes, subordinate authority posture, verifier evidence, issue-lint evidence, accepted limitations, and bounded Phase 66 handoff.
 - [Phase 64.5 Phase 66 limitation handoff](docs/phase-64-5-phase66-limitation-handoff.md) records Phase 64 limitation ownership evidence that Phase 66 may consume as subordinate RC proof input without satisfying RC gates by itself.
+- [Phase 64.6 closeout evaluation](docs/phase-64-closeout-evaluation.md) records the Limitation Ownership outcomes, subordinate authority posture, verifier evidence, issue-lint evidence, accepted limitations, and bounded Phase 66 handoff.
 - [Phase 58.5 upgrade and rollback plan contract](docs/phase-58-5-upgrade-rollback-plan-contract.md) defines reviewed upgrade-plan and rollback-plan evidence fields, failure states, and authority boundaries without implementing live upgrade or rollback execution.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
@@ -173,6 +174,8 @@ The Phase 62.8 closeout evaluation is defined by the [Phase 62.8 closeout evalua
 The Phase 63.8 closeout evaluation is defined by the [Phase 63.8 closeout evaluation](docs/phase-63-closeout-evaluation.md).
 
 The Phase 64.5 Phase 66 limitation handoff is defined by the [Phase 64.5 Phase 66 limitation handoff](docs/phase-64-5-phase66-limitation-handoff.md).
+
+The Phase 64.6 closeout evaluation is defined by the [Phase 64.6 closeout evaluation](docs/phase-64-closeout-evaluation.md).
 
 Wazuh detects, AegisOps decides, records, and reconciles, and Shuffle executes reviewed delegated routine work.
 

--- a/docs/phase-64-closeout-evaluation.md
+++ b/docs/phase-64-closeout-evaluation.md
@@ -1,7 +1,7 @@
 # Phase 64 Closeout Evaluation
 
 - **Status**: Accepted as Limitation Ownership evidence before Phase 66 RC proof, Beta, RC, GA, and commercial replacement-readiness claims.
-- **Date**: 2026-06-01
+- **Date**: 2026-06-01 Asia/Tokyo closeout date
 - **Owner**: AegisOps maintainers
 - **Related Issues**: #1365, #1366, #1367, #1368, #1369, #1370, #1371
 
@@ -50,7 +50,7 @@ Phase 64 materially added or tightened these repo-owned surfaces:
 - `control-plane/aegisops/control_plane/api/http_protected_surface.py`
 - `control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py`
 - `control-plane/aegisops/control_plane/runtime/restore_readiness_projection.py`
-- `postgres/control-plane/migrations/20260531_phase_64_known_limitation_ownership_records.sql`
+- `postgres/control-plane/migrations/0015_phase_64_known_limitation_ownership_records.sql`
 - `postgres/control-plane/schema.sql`
 - `control-plane/tests/test_phase64_known_limitation_ownership_contract.py`
 - `control-plane/tests/test_phase64_limitation_ownership_control_plane.py`

--- a/docs/phase-64-closeout-evaluation.md
+++ b/docs/phase-64-closeout-evaluation.md
@@ -1,0 +1,147 @@
+# Phase 64 Closeout Evaluation
+
+- **Status**: Accepted as Limitation Ownership evidence before Phase 66 RC proof, Beta, RC, GA, and commercial replacement-readiness claims.
+- **Date**: 2026-06-01
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1365, #1366, #1367, #1368, #1369, #1370, #1371
+
+## Verdict
+
+Phase 64 Limitation Ownership is accepted for known limitation ownership records, validation and projection boundaries, operator limitation ownership surfaces, limitation-aware advisory and readiness context, Phase 66 limitation handoff evidence, and closeout evidence.
+
+The accepted breadth is enough to show reviewed limitations have explicit owners, mitigation posture, evidence references, review posture, operator visibility, advisory context, readiness context, and Phase 66 handoff notes. It is not limitation resolution, support-bundle completion, RC gate acceptance, release gate acceptance, Phase 66 RC proof, Beta, RC, GA, or commercial replacement readiness.
+
+AegisOps records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth.
+
+Limitation ownership documents, operator UI surfaces, advisory summaries, readiness projections, Phase 66 handoff notes, verifier output, and issue-lint output remain subordinate review and planning evidence only. They cannot approve, execute, reconcile, close, gate, resolve limitations, satisfy support evidence, or claim readiness by themselves.
+
+Phase 64 must reject missing child outcomes, missing verifier evidence, missing issue-lint evidence, missing Phase 66 handoff, workstation-local paths, production secrets, RC/GA readiness claims, commercial replacement readiness claims, limitation-resolution claims, support-bundle completion claims, verifier truth, issue-lint truth, UI truth, and AI truth.
+
+This closeout does not claim Phase 64 resolves known limitations, completes support-bundle evidence, proves Beta readiness, proves RC readiness, proves GA readiness, proves self-service commercial readiness, proves commercial replacement readiness, or satisfies Phase 66 RC gates.
+
+## Child Issue Outcomes
+
+| Issue | Scope | Outcome |
+| --- | --- | --- |
+| #1365 | Epic: Phase 64 Limitation Ownership | Open until #1371 lands; accepted when this closeout, focused verifiers, focused backend/UI/advisory/readiness tests, authority-boundary checks, maintainability check, publishable path hygiene, and issue-lint pass. |
+| #1366 | Phase 64.1 known limitation ownership record contract | Closed. `docs/phase-64-1-known-limitation-ownership-record-contract.md`, validation notes, PostgreSQL schema, record-family registration, lifecycle history, and focused tests prove reviewed `known_limitation_ownership` records without limitation resolution, release truth, gate truth, verifier truth, or issue-lint truth. |
+| #1367 | Phase 64.2 limitation ownership validation projection | Closed. `control-plane/aegisops/control_plane/inspection/limitation_ownership_projection.py`, validator tightening, and focused backend tests prove current-review and projection boundaries for limitation ownership records while rejecting stale, malformed, missing, and authority-bearing context. |
+| #1368 | Phase 64.3 operator limitation ownership surface | Closed. `apps/operator-ui/src/app/operatorConsolePages/limitationOwnershipPages.tsx`, route wiring, data-provider readers, list validators, and focused UI/data-provider tests prove operator visibility from backend-bound limitation records without browser, cache, UI, or workflow truth. |
+| #1369 | Phase 64.4 limitation-aware advisory and readiness context | Closed. `control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py`, `control-plane/aegisops/control_plane/runtime/restore_readiness_projection.py`, and focused advisory/readiness tests prove limitation context can appear as directly linked subordinate advisory and readiness input without AI truth, readiness truth, or gate acceptance. |
+| #1370 | Phase 64.5 Phase 66 limitation handoff | Closed. `docs/phase-64-5-phase66-limitation-handoff.md`, reviewed limitation records, focused handoff verifier, and verifier self-test prove Phase 66 can consume limitation ownership records only as subordinate RC proof planning evidence. |
+| #1371 | Phase 64.6 Phase 64 closeout evaluation | Open until this document and focused closeout verifier land. |
+
+## Changed Files
+
+Phase 64 materially added or tightened these repo-owned surfaces:
+
+- `README.md`
+- `docs/phase-64-1-known-limitation-ownership-record-contract.md`
+- `docs/phase-64-1-known-limitation-ownership-record-contract-validation.md`
+- `docs/phase-64-1-reviewed-limitation-ownership-records.md`
+- `docs/phase-64-5-phase66-limitation-handoff.md`
+- `docs/phase-64-closeout-evaluation.md`
+- `control-plane/aegisops/control_plane/models.py`
+- `control-plane/aegisops/control_plane/record_validation.py`
+- `control-plane/aegisops/control_plane/validation/phase64_record_validators.py`
+- `control-plane/aegisops/control_plane/inspection/limitation_ownership_projection.py`
+- `control-plane/aegisops/control_plane/operator_inspection.py`
+- `control-plane/aegisops/control_plane/api/http_surface.py`
+- `control-plane/aegisops/control_plane/api/http_protected_surface.py`
+- `control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py`
+- `control-plane/aegisops/control_plane/runtime/restore_readiness_projection.py`
+- `postgres/control-plane/migrations/20260531_phase_64_known_limitation_ownership_records.sql`
+- `postgres/control-plane/schema.sql`
+- `control-plane/tests/test_phase64_known_limitation_ownership_contract.py`
+- `control-plane/tests/test_phase64_limitation_ownership_control_plane.py`
+- `control-plane/tests/test_phase60_6_cited_recommendation_draft_agent.py`
+- `control-plane/tests/test_service_readiness_projection.py`
+- `apps/operator-ui/src/app/operatorConsolePages/limitationOwnershipPages.tsx`
+- `apps/operator-ui/src/app/OperatorRoutes.limitationOwnership.testSuite.tsx`
+- `apps/operator-ui/src/dataProvider.ts`
+- `apps/operator-ui/src/dataProvider.test.ts`
+- `apps/operator-ui/src/operatorDataProvider/detailReaders.ts`
+- `apps/operator-ui/src/operatorDataProvider/listSemantics.ts`
+- `apps/operator-ui/src/operatorDataProvider/phase61ListValidators.ts`
+- `apps/operator-ui/src/operatorDataProvider/resourceBindings.ts`
+- `apps/operator-ui/src/operatorDataProvider/types.ts`
+- `scripts/verify-phase-64-1-known-limitation-ownership-record-contract.sh`
+- `scripts/verify-phase-64-5-phase66-limitation-handoff.sh`
+- `scripts/test-verify-phase-64-5-phase66-limitation-handoff.sh`
+- `scripts/verify-phase-64-6-closeout-evaluation.sh`
+- `scripts/test-verify-phase-64-6-closeout-evaluation.sh`
+
+## Behavior Before And After
+
+| Surface | Before Phase 64 | Accepted Phase 64 behavior |
+| --- | --- | --- |
+| Known limitation ownership records | Known limitations could be discussed as planning context without one reviewed AegisOps record family contract. | The `known_limitation_ownership` record family requires limitation id, owner, mitigation, evidence references, review state, review cadence or due date, accepted risk posture, Phase 66 handoff posture, and explicit subordinate authority boundary. |
+| Validation and projection | Limitation context lacked one current-review projection boundary for operator and advisory consumers. | Projection validates records at the read boundary and rejects missing owner, missing mitigation, missing evidence references, expired review posture, unsupported states, malformed context, and authority-bearing fields. |
+| Operator surface | Operators lacked a bounded limitation ownership surface. | The operator UI lists and inspects backend-bound limitation ownership records as subordinate limitation context while rejecting stale cache markers, browser-state truth, lifecycle drift, and readiness overclaims. |
+| Advisory and readiness context | Advisory and readiness surfaces could not cite known limitation ownership as a reviewed subordinate input. | Cited recommendation drafts and readiness projections can include directly linked limitation ownership context without expanding AI authority, readiness truth, release truth, gate truth, or limitation truth. |
+| Phase 66 handoff | Phase 66 had no reviewed limitation handoff document for the Phase 64 record set. | Phase 66 handoff entries bind limitation ids to owners, mitigation status, evidence references, open blockers, accepted risks, next review dates, and RC-gate consumption notes as planning evidence only. |
+
+## Verifier Evidence
+
+Focused Phase 64 and closeout verifiers that must pass:
+
+- `bash scripts/verify-phase-64-1-known-limitation-ownership-record-contract.sh`
+- `bash scripts/verify-phase-64-5-phase66-limitation-handoff.sh`
+- `bash scripts/test-verify-phase-64-5-phase66-limitation-handoff.sh`
+- `bash scripts/verify-phase-64-6-closeout-evaluation.sh`
+- `bash scripts/test-verify-phase-64-6-closeout-evaluation.sh`
+- `bash scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh`
+- `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`
+- `bash scripts/verify-maintainability-hotspots.sh`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+- `python3 -m unittest control-plane.tests.test_phase64_known_limitation_ownership_contract`
+- `python3 -m unittest control-plane.tests.test_phase64_limitation_ownership_control_plane`
+- `python3 -m unittest control-plane.tests.test_phase60_6_cited_recommendation_draft_agent`
+- `python3 -m unittest control-plane.tests.test_service_readiness_projection`
+- `npm run test --workspace @aegisops/operator-ui -- OperatorRoutes.test.tsx`
+- `npm run test --workspace @aegisops/operator-ui -- dataProvider.test.ts`
+- `npm run typecheck --workspace @aegisops/operator-ui`
+
+Issue-lint evidence:
+
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1365 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1366 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1367 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1368 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1369 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1370 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1371 --config <supervisor-config-path>`
+
+Each command should report `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, and `high_risk_blocking_ambiguity=none` before Phase 64 is considered fully closed.
+
+Focused negative behaviors covered:
+
+- Known limitation ownership record validation rejects missing owner, missing mitigation, missing evidence reference, missing affected surface, missing review state, missing Phase 66 handoff posture, unsupported review state, unsupported handoff posture, and forbidden readiness or release overclaims.
+- Limitation ownership projection validation rejects expired current-review posture, malformed records, missing authority boundary, missing review due-date status, unsupported states, unsupported handoff posture, missing evidence references, and authority promotion.
+- Operator limitation ownership surface tests reject browser or cache sourced limitation truth, requested-id mismatch, unsupported severity, unsupported review state, unsupported handoff posture, malformed evidence references, lifecycle drift, stale-cache authority, and readiness, release, gate, or workflow truth.
+- Advisory and readiness context tests reject inferred limitation linkage, missing direct record linkage, AI-generated authority promotion, readiness-truth promotion, release-truth promotion, gate-truth promotion, limitation-truth promotion, and stale limitation context.
+- Phase 66 handoff verification rejects missing limitation owner, missing mitigation, missing evidence references, missing open blockers, missing next review date, inferred RC pass, gate truth shortcut, release truth shortcut, verifier-as-readiness-truth, issue-lint-as-readiness-truth, and readiness claims.
+- Path hygiene rejects workstation-local absolute paths in publishable docs, scripts, tests, prompts, and validation output.
+
+## Issue-Lint Summary
+
+Issue-lint is required for #1365 through #1371 using `node <codex-supervisor-root>/dist/index.js issue-lint <issue-number> --config <supervisor-config-path>`.
+
+Required summary for each issue: `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, and `high_risk_blocking_ambiguity=none`.
+
+Issue-lint output is planning and metadata evidence only. It does not become release truth, closeout truth, workflow truth, limitation truth, gate truth, or readiness truth.
+
+## Accepted Limitations
+
+- Phase 64 does not resolve limitations, close known limitation records, satisfy support-bundle evidence, accept release gates, approve RC gates, execute gate acceptance, prove Phase 66 RC readiness, prove Phase 67 GA readiness, or replace the Phase 51.3 gate contract.
+- Phase 64 does not implement new SIEM breadth, SOAR breadth, evidence source breadth, source-native truth, autonomous AI authority, Controlled Write, Hard Write, endpoint remediation, containment, quarantine, suppression activation, detector activation, approval bypass, execution bypass, reconciliation bypass, or case-closure shortcuts.
+- Phase 64 does not implement production secret material, customer-private data handling expansion, live credential custody expansion, production rollout readiness, self-service commercial readiness, or broad SIEM/SOAR replacement readiness.
+- Phase 64 limitation ownership records, validation projections, operator UI surfaces, advisory context, readiness context, handoff notes, verifier output, and issue-lint output are context only; they do not replace authoritative AegisOps alert, case, evidence request, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, or closeout records.
+
+## Phase 66 Handoff
+
+Phase 66 can consume Phase 64 as one RC evidence input for known limitation ownership. Phase 66 must still prove RC gates, first-user RC readiness, issue-lint and verifier completeness, rollout operational hygiene, support and restore evidence, SIEM breadth evidence, SOAR breadth evidence, upgrade and rollback readiness, production rollout readiness, security review, packaging evidence, and real RC gate acceptance outside this closeout.
+
+Phase 66 must treat `docs/phase-64-1-reviewed-limitation-ownership-records.md` and `docs/phase-64-5-phase66-limitation-handoff.md` as subordinate limitation ownership evidence only. It must not infer RC gate acceptance from issue closure, owner assignment, mitigation wording, review date, verifier success, issue-lint success, UI display, AI summary, readiness projection, or this closeout date.
+
+Phase 64 closeout is release and planning evidence only. It does not add limitation resolution, support-bundle completion, UI authority, AI authority, readiness authority, verifier authority, issue-lint authority, approval bypass, execution bypass, reconciliation bypass, Phase 66 RC proof, Phase 67 GA proof, or readiness and replacement claims.

--- a/scripts/test-verify-phase-64-6-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-64-6-closeout-evaluation.sh
@@ -73,6 +73,14 @@ remove_doc_text() {
     "${target}/docs/phase-64-closeout-evaluation.md"
 }
 
+comment_doc_text() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E/<!-- $ENV{TEXT} -->/g' \
+    "${target}/docs/phase-64-closeout-evaluation.md"
+}
+
 valid_repo="${workdir}/valid"
 copy_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
@@ -100,6 +108,14 @@ assert_fails_with \
   "${missing_child_repo}" \
   "Missing Phase 64 child issue outcome row in Child Issue Outcomes table"
 
+commented_child_repo="${workdir}/commented-child"
+copy_valid_repo "${commented_child_repo}"
+comment_doc_text "${commented_child_repo}" \
+  "| #1368 | Phase 64.3 operator limitation ownership surface | Closed. \`apps/operator-ui/src/app/operatorConsolePages/limitationOwnershipPages.tsx\`, route wiring, data-provider readers, list validators, and focused UI/data-provider tests prove operator visibility from backend-bound limitation records without browser, cache, UI, or workflow truth. |"
+assert_fails_with \
+  "${commented_child_repo}" \
+  "Missing Phase 64 child issue outcome row in Child Issue Outcomes table"
+
 missing_verifier_repo="${workdir}/missing-verifier"
 copy_valid_repo "${missing_verifier_repo}"
 remove_doc_text "${missing_verifier_repo}" \
@@ -108,12 +124,28 @@ assert_fails_with \
   "${missing_verifier_repo}" \
   "Missing Phase 64 verifier evidence line in Verifier Evidence section"
 
+commented_verifier_repo="${workdir}/commented-verifier"
+copy_valid_repo "${commented_verifier_repo}"
+comment_doc_text "${commented_verifier_repo}" \
+  "- \`python3 -m unittest control-plane.tests.test_phase64_limitation_ownership_control_plane\`"
+assert_fails_with \
+  "${commented_verifier_repo}" \
+  "Missing Phase 64 verifier evidence line in Verifier Evidence section"
+
 missing_issue_lint_repo="${workdir}/missing-issue-lint"
 copy_valid_repo "${missing_issue_lint_repo}"
 perl -0pi -e 's/- `node <codex-supervisor-root>\/dist\/index\.js issue-lint 1371 --config <supervisor-config-path>`.*\n//m' \
   "${missing_issue_lint_repo}/docs/phase-64-closeout-evaluation.md"
 assert_fails_with \
   "${missing_issue_lint_repo}" \
+  "Missing Phase 64 issue-lint evidence line in Issue-lint evidence section"
+
+commented_issue_lint_repo="${workdir}/commented-issue-lint"
+copy_valid_repo "${commented_issue_lint_repo}"
+comment_doc_text "${commented_issue_lint_repo}" \
+  "- \`node <codex-supervisor-root>/dist/index.js issue-lint 1371 --config <supervisor-config-path>\`"
+assert_fails_with \
+  "${commented_issue_lint_repo}" \
   "Missing Phase 64 issue-lint evidence line in Issue-lint evidence section"
 
 missing_handoff_repo="${workdir}/missing-handoff"

--- a/scripts/test-verify-phase-64-6-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-64-6-closeout-evaluation.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-64-6-closeout-evaluation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fiq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+copy_valid_repo() {
+  local target="$1"
+
+  mkdir -p "${target}/docs" "${target}/scripts" "${target}/control-plane/aegisops/control_plane"
+  cp "${repo_root}/README.md" "${target}/README.md"
+  cp "${repo_root}/docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md" "${target}/docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md"
+  cp "${repo_root}/docs/phase-51-6-authority-boundary-negative-test-policy.md" "${target}/docs/phase-51-6-authority-boundary-negative-test-policy.md"
+  cp "${repo_root}/docs/phase-63-closeout-evaluation.md" "${target}/docs/phase-63-closeout-evaluation.md"
+  cp "${repo_root}/docs/phase-64-1-known-limitation-ownership-record-contract.md" "${target}/docs/phase-64-1-known-limitation-ownership-record-contract.md"
+  cp "${repo_root}/docs/phase-64-1-reviewed-limitation-ownership-records.md" "${target}/docs/phase-64-1-reviewed-limitation-ownership-records.md"
+  cp "${repo_root}/docs/phase-64-5-phase66-limitation-handoff.md" "${target}/docs/phase-64-5-phase66-limitation-handoff.md"
+  cp "${repo_root}/docs/phase-64-closeout-evaluation.md" "${target}/docs/phase-64-closeout-evaluation.md"
+  cp "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${target}/scripts/verify-publishable-path-hygiene.sh"
+  : >"${target}/control-plane/aegisops/__init__.py"
+  : >"${target}/control-plane/aegisops/control_plane/__init__.py"
+  cp "${repo_root}/control-plane/aegisops/control_plane/publishable_paths.py" "${target}/control-plane/aegisops/control_plane/publishable_paths.py"
+  git -C "${target}" init -q
+  git -C "${target}" config user.email "aegisops@example.invalid"
+  git -C "${target}" config user.name "AegisOps Test"
+  git -C "${target}" add README.md docs scripts control-plane/aegisops
+  git -C "${target}" commit -q -m "fixture"
+}
+
+remove_doc_text() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-64-closeout-evaluation.md"
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+copy_valid_repo "${missing_doc_repo}"
+rm "${missing_doc_repo}/docs/phase-64-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_doc_repo}" \
+  "Missing Phase 64 closeout evaluation: docs/phase-64-closeout-evaluation.md"
+
+missing_readme_repo="${workdir}/missing-readme"
+copy_valid_repo "${missing_readme_repo}"
+perl -0pi -e 's/- \[Phase 64\.6 closeout evaluation\]\(docs\/phase-64-closeout-evaluation\.md\)[^\n]*\n/- Phase 64.6 closeout evaluation\\n/' \
+  "${missing_readme_repo}/README.md"
+assert_fails_with \
+  "${missing_readme_repo}" \
+  "Missing README canonical cross-phase boundary bullet"
+
+missing_child_repo="${workdir}/missing-child"
+copy_valid_repo "${missing_child_repo}"
+remove_doc_text "${missing_child_repo}" \
+  "| #1368 | Phase 64.3 operator limitation ownership surface | Closed. \`apps/operator-ui/src/app/operatorConsolePages/limitationOwnershipPages.tsx\`, route wiring, data-provider readers, list validators, and focused UI/data-provider tests prove operator visibility from backend-bound limitation records without browser, cache, UI, or workflow truth. |"
+assert_fails_with \
+  "${missing_child_repo}" \
+  "Missing Phase 64 child issue outcome row in Child Issue Outcomes table"
+
+missing_verifier_repo="${workdir}/missing-verifier"
+copy_valid_repo "${missing_verifier_repo}"
+remove_doc_text "${missing_verifier_repo}" \
+  "- \`python3 -m unittest control-plane.tests.test_phase64_limitation_ownership_control_plane\`"
+assert_fails_with \
+  "${missing_verifier_repo}" \
+  "Missing Phase 64 verifier evidence line in Verifier Evidence section"
+
+missing_issue_lint_repo="${workdir}/missing-issue-lint"
+copy_valid_repo "${missing_issue_lint_repo}"
+perl -0pi -e 's/- `node <codex-supervisor-root>\/dist\/index\.js issue-lint 1371 --config <supervisor-config-path>`.*\n//m' \
+  "${missing_issue_lint_repo}/docs/phase-64-closeout-evaluation.md"
+assert_fails_with \
+  "${missing_issue_lint_repo}" \
+  "Missing Phase 64 issue-lint evidence line in Issue-lint evidence section"
+
+missing_handoff_repo="${workdir}/missing-handoff"
+copy_valid_repo "${missing_handoff_repo}"
+remove_doc_text "${missing_handoff_repo}" \
+  "Phase 66 can consume Phase 64 as one RC evidence input for known limitation ownership."
+assert_fails_with \
+  "${missing_handoff_repo}" \
+  "Phase 66 can consume Phase 64 as one RC evidence input"
+
+missing_limitations_repo="${workdir}/missing-limitations"
+copy_valid_repo "${missing_limitations_repo}"
+remove_doc_text "${missing_limitations_repo}" \
+  "Phase 64 does not resolve limitations, close known limitation records, satisfy support-bundle evidence, accept release gates, approve RC gates, execute gate acceptance, prove Phase 66 RC readiness, prove Phase 67 GA readiness, or replace the Phase 51.3 gate contract."
+assert_fails_with \
+  "${missing_limitations_repo}" \
+  "Missing Phase 64 accepted limitations boundary"
+
+rc_ready_repo="${workdir}/rc-ready"
+copy_valid_repo "${rc_ready_repo}"
+printf '%s\n' "Phase 64 proves RC readiness." >>"${rc_ready_repo}/docs/phase-64-closeout-evaluation.md"
+assert_fails_with \
+  "${rc_ready_repo}" \
+  "Forbidden Phase 64 closeout evaluation claim: phase 64 proves rc readiness"
+
+support_complete_repo="${workdir}/support-complete"
+copy_valid_repo "${support_complete_repo}"
+printf '%s\n' "Support-bundle evidence is complete." >>"${support_complete_repo}/docs/phase-64-closeout-evaluation.md"
+assert_fails_with \
+  "${support_complete_repo}" \
+  "Forbidden Phase 64 closeout evaluation claim: support-bundle evidence is complete"
+
+ui_truth_repo="${workdir}/ui-truth"
+copy_valid_repo "${ui_truth_repo}"
+printf '%s\n' "UI display is limitation truth." >>"${ui_truth_repo}/docs/phase-64-closeout-evaluation.md"
+assert_fails_with \
+  "${ui_truth_repo}" \
+  "Forbidden Phase 64 closeout evaluation claim: ui display is limitation truth"
+
+ai_truth_repo="${workdir}/ai-truth"
+copy_valid_repo "${ai_truth_repo}"
+printf '%s\n' "AI summary is limitation truth." >>"${ai_truth_repo}/docs/phase-64-closeout-evaluation.md"
+assert_fails_with \
+  "${ai_truth_repo}" \
+  "Forbidden Phase 64 closeout evaluation claim: ai summary is limitation truth"
+
+verifier_truth_repo="${workdir}/verifier-truth"
+copy_valid_repo "${verifier_truth_repo}"
+printf '%s\n' "Verifier output is release truth." >>"${verifier_truth_repo}/docs/phase-64-closeout-evaluation.md"
+assert_fails_with \
+  "${verifier_truth_repo}" \
+  "Forbidden Phase 64 closeout evaluation claim: verifier output is release truth"
+
+secret_repo="${workdir}/secret"
+copy_valid_repo "${secret_repo}"
+printf '%s\n' "secret = actual-production-token" >>"${secret_repo}/docs/phase-64-closeout-evaluation.md"
+assert_fails_with \
+  "${secret_repo}" \
+  "production secret-looking value detected"
+
+path_repo="${workdir}/path"
+copy_valid_repo "${path_repo}"
+users_segment="Users"
+printf '%s\n' "Operator note mentions /${users_segment}/local/repo." >>"${path_repo}/docs/phase-64-closeout-evaluation.md"
+git -C "${path_repo}" add docs/phase-64-closeout-evaluation.md
+git -C "${path_repo}" commit -q -m "path"
+assert_fails_with \
+  "${path_repo}" \
+  "Forbidden Phase 64 closeout evaluation absolute path usage detected"
+
+echo "Phase 64.6 closeout verifier self-test passes."

--- a/scripts/verify-phase-64-6-closeout-evaluation.sh
+++ b/scripts/verify-phase-64-6-closeout-evaluation.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${1:-${default_repo_root}}"
+
+doc_path="docs/phase-64-closeout-evaluation.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+readme_path="${repo_root}/README.md"
+phase51_gate_path="${repo_root}/docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md"
+phase51_negative_path="${repo_root}/docs/phase-51-6-authority-boundary-negative-test-policy.md"
+phase63_closeout_path="${repo_root}/docs/phase-63-closeout-evaluation.md"
+phase64_contract_path="${repo_root}/docs/phase-64-1-known-limitation-ownership-record-contract.md"
+phase64_records_path="${repo_root}/docs/phase-64-1-reviewed-limitation-ownership-records.md"
+phase64_handoff_path="${repo_root}/docs/phase-64-5-phase66-limitation-handoff.md"
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -s "${path}" ]]; then
+    echo "Missing ${description}: ${path#"${repo_root}/"}" >&2
+    exit 1
+  fi
+}
+
+visible_markdown_text() {
+  local file="$1"
+
+  perl -0pe 's/<!--.*?-->//gs' "${file}"
+}
+
+require_phrase() {
+  local file="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" < <(visible_markdown_text "${file}"); then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+require_section_phrase() {
+  local section="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" <<<"${section}"; then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+section_text() {
+  local file="$1"
+  local heading="$2"
+  local next_heading="$3"
+
+  awk -v heading="${heading}" -v next_heading="${next_heading}" '
+    {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+    }
+    line == heading { in_section = 1 }
+    in_section {
+      if (next_heading != "" && (line == next_heading || index(line, next_heading) == 1)) {
+        exit
+      }
+      print
+    }
+  ' "${file}"
+}
+
+require_file "${absolute_doc_path}" "Phase 64 closeout evaluation"
+require_file "${readme_path}" "README for Phase 64 closeout link check"
+require_file "${phase51_gate_path}" "Phase 51.3 gate contract"
+require_file "${phase51_negative_path}" "Phase 51.6 authority-boundary negative test policy"
+require_file "${phase63_closeout_path}" "Phase 63 closeout evaluation"
+require_file "${phase64_contract_path}" "Phase 64.1 known limitation ownership contract"
+require_file "${phase64_records_path}" "Phase 64.1 reviewed limitation ownership records"
+require_file "${phase64_handoff_path}" "Phase 64.5 Phase 66 limitation handoff"
+
+require_phrase "${readme_path}" "- [Phase 64.6 closeout evaluation](docs/phase-64-closeout-evaluation.md)" "README canonical cross-phase boundary bullet"
+require_phrase "${readme_path}" "The Phase 64.6 closeout evaluation is defined by the [Phase 64.6 closeout evaluation](docs/phase-64-closeout-evaluation.md)." "README Product positioning reference"
+
+required_phrases=()
+while IFS= read -r phrase; do
+  required_phrases+=("${phrase}")
+done <<'EOF_PHRASE'
+# Phase 64 Closeout Evaluation
+**Status**: Accepted as Limitation Ownership evidence before Phase 66 RC proof, Beta, RC, GA, and commercial replacement-readiness claims.
+**Related Issues**: #1365, #1366, #1367, #1368, #1369, #1370, #1371
+Phase 64 Limitation Ownership is accepted for known limitation ownership records, validation and projection boundaries, operator limitation ownership surfaces, limitation-aware advisory and readiness context, Phase 66 limitation handoff evidence, and closeout evidence.
+AegisOps records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth.
+Limitation ownership documents, operator UI surfaces, advisory summaries, readiness projections, Phase 66 handoff notes, verifier output, and issue-lint output remain subordinate review and planning evidence only. They cannot approve, execute, reconcile, close, gate, resolve limitations, satisfy support evidence, or claim readiness by themselves.
+Phase 64 must reject missing child outcomes, missing verifier evidence, missing issue-lint evidence, missing Phase 66 handoff, workstation-local paths, production secrets, RC/GA readiness claims, commercial replacement readiness claims, limitation-resolution claims, support-bundle completion claims, verifier truth, issue-lint truth, UI truth, and AI truth.
+This closeout does not claim Phase 64 resolves known limitations, completes support-bundle evidence, proves Beta readiness, proves RC readiness, proves GA readiness, proves self-service commercial readiness, proves commercial replacement readiness, or satisfies Phase 66 RC gates.
+Focused Phase 64 and closeout verifiers that must pass:
+Issue-lint evidence:
+Each command should report `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, and `high_risk_blocking_ambiguity=none` before Phase 64 is considered fully closed.
+Issue-lint output is planning and metadata evidence only. It does not become release truth, closeout truth, workflow truth, limitation truth, gate truth, or readiness truth.
+Path hygiene rejects workstation-local absolute paths in publishable docs, scripts, tests, prompts, and validation output.
+Phase 66 can consume Phase 64 as one RC evidence input for known limitation ownership.
+Phase 66 must treat `docs/phase-64-1-reviewed-limitation-ownership-records.md` and `docs/phase-64-5-phase66-limitation-handoff.md` as subordinate limitation ownership evidence only.
+Phase 64 closeout is release and planning evidence only.
+EOF_PHRASE
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${absolute_doc_path}" "${phrase}" "required Phase 64 closeout term in ${doc_path}"
+done
+
+child_issue_outcomes="$(section_text "${absolute_doc_path}" "## Child Issue Outcomes" "## Changed Files")"
+required_child_rows=(
+  "| #1365 | Epic: Phase 64 Limitation Ownership | Open until #1371 lands; accepted when this closeout, focused verifiers, focused backend/UI/advisory/readiness tests, authority-boundary checks, maintainability check, publishable path hygiene, and issue-lint pass. |"
+  "| #1366 | Phase 64.1 known limitation ownership record contract | Closed. \`docs/phase-64-1-known-limitation-ownership-record-contract.md\`, validation notes, PostgreSQL schema, record-family registration, lifecycle history, and focused tests prove reviewed \`known_limitation_ownership\` records without limitation resolution, release truth, gate truth, verifier truth, or issue-lint truth. |"
+  "| #1367 | Phase 64.2 limitation ownership validation projection | Closed. \`control-plane/aegisops/control_plane/inspection/limitation_ownership_projection.py\`, validator tightening, and focused backend tests prove current-review and projection boundaries for limitation ownership records while rejecting stale, malformed, missing, and authority-bearing context. |"
+  "| #1368 | Phase 64.3 operator limitation ownership surface | Closed. \`apps/operator-ui/src/app/operatorConsolePages/limitationOwnershipPages.tsx\`, route wiring, data-provider readers, list validators, and focused UI/data-provider tests prove operator visibility from backend-bound limitation records without browser, cache, UI, or workflow truth. |"
+  "| #1369 | Phase 64.4 limitation-aware advisory and readiness context | Closed. \`control-plane/aegisops/control_plane/assistant/cited_recommendation_draft.py\`, \`control-plane/aegisops/control_plane/runtime/restore_readiness_projection.py\`, and focused advisory/readiness tests prove limitation context can appear as directly linked subordinate advisory and readiness input without AI truth, readiness truth, or gate acceptance. |"
+  "| #1370 | Phase 64.5 Phase 66 limitation handoff | Closed. \`docs/phase-64-5-phase66-limitation-handoff.md\`, reviewed limitation records, focused handoff verifier, and verifier self-test prove Phase 66 can consume limitation ownership records only as subordinate RC proof planning evidence. |"
+  "| #1371 | Phase 64.6 Phase 64 closeout evaluation | Open until this document and focused closeout verifier land. |"
+)
+
+for row in "${required_child_rows[@]}"; do
+  require_section_phrase "${child_issue_outcomes}" "${row}" "Phase 64 child issue outcome row in Child Issue Outcomes table"
+done
+
+verifier_evidence="$(section_text "${absolute_doc_path}" "## Verifier Evidence" "## Issue-Lint Summary")"
+required_verifier_lines=(
+  "- \`bash scripts/verify-phase-64-1-known-limitation-ownership-record-contract.sh\`"
+  "- \`bash scripts/verify-phase-64-5-phase66-limitation-handoff.sh\`"
+  "- \`bash scripts/test-verify-phase-64-5-phase66-limitation-handoff.sh\`"
+  "- \`bash scripts/verify-phase-64-6-closeout-evaluation.sh\`"
+  "- \`bash scripts/test-verify-phase-64-6-closeout-evaluation.sh\`"
+  "- \`bash scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh\`"
+  "- \`bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh\`"
+  "- \`bash scripts/verify-maintainability-hotspots.sh\`"
+  "- \`bash scripts/verify-publishable-path-hygiene.sh\`"
+  "- \`python3 -m unittest control-plane.tests.test_phase64_known_limitation_ownership_contract\`"
+  "- \`python3 -m unittest control-plane.tests.test_phase64_limitation_ownership_control_plane\`"
+  "- \`python3 -m unittest control-plane.tests.test_phase60_6_cited_recommendation_draft_agent\`"
+  "- \`python3 -m unittest control-plane.tests.test_service_readiness_projection\`"
+  "- \`npm run test --workspace @aegisops/operator-ui -- OperatorRoutes.test.tsx\`"
+  "- \`npm run test --workspace @aegisops/operator-ui -- dataProvider.test.ts\`"
+  "- \`npm run typecheck --workspace @aegisops/operator-ui\`"
+)
+
+for line in "${required_verifier_lines[@]}"; do
+  require_section_phrase "${verifier_evidence}" "${line}" "Phase 64 verifier evidence line in Verifier Evidence section"
+done
+
+issue_lint_evidence="$(section_text "${absolute_doc_path}" "Issue-lint evidence:" "Each command should report")"
+for issue_number in 1365 1366 1367 1368 1369 1370 1371; do
+  issue_lint_line="- \`node <codex-supervisor-root>/dist/index.js issue-lint ${issue_number} --config <supervisor-config-path>\`"
+  require_section_phrase "${issue_lint_evidence}" "${issue_lint_line}" "Phase 64 issue-lint evidence line in Issue-lint evidence section"
+done
+
+accepted_limitations="$(section_text "${absolute_doc_path}" "## Accepted Limitations" "## Phase 66 Handoff")"
+require_section_phrase "${accepted_limitations}" "Phase 64 does not resolve limitations, close known limitation records, satisfy support-bundle evidence, accept release gates, approve RC gates, execute gate acceptance, prove Phase 66 RC readiness, prove Phase 67 GA readiness, or replace the Phase 51.3 gate contract." "Phase 64 accepted limitations boundary"
+require_section_phrase "${accepted_limitations}" "Phase 64 limitation ownership records, validation projections, operator UI surfaces, advisory context, readiness context, handoff notes, verifier output, and issue-lint output are context only; they do not replace authoritative AegisOps alert, case, evidence request, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, or closeout records." "Phase 64 subordinate limitation context boundary"
+
+phase66_handoff="$(section_text "${absolute_doc_path}" "## Phase 66 Handoff" "")"
+require_section_phrase "${phase66_handoff}" "Phase 66 can consume Phase 64 as one RC evidence input for known limitation ownership." "Phase 66 handoff consumption note"
+require_section_phrase "${phase66_handoff}" "Phase 66 must treat \`docs/phase-64-1-reviewed-limitation-ownership-records.md\` and \`docs/phase-64-5-phase66-limitation-handoff.md\` as subordinate limitation ownership evidence only." "Phase 66 subordinate handoff boundary"
+
+forbidden_claims=(
+  "phase 64 resolves known limitations"
+  "known limitations are resolved"
+  "support-bundle evidence is complete"
+  "support bundle evidence is complete"
+  "phase 64 proves beta readiness"
+  "phase 64 proves rc readiness"
+  "phase 64 proves ga readiness"
+  "phase 64 proves commercial replacement readiness"
+  "phase 64 satisfies phase 66 rc gates"
+  "phase 66 rc gates are satisfied"
+  "aegisops is beta"
+  "aegisops is rc"
+  "aegisops is ga"
+  "aegisops is self-service commercially ready"
+  "aegisops is a commercial replacement for every siem/soar capability"
+  "limitation ownership records are release truth"
+  "limitation ownership records are gate truth"
+  "limitation ownership records are readiness truth"
+  "limitation ownership records resolve limitations"
+  "operator ui is limitation truth"
+  "ui display is limitation truth"
+  "ai summary is limitation truth"
+  "readiness projection is gate truth"
+  "verifier output is release truth"
+  "verifier output is readiness truth"
+  "issue-lint output is release truth"
+  "issue-lint output is readiness truth"
+)
+
+allowed_non_claim_line="This closeout does not claim Phase 64 resolves known limitations, completes support-bundle evidence, proves Beta readiness, proves RC readiness, proves GA readiness, proves self-service commercial readiness, proves commercial replacement readiness, or satisfies Phase 66 RC gates."
+allowed_non_claim_line_lower="$(printf '%s' "${allowed_non_claim_line}" | tr '[:upper:]' '[:lower:]')"
+required_issue_lint_boundary_line="Issue-lint output is planning and metadata evidence only. It does not become release truth, closeout truth, workflow truth, limitation truth, gate truth, or readiness truth."
+required_issue_lint_boundary_line_lower="$(printf '%s' "${required_issue_lint_boundary_line}" | tr '[:upper:]' '[:lower:]')"
+
+while IFS= read -r line; do
+  line_lower="$(printf '%s' "${line}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${line_lower}" == "${allowed_non_claim_line_lower}" || "${line_lower}" == "${required_issue_lint_boundary_line_lower}" ]]; then
+    continue
+  fi
+  for claim in "${forbidden_claims[@]}"; do
+    if [[ "${line_lower}" == *"${claim}"* ]]; then
+      echo "Forbidden Phase 64 closeout evaluation claim: ${claim}" >&2
+      exit 1
+    fi
+  done
+done < "${absolute_doc_path}"
+
+if grep -Eiq -- '(AKIA[0-9A-Z]{16}|aws_secret_access_key|BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|ghp_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|password[[:space:]]*=[[:space:]]*[^<[:space:]]+|secret[[:space:]]*=[[:space:]]*[^<[:space:]]+)' "${absolute_doc_path}"; then
+  echo "Forbidden Phase 64 closeout evaluation: production secret-looking value detected" >&2
+  exit 1
+fi
+
+path_hygiene_stderr="${repo_root}/.tmp-phase64-6-path-hygiene.err"
+trap 'rm -f "${path_hygiene_stderr}"' EXIT
+if ! bash "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" >/dev/null 2>"${path_hygiene_stderr}"; then
+  cat "${path_hygiene_stderr}" >&2
+  echo "Forbidden Phase 64 closeout evaluation absolute path usage detected" >&2
+  exit 1
+fi
+
+echo "Phase 64.6 closeout evaluation contract and focused negative checks pass."

--- a/scripts/verify-phase-64-6-closeout-evaluation.sh
+++ b/scripts/verify-phase-64-6-closeout-evaluation.sh
@@ -46,8 +46,11 @@ require_section_phrase() {
   local section="$1"
   local phrase="$2"
   local description="$3"
+  local visible_section
 
-  if ! grep -Fq -- "${phrase}" <<<"${section}"; then
+  visible_section="$(perl -0pe 's/<!--.*?-->//gs' <<<"${section}")"
+
+  if ! grep -Fq -- "${phrase}" <<<"${visible_section}"; then
     echo "Missing ${description}: ${phrase}" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
- Add the Phase 64 closeout evaluation with child outcomes, verifier evidence, accepted limitations, and Phase 66 handoff boundaries.
- Add a focused Phase 64.6 closeout verifier and negative-case self-test.
- Link the closeout from the README cross-phase boundary index.

## Verification
- bash scripts/verify-phase-64-6-closeout-evaluation.sh
- bash scripts/test-verify-phase-64-6-closeout-evaluation.sh
- bash scripts/verify-phase-64-1-known-limitation-ownership-record-contract.sh
- bash scripts/verify-phase-64-5-phase66-limitation-handoff.sh
- bash scripts/test-verify-phase-64-5-phase66-limitation-handoff.sh
- bash scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh
- bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh
- bash scripts/verify-maintainability-hotspots.sh
- bash scripts/verify-publishable-path-hygiene.sh
- python3 -m unittest control-plane.tests.test_phase64_known_limitation_ownership_contract
- python3 -m unittest control-plane.tests.test_phase64_limitation_ownership_control_plane
- python3 -m unittest control-plane.tests.test_phase60_6_cited_recommendation_draft_agent
- python3 -m unittest control-plane.tests.test_service_readiness_projection
- npm run test --workspace @aegisops/operator-ui -- OperatorRoutes.test.tsx
- npm run test --workspace @aegisops/operator-ui -- dataProvider.test.ts
- npm run typecheck --workspace @aegisops/operator-ui
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1365 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.codex.json
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1366 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.codex.json
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1367 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.codex.json
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1368 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.codex.json
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1369 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.codex.json
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1370 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.codex.json
- node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1371 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.codex.json