### PR TITLE
[codex] Add Phase 66.1 clean-host RC E2E harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Canonical cross-phase boundary reference:
 - [Phase 65.7 standalone Wazuh migration guide](docs/migration/phase-65-7-standalone-wazuh-migration-guide.md), [standalone Shuffle migration guide](docs/migration/phase-65-7-standalone-shuffle-migration-guide.md), and [manual SOC/ticket workflow migration guide](docs/migration/phase-65-7-manual-soc-ticket-workflow-migration-guide.md) define beta/design-partner migration planning guidance that preserves subordinate-source and authority boundaries without automated migration, production customer-data import, RC, GA, or commercial replacement readiness claims.
 - [Phase 65.8 beta known-limitations template](docs/deployment/release/phase-65-8-beta-known-limitations-template.md) and [design-partner evidence template](docs/deployment/release/phase-65-8-design-partner-evidence-template.md) define beta/design-partner evidence-capture scaffolds for owners, dates, limitation links, evidence references, blocker disposition, support-bundle posture, upgrade posture, accepted risk, and next review dates without real beta evidence, RC, GA, or commercial replacement readiness claims.
 - [Phase 65.9 closeout evaluation](docs/phase-65-closeout-evaluation.md) records the Commercial Packaging and Beta boundary outcomes, subordinate authority posture, verifier evidence, issue-lint evidence, accepted limitations, and bounded Phase 66 handoff without RC, GA, real design-partner success, or commercial replacement claims.
+- [Phase 66.1 clean-host RC E2E harness](docs/phase-66-1-clean-host-rc-e2e-harness.md) defines the clean-host release-candidate journey contract from setup through report export while preserving Phase 65 as input evidence only and excluding GA, production rollout, self-service commercial, and broad SIEM/SOAR parity claims.
 - [Phase 58.5 upgrade and rollback plan contract](docs/phase-58-5-upgrade-rollback-plan-contract.md) defines reviewed upgrade-plan and rollback-plan evidence fields, failure states, and authority boundaries without implementing live upgrade or rollback execution.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
@@ -101,6 +102,8 @@ The Phase 51.4 SMB personas and jobs-to-be-done matrix is defined by the [Phase 
 The Phase 51.5 competitive gap matrix is defined by the [Phase 51.5 competitive gap matrix](docs/phase-51-5-competitive-gap-matrix.md).
 
 The Phase 51.6 authority-boundary negative-test policy is defined by the [Phase 51.6 authority-boundary negative-test policy](docs/phase-51-6-authority-boundary-negative-test-policy.md).
+
+The Phase 66.1 clean-host RC E2E harness is defined by the [Phase 66.1 clean-host RC E2E harness](docs/phase-66-1-clean-host-rc-e2e-harness.md).
 
 The Phase 52.1 first-user CLI command contract is defined by the [Phase 52.1 CLI command contract](docs/phase-52-1-cli-command-contract.md).
 

--- a/docs/phase-66-1-clean-host-rc-e2e-harness.md
+++ b/docs/phase-66-1-clean-host-rc-e2e-harness.md
@@ -1,0 +1,102 @@
+# Phase 66.1 Clean-Host RC E2E Harness
+
+- **Status**: Accepted as the Phase 66.1 clean-host RC E2E harness contract for release-candidate proof planning only.
+- **Date**: 2026-06-08
+- **Owners**: AegisOps maintainers
+- **Related Baseline**: `docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`, `docs/phase-65-closeout-evaluation.md`, `docs/getting-started/first-user-journey.md`, `docs/getting-started/first-user-demo-report-export.md`
+- **Related Issues**: #1397, #1398
+
+This contract defines the Phase 66.1 clean-host RC E2E harness shape for the first release-candidate replacement-readiness journey. It binds the documented first-user stack path to one reviewed proof surface from setup through report export.
+
+Phase 65 packaging evidence is input only. It can supply release-bundle, offline-bundle, upgrade, integrity, licensing, documentation, migration, limitation, design-partner template, verifier, and issue-lint context, but it does not satisfy the Phase 66.1 clean-host RC E2E harness by itself.
+
+## 1. Harness Purpose
+
+The harness proves that a documented clean-host profile can collect one bounded RC journey packet for `init -> up -> doctor -> seed-demo -> UI workflow -> report export`.
+
+The harness is proof evidence only. It records required commands, operator-visible workflow steps, evidence fields, failure boundaries, verifier coverage, and non-claims for the RC journey. It does not implement production deployment automation, GA readiness, real design-partner success, production rollout readiness, broad SIEM/SOAR parity, hosted update service readiness, or autonomous workflow authority.
+
+## 2. Clean-Host Profile
+
+The clean-host profile must record these fields before the journey starts:
+
+| Field | Required value or evidence | Failure boundary |
+| --- | --- | --- |
+| `journey_run_id` | Stable identifier for the reviewed RC E2E run. | Missing or reused run identifiers fail the harness. |
+| `repository_revision` | Immutable repository revision for the harness run. | Mutable branch names fail the harness. |
+| `profile` | `smb-single-node`. | Any other profile must be handled by a later contract. |
+| `environment_class` | `clean-host-rc-e2e`. | Unlabeled local developer state fails the harness. |
+| `runtime_env_reference` | Repo-relative placeholder such as `<runtime-env-file>`. | Workstation-local paths and raw secret material fail the harness. |
+| `operator_role` | Human operator or maintainer role that performed the run. | Browser state or UI cache cannot stand in for operator identity. |
+| `evidence_dir` | Repo-relative placeholder such as `<evidence-dir>`. | Untracked local paths cannot become proof evidence. |
+| `phase65_input_references` | Phase 65 closeout and packaging artifacts consumed as subordinate input. | Phase 65 closure cannot satisfy RC E2E by inference. |
+
+## 3. Required Journey Steps
+
+The harness must cover every step in this order.
+
+| Order | Required step | Evidence required | Failure boundary |
+| --- | --- | --- | --- |
+| 1 | `aegisops init --profile smb-single-node` | Command, profile, revision, generated placeholder summary, and preflight outcome. | Missing profile or unsafe prerequisite must fail closed. |
+| 2 | `aegisops up --with-wazuh --with-shuffle` | Component start result for AegisOps, Wazuh, Shuffle, and proxy-facing access path. | Mocked, skipped, or blocked components must stay explicit. |
+| 3 | `aegisops doctor` | Product health, Wazuh health, Shuffle health, queue readiness, evidence storage, and report export readiness. | Doctor output is readiness evidence only, not workflow truth. |
+| 4 | `aegisops seed-demo` | Demo seed identifier, demo-only labels, sample alert references, and reset posture. | Demo data cannot become production, gate, or workflow truth. |
+| 5 | Login | Operator role, selected profile, visible demo or RC labels, and access result. | Browser state and session state remain subordinate context. |
+| 6 | Health review | Reviewed health records for AegisOps, Wazuh source health, Shuffle availability, AI posture, and supportability posture. | Dashboard status cannot replace AegisOps readiness records. |
+| 7 | Queue item | Queue item identifier, source, severity, identity or asset context, and demo or RC label. | Queue text cannot create an alert without AegisOps admission. |
+| 8 | Wazuh-origin signal inspection | Wazuh signal identifier, source-health reference, AegisOps alert identifier, admission review, and provenance link. | Raw Wazuh state remains subordinate detection signal evidence. |
+| 9 | Case promotion | Case identifier, alert binding, human decision, and case status. | Wazuh, UI, ticket, or AI state cannot promote a case. |
+| 10 | Evidence review | Evidence identifiers, freshness, provenance, binding to alert and case, and unavailable follow-up when missing. | Evidence systems remain subordinate custody context. |
+| 11 | AI trace review | AI trace identifier, cited sources, advisory output, human accepted/rejected/unresolved decision, and refused autonomous action scope. | AI cannot approve, execute, reconcile, close, activate detectors, or define source truth. |
+| 12 | Action request | Action request identifier, target, action class, policy, protected-state boundary, and required approval. | Request text alone cannot execute an action. |
+| 13 | Approval | Approval decision identifier, approver role, separation from executor, scope, and timestamp. | Approval cannot be inferred from comments, tickets, or UI state. |
+| 14 | Shuffle delegation receipt | Shuffle workflow identifier, delegated action request, execution receipt, callback or receipt reference, and mismatch handling. | Shuffle success cannot become reconciliation truth. |
+| 15 | Reconciliation | Reconciliation identifier, approved request, execution receipt, compared result, mismatch outcome, and rollback or follow-up owner. | Reconciliation cannot be inferred from downstream status. |
+| 16 | Report export | Export command, export artifact reference, schema version, redaction review, source record identifiers, and non-secret result. | Reports are derived surfaces and cannot replace source records. |
+| 17 | Next-step guidance | Known limitations, blocker owner, supportability follow-up, Phase 66 continuation, and Phase 67 prerequisite reminder. | Next-step guidance cannot accept RC or GA gates by itself. |
+
+## 4. Evidence Packet Fields
+
+Every Phase 66.1 packet must include these field families:
+
+| Family | Required fields | Authority rule |
+| --- | --- | --- |
+| Install evidence | `journey_run_id`, `repository_revision`, `profile`, `environment_class`, `runtime_env_reference`, `operator_role`, `evidence_dir`. | Install success is accepted only as setup evidence. |
+| Wazuh signal evidence | `wazuh_signal_id`, `source_health_reference`, `aegisops_alert_id`, `admission_review_id`, `provenance_reference`. | Wazuh remains subordinate detection signal evidence. |
+| Shuffle execution evidence | `shuffle_workflow_id`, `action_request_id`, `approval_decision_id`, `execution_receipt_id`, `reconciliation_id`. | Shuffle remains subordinate delegated execution evidence. |
+| AI trace evidence | `ai_trace_id`, `citation_set`, `reviewed_recommendation_id`, `human_decision`, `autonomous_action_refusal`. | AI remains advisory-only evidence. |
+| Report export evidence | `export_command`, `export_artifact_reference`, `report_schema_version`, `redaction_review_id`, `source_record_ids`. | Reports remain derived evidence surfaces. |
+| Supportability evidence | `doctor_result_id`, `support_bundle_posture`, `backup_restore_posture`, `upgrade_plan_reference`, `known_limitation_ids`. | Supportability evidence cannot become gate truth. |
+| Limitation evidence | `limitation_id`, `owner`, `accepted_or_refused_reason`, `decision_date`, `follow_up_date`. | Limitations remain explicit AegisOps-owned records. |
+
+Missing, malformed, mixed-snapshot, placeholder-backed where a concrete reviewed identifier is required, or subordinate-authority evidence blocks the harness until it is supplied or explicitly refused with an owner and follow-up date.
+
+## 5. Authority Boundary
+
+AegisOps records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth.
+
+Wazuh, Shuffle, AI, reports, UI state, browser state, verifier output, issue-lint output, release artifacts, demo data, tickets, evidence systems, dashboards, support bundles, and downstream receipts remain subordinate context. They cannot approve, execute, reconcile, close, accept limitations, accept RC gates, accept GA gates, or become workflow truth by themselves.
+
+The harness must reject missing journey steps, missing evidence fields, missing authority boundaries, missing limitations, workstation-local paths, production secrets, customer-private data, inferred RC pass, inferred GA pass, self-service commercial readiness claims, production rollout readiness claims, broad SIEM/SOAR parity claims, verifier-as-readiness-truth, and issue-lint-as-readiness-truth.
+
+## 6. Accepted Limitations
+
+Phase 66.1 proves the harness shape and evidence contract for one bounded clean-host RC E2E path. It does not collect real design-partner evidence, prove real design-partner success, complete support-bundle review, complete restore dry-run proof, complete upgrade rehearsal proof, approve production rollout, approve self-service commercial readiness, or satisfy Phase 67 GA readiness.
+
+Later Phase 66 issues must still prove Wazuh sample signal, Shuffle sample execution, AI-assisted triage, report export, supportability, authority-boundary negative tests, and closeout evidence independently.
+
+## 7. Verification
+
+Run `bash scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh`.
+
+Run `bash scripts/test-verify-phase-66-1-clean-host-rc-e2e-harness.sh`.
+
+Run `bash scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh`.
+
+Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1397 --config <supervisor-config-path>`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1398 --config <supervisor-config-path>`.

--- a/docs/phase-66-1-clean-host-rc-e2e-harness.md
+++ b/docs/phase-66-1-clean-host-rc-e2e-harness.md
@@ -1,7 +1,7 @@
 # Phase 66.1 Clean-Host RC E2E Harness
 
 - **Status**: Accepted as the Phase 66.1 clean-host RC E2E harness contract for release-candidate proof planning only.
-- **Date**: 2026-06-08
+- **Date**: 2026-06-08 Asia/Tokyo
 - **Owners**: AegisOps maintainers
 - **Related Baseline**: `docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md`, `docs/phase-51-6-authority-boundary-negative-test-policy.md`, `docs/phase-65-closeout-evaluation.md`, `docs/getting-started/first-user-journey.md`, `docs/getting-started/first-user-demo-report-export.md`
 - **Related Issues**: #1397, #1398
@@ -37,10 +37,10 @@ The harness must cover every step in this order.
 
 | Order | Required step | Evidence required | Failure boundary |
 | --- | --- | --- | --- |
-| 1 | `aegisops init --profile smb-single-node` | Command, profile, revision, generated placeholder summary, and preflight outcome. | Missing profile or unsafe prerequisite must fail closed. |
-| 2 | `aegisops up --with-wazuh --with-shuffle` | Component start result for AegisOps, Wazuh, Shuffle, and proxy-facing access path. | Mocked, skipped, or blocked components must stay explicit. |
-| 3 | `aegisops doctor` | Product health, Wazuh health, Shuffle health, queue readiness, evidence storage, and report export readiness. | Doctor output is readiness evidence only, not workflow truth. |
-| 4 | `aegisops seed-demo` | Demo seed identifier, demo-only labels, sample alert references, and reset posture. | Demo data cannot become production, gate, or workflow truth. |
+| 1 | `aegisops init --profile smb-single-node --runtime-env <runtime-env-file>` | Command, profile, revision, generated placeholder summary, and preflight outcome. | Missing profile or unsafe prerequisite must fail closed. |
+| 2 | `aegisops up --profile smb-single-node --runtime-env <runtime-env-file>` | Component start result for AegisOps, Wazuh, Shuffle, and proxy-facing access path. | Mocked, skipped, or blocked components must stay explicit. |
+| 3 | `aegisops doctor --profile smb-single-node --runtime-env <runtime-env-file>` | Product health, Wazuh health, Shuffle health, queue readiness, evidence storage, and report export readiness. | Doctor output is readiness evidence only, not workflow truth. |
+| 4 | `aegisops seed-demo --profile smb-single-node --demo-mode explicit` | Demo seed identifier, demo-only labels, sample alert references, and reset posture. | Demo data cannot become production, gate, or workflow truth. |
 | 5 | Login | Operator role, selected profile, visible demo or RC labels, and access result. | Browser state and session state remain subordinate context. |
 | 6 | Health review | Reviewed health records for AegisOps, Wazuh source health, Shuffle availability, AI posture, and supportability posture. | Dashboard status cannot replace AegisOps readiness records. |
 | 7 | Queue item | Queue item identifier, source, severity, identity or asset context, and demo or RC label. | Queue text cannot create an alert without AegisOps admission. |

--- a/scripts/test-verify-phase-66-1-clean-host-rc-e2e-harness.sh
+++ b/scripts/test-verify-phase-66-1-clean-host-rc-e2e-harness.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fiq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+copy_repo_path() {
+  local target="$1"
+  local relative_path="$2"
+
+  mkdir -p "${target}/$(dirname "${relative_path}")"
+  cp -p "${repo_root}/${relative_path}" "${target}/${relative_path}"
+}
+
+copy_valid_repo() {
+  local target="$1"
+  local path
+
+  mkdir -p "${target}"
+  copy_repo_path "${target}" "README.md"
+  copy_repo_path "${target}" "docs/phase-66-1-clean-host-rc-e2e-harness.md"
+  copy_repo_path "${target}" "control-plane/aegisops/control_plane/publishable_paths.py"
+  : >"${target}/control-plane/aegisops/__init__.py"
+  : >"${target}/control-plane/aegisops/control_plane/__init__.py"
+
+  for path in \
+    "docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md" \
+    "docs/phase-51-6-authority-boundary-negative-test-policy.md" \
+    "docs/phase-65-closeout-evaluation.md" \
+    "docs/getting-started/first-user-journey.md" \
+    "docs/getting-started/first-user-demo-report-export.md"; do
+    copy_repo_path "${target}" "${path}"
+  done
+
+  for path in \
+    "scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh" \
+    "scripts/test-verify-phase-66-1-clean-host-rc-e2e-harness.sh" \
+    "scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh" \
+    "scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh" \
+    "scripts/verify-publishable-path-hygiene.sh"; do
+    copy_repo_path "${target}" "${path}"
+  done
+
+  git -C "${target}" init -q
+  git -C "${target}" config user.email "aegisops@example.invalid"
+  git -C "${target}" config user.name "AegisOps Test"
+  git -C "${target}" add README.md docs scripts control-plane/aegisops
+  git -C "${target}" commit -q -m "fixture"
+}
+
+remove_doc_text() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
+}
+
+comment_doc_text() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E/<!-- $ENV{TEXT} -->/g' \
+    "${target}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+copy_valid_repo "${missing_doc_repo}"
+rm "${missing_doc_repo}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
+assert_fails_with "${missing_doc_repo}" "Missing Phase 66.1 clean-host RC E2E harness"
+
+missing_reference_repo="${workdir}/missing-reference"
+copy_valid_repo "${missing_reference_repo}"
+rm "${missing_reference_repo}/docs/phase-65-closeout-evaluation.md"
+assert_fails_with "${missing_reference_repo}" "Missing Phase 66.1 reference docs/phase-65-closeout-evaluation.md"
+
+missing_readme_repo="${workdir}/missing-readme"
+copy_valid_repo "${missing_readme_repo}"
+perl -0pi -e 's/- \[Phase 66\.1 clean-host RC E2E harness\]\(docs\/phase-66-1-clean-host-rc-e2e-harness\.md\)[^\n]*\n//m' \
+  "${missing_readme_repo}/README.md"
+assert_fails_with "${missing_readme_repo}" "Missing README canonical Phase 66.1 boundary bullet"
+
+missing_profile_repo="${workdir}/missing-profile-field"
+copy_valid_repo "${missing_profile_repo}"
+remove_doc_text "${missing_profile_repo}" \
+  "| \`phase65_input_references\` | Phase 65 closeout and packaging artifacts consumed as subordinate input. | Phase 65 closure cannot satisfy RC E2E by inference. |"
+assert_fails_with "${missing_profile_repo}" "Missing Phase 66.1 clean-host profile field"
+
+commented_profile_repo="${workdir}/commented-profile-field"
+copy_valid_repo "${commented_profile_repo}"
+comment_doc_text "${commented_profile_repo}" \
+  "| \`phase65_input_references\` | Phase 65 closeout and packaging artifacts consumed as subordinate input. | Phase 65 closure cannot satisfy RC E2E by inference. |"
+assert_fails_with "${commented_profile_repo}" "Missing Phase 66.1 clean-host profile field"
+
+missing_journey_step_repo="${workdir}/missing-journey-step"
+copy_valid_repo "${missing_journey_step_repo}"
+remove_doc_text "${missing_journey_step_repo}" "Wazuh-origin signal inspection"
+assert_fails_with "${missing_journey_step_repo}" "Missing Phase 66.1 required journey step"
+
+missing_evidence_field_repo="${workdir}/missing-evidence-field"
+copy_valid_repo "${missing_evidence_field_repo}"
+remove_doc_text "${missing_evidence_field_repo}" \
+  "\`shuffle_workflow_id\`, \`action_request_id\`, \`approval_decision_id\`, \`execution_receipt_id\`, \`reconciliation_id\`."
+assert_fails_with "${missing_evidence_field_repo}" "Missing Phase 66.1 evidence packet field group"
+
+missing_limitations_repo="${workdir}/missing-limitations"
+copy_valid_repo "${missing_limitations_repo}"
+remove_doc_text "${missing_limitations_repo}" \
+  "It does not collect real design-partner evidence, prove real design-partner success, complete support-bundle review, complete restore dry-run proof, complete upgrade rehearsal proof, approve production rollout, approve self-service commercial readiness, or satisfy Phase 67 GA readiness."
+assert_fails_with "${missing_limitations_repo}" "Missing Phase 66.1 accepted limitations boundary"
+
+missing_verifier_script_repo="${workdir}/missing-verifier-script"
+copy_valid_repo "${missing_verifier_script_repo}"
+rm "${missing_verifier_script_repo}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+assert_fails_with "${missing_verifier_script_repo}" "Missing Phase 66.1 verifier script scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+
+ga_ready_repo="${workdir}/ga-ready"
+copy_valid_repo "${ga_ready_repo}"
+printf '%s\n' "Phase 66.1 proves GA readiness." >>"${ga_ready_repo}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
+assert_fails_with "${ga_ready_repo}" "Forbidden Phase 66.1 clean-host RC E2E harness claim matched"
+
+commercial_ready_repo="${workdir}/commercial-ready"
+copy_valid_repo "${commercial_ready_repo}"
+printf '%s\n' "AegisOps is a self-service commercial replacement after this harness." >>"${commercial_ready_repo}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
+assert_fails_with "${commercial_ready_repo}" "Forbidden Phase 66.1 clean-host RC E2E harness claim matched"
+
+ai_authority_repo="${workdir}/ai-authority"
+copy_valid_repo "${ai_authority_repo}"
+printf '%s\n' "AI approves the action during this harness." >>"${ai_authority_repo}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
+assert_fails_with "${ai_authority_repo}" "Forbidden Phase 66.1 clean-host RC E2E harness claim matched"
+
+secret_repo="${workdir}/secret"
+copy_valid_repo "${secret_repo}"
+printf '%s\n' "token: abcdefghijklmnop" >>"${secret_repo}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
+assert_fails_with "${secret_repo}" "production secret-looking value detected"
+
+customer_private_repo="${workdir}/customer-private"
+copy_valid_repo "${customer_private_repo}"
+printf '%s\n' "The packet includes customer-private alert export." >>"${customer_private_repo}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
+assert_fails_with "${customer_private_repo}" "customer-private data detected"
+
+local_path_repo="${workdir}/local-path"
+copy_valid_repo "${local_path_repo}"
+printf 'Evidence path: /%s/example/aegisops/private\n' "Users" >>"${local_path_repo}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
+assert_fails_with "${local_path_repo}" "absolute path"
+
+echo "Phase 66.1 clean-host RC E2E harness verifier self-test passed."

--- a/scripts/test-verify-phase-66-1-clean-host-rc-e2e-harness.sh
+++ b/scripts/test-verify-phase-66-1-clean-host-rc-e2e-harness.sh
@@ -139,6 +139,15 @@ copy_valid_repo "${missing_journey_step_repo}"
 remove_doc_text "${missing_journey_step_repo}" "Wazuh-origin signal inspection"
 assert_fails_with "${missing_journey_step_repo}" "Missing Phase 66.1 required journey step"
 
+out_of_order_journey_repo="${workdir}/out-of-order-journey"
+copy_valid_repo "${out_of_order_journey_repo}"
+report_export_row="| 16 | Report export | Export command, export artifact reference, schema version, redaction review, source record identifiers, and non-secret result. | Reports are derived surfaces and cannot replace source records. |"
+login_row="| 5 | Login | Operator role, selected profile, visible demo or RC labels, and access result. | Browser state and session state remain subordinate context. |"
+remove_doc_text "${out_of_order_journey_repo}" "${report_export_row}"
+LOGIN_ROW="${login_row}" REPORT_EXPORT_ROW="${report_export_row}" perl -0pi -e 's/\Q$ENV{LOGIN_ROW}\E/$ENV{REPORT_EXPORT_ROW}\n$ENV{LOGIN_ROW}/' \
+  "${out_of_order_journey_repo}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
+assert_fails_with "${out_of_order_journey_repo}" "Missing ordered Phase 66.1 required journey step"
+
 missing_evidence_field_repo="${workdir}/missing-evidence-field"
 copy_valid_repo "${missing_evidence_field_repo}"
 remove_doc_text "${missing_evidence_field_repo}" \
@@ -160,6 +169,16 @@ ga_ready_repo="${workdir}/ga-ready"
 copy_valid_repo "${ga_ready_repo}"
 printf '%s\n' "Phase 66.1 proves GA readiness." >>"${ga_ready_repo}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
 assert_fails_with "${ga_ready_repo}" "Forbidden Phase 66.1 clean-host RC E2E harness claim matched"
+
+negation_bypass_repo="${workdir}/negation-bypass"
+copy_valid_repo "${negation_bypass_repo}"
+printf '%s\n' "No operator review occurred; Phase 66.1 proves GA readiness." >>"${negation_bypass_repo}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
+assert_fails_with "${negation_bypass_repo}" "Forbidden Phase 66.1 clean-host RC E2E harness claim matched"
+
+readme_overclaim_repo="${workdir}/readme-overclaim"
+copy_valid_repo "${readme_overclaim_repo}"
+printf '%s\n' "Phase 66.1 proves GA readiness." >>"${readme_overclaim_repo}/README.md"
+assert_fails_with "${readme_overclaim_repo}" "Forbidden Phase 66.1 README claim matched"
 
 commercial_ready_repo="${workdir}/commercial-ready"
 copy_valid_repo "${commercial_ready_repo}"

--- a/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh
+++ b/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+repo_root="$(cd "${repo_root}" && pwd -P)"
+
+doc_path="docs/phase-66-1-clean-host-rc-e2e-harness.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+readme_path="${repo_root}/README.md"
+
+required_reference_paths=(
+  "docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md"
+  "docs/phase-51-6-authority-boundary-negative-test-policy.md"
+  "docs/phase-65-closeout-evaluation.md"
+  "docs/getting-started/first-user-journey.md"
+  "docs/getting-started/first-user-demo-report-export.md"
+)
+
+required_verifier_scripts=(
+  "scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+  "scripts/test-verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+  "scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh"
+  "scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh"
+  "scripts/verify-publishable-path-hygiene.sh"
+)
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -s "${path}" ]]; then
+    echo "Missing ${description}: ${path#"${repo_root}/"}" >&2
+    exit 1
+  fi
+}
+
+visible_text() {
+  perl -0pe 's/<!--.*?-->//gs' "$@"
+}
+
+require_phrase() {
+  local file="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" < <(visible_text "${file}"); then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+require_section_phrase() {
+  local section="$1"
+  local phrase="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "${phrase}" < <(perl -0pe 's/<!--.*?-->//gs' <<<"${section}"); then
+    echo "Missing ${description}: ${phrase}" >&2
+    exit 1
+  fi
+}
+
+section_text() {
+  local file="$1"
+  local heading="$2"
+  local next_heading="$3"
+
+  awk -v heading="${heading}" -v next_heading="${next_heading}" '
+    {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+    }
+    line == heading { in_section = 1 }
+    in_section {
+      if (next_heading != "" && line == next_heading) {
+        exit
+      }
+      print
+    }
+  ' "${file}"
+}
+
+require_file "${absolute_doc_path}" "Phase 66.1 clean-host RC E2E harness"
+require_file "${readme_path}" "README for Phase 66.1 link check"
+for reference_path in "${required_reference_paths[@]}"; do
+  require_file "${repo_root}/${reference_path}" "Phase 66.1 reference ${reference_path}"
+done
+for verifier_script in "${required_verifier_scripts[@]}"; do
+  require_file "${repo_root}/${verifier_script}" "Phase 66.1 verifier script ${verifier_script}"
+done
+
+require_phrase "${readme_path}" "- [Phase 66.1 clean-host RC E2E harness](docs/phase-66-1-clean-host-rc-e2e-harness.md) defines the clean-host release-candidate journey contract from setup through report export while preserving Phase 65 as input evidence only and excluding GA, production rollout, self-service commercial, and broad SIEM/SOAR parity claims." "README canonical Phase 66.1 boundary bullet"
+require_phrase "${readme_path}" "The Phase 66.1 clean-host RC E2E harness is defined by the [Phase 66.1 clean-host RC E2E harness](docs/phase-66-1-clean-host-rc-e2e-harness.md)." "README Product positioning Phase 66.1 reference"
+
+required_phrases=(
+  "# Phase 66.1 Clean-Host RC E2E Harness"
+  "**Status**: Accepted as the Phase 66.1 clean-host RC E2E harness contract for release-candidate proof planning only."
+  "**Related Issues**: #1397, #1398"
+  "This contract defines the Phase 66.1 clean-host RC E2E harness shape for the first release-candidate replacement-readiness journey."
+  "Phase 65 packaging evidence is input only."
+  'The harness proves that a documented clean-host profile can collect one bounded RC journey packet for `init -> up -> doctor -> seed-demo -> UI workflow -> report export`.'
+  "The harness is proof evidence only."
+  "AegisOps records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth."
+  "Wazuh, Shuffle, AI, reports, UI state, browser state, verifier output, issue-lint output, release artifacts, demo data, tickets, evidence systems, dashboards, support bundles, and downstream receipts remain subordinate context."
+  "The harness must reject missing journey steps, missing evidence fields, missing authority boundaries, missing limitations, workstation-local paths, production secrets, customer-private data, inferred RC pass, inferred GA pass, self-service commercial readiness claims, production rollout readiness claims, broad SIEM/SOAR parity claims, verifier-as-readiness-truth, and issue-lint-as-readiness-truth."
+  "Phase 66.1 proves the harness shape and evidence contract for one bounded clean-host RC E2E path."
+  "Later Phase 66 issues must still prove Wazuh sample signal, Shuffle sample execution, AI-assisted triage, report export, supportability, authority-boundary negative tests, and closeout evidence independently."
+  'Run `bash scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh`.'
+  'Run `bash scripts/test-verify-phase-66-1-clean-host-rc-e2e-harness.sh`.'
+  'Run `bash scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh`.'
+  'Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.'
+  'Run `bash scripts/verify-publishable-path-hygiene.sh`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1397 --config <supervisor-config-path>`.'
+  'Run `node <codex-supervisor-root>/dist/index.js issue-lint 1398 --config <supervisor-config-path>`.'
+)
+
+for phrase in "${required_phrases[@]}"; do
+  require_phrase "${absolute_doc_path}" "${phrase}" "required Phase 66.1 harness term in ${doc_path}"
+done
+
+profile_section="$(section_text "${absolute_doc_path}" "## 2. Clean-Host Profile" "## 3. Required Journey Steps")"
+profile_fields=(
+  "| \`journey_run_id\` | Stable identifier for the reviewed RC E2E run. | Missing or reused run identifiers fail the harness. |"
+  "| \`repository_revision\` | Immutable repository revision for the harness run. | Mutable branch names fail the harness. |"
+  "| \`profile\` | \`smb-single-node\`. | Any other profile must be handled by a later contract. |"
+  "| \`environment_class\` | \`clean-host-rc-e2e\`. | Unlabeled local developer state fails the harness. |"
+  "| \`runtime_env_reference\` | Repo-relative placeholder such as \`<runtime-env-file>\`. | Workstation-local paths and raw secret material fail the harness. |"
+  "| \`operator_role\` | Human operator or maintainer role that performed the run. | Browser state or UI cache cannot stand in for operator identity. |"
+  "| \`evidence_dir\` | Repo-relative placeholder such as \`<evidence-dir>\`. | Untracked local paths cannot become proof evidence. |"
+  "| \`phase65_input_references\` | Phase 65 closeout and packaging artifacts consumed as subordinate input. | Phase 65 closure cannot satisfy RC E2E by inference. |"
+)
+
+for row in "${profile_fields[@]}"; do
+  require_section_phrase "${profile_section}" "${row}" "Phase 66.1 clean-host profile field"
+done
+
+journey_section="$(section_text "${absolute_doc_path}" "## 3. Required Journey Steps" "## 4. Evidence Packet Fields")"
+journey_steps=(
+  '`aegisops init --profile smb-single-node`'
+  '`aegisops up --with-wazuh --with-shuffle`'
+  '`aegisops doctor`'
+  '`aegisops seed-demo`'
+  "Login"
+  "Health review"
+  "Queue item"
+  "Wazuh-origin signal inspection"
+  "Case promotion"
+  "Evidence review"
+  "AI trace review"
+  "Action request"
+  "Approval"
+  "Shuffle delegation receipt"
+  "Reconciliation"
+  "Report export"
+  "Next-step guidance"
+)
+
+for step in "${journey_steps[@]}"; do
+  require_section_phrase "${journey_section}" "${step}" "Phase 66.1 required journey step"
+done
+
+evidence_section="$(section_text "${absolute_doc_path}" "## 4. Evidence Packet Fields" "## 5. Authority Boundary")"
+evidence_fields=(
+  "\`journey_run_id\`, \`repository_revision\`, \`profile\`, \`environment_class\`, \`runtime_env_reference\`, \`operator_role\`, \`evidence_dir\`."
+  "\`wazuh_signal_id\`, \`source_health_reference\`, \`aegisops_alert_id\`, \`admission_review_id\`, \`provenance_reference\`."
+  "\`shuffle_workflow_id\`, \`action_request_id\`, \`approval_decision_id\`, \`execution_receipt_id\`, \`reconciliation_id\`."
+  "\`ai_trace_id\`, \`citation_set\`, \`reviewed_recommendation_id\`, \`human_decision\`, \`autonomous_action_refusal\`."
+  "\`export_command\`, \`export_artifact_reference\`, \`report_schema_version\`, \`redaction_review_id\`, \`source_record_ids\`."
+  "\`doctor_result_id\`, \`support_bundle_posture\`, \`backup_restore_posture\`, \`upgrade_plan_reference\`, \`known_limitation_ids\`."
+  "\`limitation_id\`, \`owner\`, \`accepted_or_refused_reason\`, \`decision_date\`, \`follow_up_date\`."
+)
+
+for field_group in "${evidence_fields[@]}"; do
+  require_section_phrase "${evidence_section}" "${field_group}" "Phase 66.1 evidence packet field group"
+done
+
+limitations_section="$(section_text "${absolute_doc_path}" "## 6. Accepted Limitations" "## 7. Verification")"
+require_section_phrase "${limitations_section}" "It does not collect real design-partner evidence, prove real design-partner success, complete support-bundle review, complete restore dry-run proof, complete upgrade rehearsal proof, approve production rollout, approve self-service commercial readiness, or satisfy Phase 67 GA readiness." "Phase 66.1 accepted limitations boundary"
+
+forbidden_patterns=(
+  'phase[[:space:]]+66\.1[[:space:]]+(proves|satisfies|passes|accepts|grants|confirms)[^.[:cntrl:]]*(ga|general[- ]availability)'
+  'phase[[:space:]]+66\.1[[:space:]]+(proves|satisfies|passes|accepts|grants|confirms)[^.[:cntrl:]]*(production[[:space:]]+rollout|self[- ]service[[:space:]]+commercial|broad[[:space:]]+siem|broad[[:space:]]+soar|real[[:space:]]+design[- ]partner)'
+  'aegisops[[:space:]]+(is|becomes|serves[[:space:]]+as)[^.[:cntrl:]]*(ga|general[- ]availability|production[[:space:]]+rollout|self[- ]service[[:space:]]+commercial|broad[[:space:]]+siem|broad[[:space:]]+soar)'
+  '(wazuh|shuffle|ai|report|ui|browser|verifier|issue-lint)[[:space:]]+(output[[:space:]]+)?(is|becomes|serves[[:space:]]+as)[^.[:cntrl:]]*(workflow|gate|release|readiness|reconciliation|approval)[[:space:]]+truth'
+  'ai[[:space:]]+(approves|executes|reconciles|closes|activates)[^.[:cntrl:]]*(action|case|detector|record)'
+)
+
+while IFS= read -r line || [[ -n "${line}" ]]; do
+  line_lower="$(printf '%s' "${line}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${line_lower}" =~ (does[[:space:]]+not|cannot|must[[:space:]]+reject|reject|out[[:space:]]+of[[:space:]]+scope|no[[:space:]]+) ]]; then
+    continue
+  fi
+  for pattern in "${forbidden_patterns[@]}"; do
+    if grep -Eiq -- "${pattern}" <<<"${line}"; then
+      echo "Forbidden Phase 66.1 clean-host RC E2E harness claim matched: ${pattern}" >&2
+      exit 1
+    fi
+  done
+done < <(visible_text "${absolute_doc_path}")
+
+if grep -Eiq -- 'authorization[[:space:]]*:[[:space:]]*bearer[[:space:]]+[A-Za-z0-9_./+=-]{12,}|(password|passwd|secret|token|api[_ -]?key)[[:space:]]*[:=][[:space:]]*`?[^[:space:]`<>]+`?|AKIA[0-9A-Z]{16}|BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|ghp_[A-Za-z0-9_]{20,}' < <(visible_text "${absolute_doc_path}"); then
+  echo "Forbidden Phase 66.1 clean-host RC E2E harness: production secret-looking value detected" >&2
+  exit 1
+fi
+
+while IFS= read -r line; do
+  line_lower="$(printf '%s' "${line}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${line_lower}" =~ (reject|without|must[[:space:]]+reject|does[[:space:]]+not|cannot|no[[:space:]]+) ]]; then
+    continue
+  fi
+  if grep -Eiq -- '(includes|contains|embeds|carries)[[:space:]]+(customer[-_ ]private|raw[[:space:]]+customer[[:space:]]+data|unredacted[[:space:]]+customer)|customer[-_ ]private[[:space:]]+(example|ticket|alert|log|chat|payload|export)|unredacted[[:space:]]+customer[[:space:]]+(ticket|alert|log|chat|payload|export|data)' <<<"${line}"; then
+    echo "Forbidden Phase 66.1 clean-host RC E2E harness: customer-private data detected" >&2
+    exit 1
+  fi
+done < <(visible_text "${absolute_doc_path}")
+
+path_hygiene_stderr="${repo_root}/.tmp-phase66-1-path-hygiene.err"
+trap 'rm -f "${path_hygiene_stderr}"' EXIT
+if ! bash "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" >/dev/null 2>"${path_hygiene_stderr}"; then
+  cat "${path_hygiene_stderr}" >&2
+  echo "Forbidden Phase 66.1 clean-host RC E2E harness absolute path usage detected" >&2
+  exit 1
+fi
+
+echo "Phase 66.1 clean-host RC E2E harness contract and focused negative checks pass."

--- a/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh
+++ b/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh
@@ -137,10 +137,10 @@ done
 
 journey_section="$(section_text "${absolute_doc_path}" "## 3. Required Journey Steps" "## 4. Evidence Packet Fields")"
 journey_steps=(
-  '`aegisops init --profile smb-single-node`'
-  '`aegisops up --with-wazuh --with-shuffle`'
-  '`aegisops doctor`'
-  '`aegisops seed-demo`'
+  '`aegisops init --profile smb-single-node --runtime-env <runtime-env-file>`'
+  '`aegisops up --profile smb-single-node --runtime-env <runtime-env-file>`'
+  '`aegisops doctor --profile smb-single-node --runtime-env <runtime-env-file>`'
+  '`aegisops seed-demo --profile smb-single-node --demo-mode explicit`'
   "Login"
   "Health review"
   "Queue item"
@@ -156,8 +156,14 @@ journey_steps=(
   "Next-step guidance"
 )
 
+remaining_journey_section="${journey_section}"
 for step in "${journey_steps[@]}"; do
   require_section_phrase "${journey_section}" "${step}" "Phase 66.1 required journey step"
+  if [[ "${remaining_journey_section}" != *"${step}"* ]]; then
+    echo "Missing ordered Phase 66.1 required journey step: ${step}" >&2
+    exit 1
+  fi
+  remaining_journey_section="${remaining_journey_section#*"${step}"}"
 done
 
 evidence_section="$(section_text "${absolute_doc_path}" "## 4. Evidence Packet Fields" "## 5. Authority Boundary")"
@@ -186,18 +192,27 @@ forbidden_patterns=(
   'ai[[:space:]]+(approves|executes|reconciles|closes|activates)[^.[:cntrl:]]*(action|case|detector|record)'
 )
 
-while IFS= read -r line || [[ -n "${line}" ]]; do
-  line_lower="$(printf '%s' "${line}" | tr '[:upper:]' '[:lower:]')"
-  if [[ "${line_lower}" =~ (does[[:space:]]+not|cannot|must[[:space:]]+reject|reject|out[[:space:]]+of[[:space:]]+scope|no[[:space:]]+) ]]; then
-    continue
-  fi
-  for pattern in "${forbidden_patterns[@]}"; do
-    if grep -Eiq -- "${pattern}" <<<"${line}"; then
-      echo "Forbidden Phase 66.1 clean-host RC E2E harness claim matched: ${pattern}" >&2
-      exit 1
-    fi
-  done
-done < <(visible_text "${absolute_doc_path}")
+scan_forbidden_claims() {
+  local file="$1"
+  local description="$2"
+  local line
+  local clause
+  local pattern
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    while IFS= read -r clause || [[ -n "${clause}" ]]; do
+      for pattern in "${forbidden_patterns[@]}"; do
+        if grep -Eiq -- "${pattern}" <<<"${clause}"; then
+          echo "Forbidden Phase 66.1 ${description} claim matched: ${pattern}" >&2
+          exit 1
+        fi
+      done
+    done < <(printf '%s\n' "${line}" | tr ';' '\n')
+  done < <(visible_text "${file}")
+}
+
+scan_forbidden_claims "${absolute_doc_path}" "clean-host RC E2E harness"
+scan_forbidden_claims "${readme_path}" "README"
 
 if grep -Eiq -- 'authorization[[:space:]]*:[[:space:]]*bearer[[:space:]]+[A-Za-z0-9_./+=-]{12,}|(password|passwd|secret|token|api[_ -]?key)[[:space:]]*[:=][[:space:]]*`?[^[:space:]`<>]+`?|AKIA[0-9A-Z]{16}|BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|ghp_[A-Za-z0-9_]{20,}' < <(visible_text "${absolute_doc_path}"); then
   echo "Forbidden Phase 66.1 clean-host RC E2E harness: production secret-looking value detected" >&2


### PR DESCRIPTION
## Summary

- Add the Phase 66.1 clean-host RC E2E harness contract for the bounded `init -> up -> doctor -> seed-demo -> UI workflow -> report export` journey.
- Add a focused verifier and self-test that fail closed on missing journey steps, missing evidence fields, authority-boundary gaps, unsafe paths, secret-looking values, customer-private data, and RC/GA overclaims.
- Link the new Phase 66.1 surface from README canonical boundary and product-positioning sections.

## Why

Issue #1398 requires Phase 66 RC proof to start from a clean-host E2E harness rather than inferring readiness from Phase 65 packaging evidence. This keeps Phase 65 as subordinate input and preserves the Phase 51.3 / Phase 51.6 authority boundaries.

## Verification

- `bash scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh`
- `bash scripts/test-verify-phase-66-1-clean-host-rc-e2e-harness.sh`
- `bash scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh`
- `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1397 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.codex.json`
- `node /Users/jp.infra/Dev/codex-supervisor/dist/index.js issue-lint 1398 --config /Users/jp.infra/Dev/codex-supervisor/supervisor.config.codex.json`

Closes #1398
