### PR TITLE
[codex] Add Phase 66.7 RC authority-boundary proof pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Canonical cross-phase boundary reference:
 - [Phase 66.4 AI-assisted triage RC proof](docs/phase-66-4-ai-assisted-triage-rc-proof.md) defines the reviewed AI-assisted triage proof surface for RC evidence while preserving AI output as cited, reviewable, advisory evidence and excluding AI approval, AI execution, AI reconciliation, case-closure authority, GA, and commercial replacement claims.
 - [Phase 66.5 report export RC proof](docs/phase-66-5-report-export-rc-proof.md) defines the reviewed report export proof surface for RC evidence while preserving AegisOps records as workflow authority and excluding compliance certification, production SLA reporting, customer portal readiness, GA, and commercial replacement claims.
 - [Phase 66.6 RC supportability proof](docs/phase-66-6-rc-supportability-proof.md) defines the reviewed backup, restore dry-run, upgrade, rollback, support-bundle, redaction, owner-review, limitation, and non-claim evidence surface while preserving AegisOps records as workflow, release, gate, limitation, and closeout truth and excluding GA, production support, customer portal, and commercial replacement claims.
+- [Phase 66.7 RC authority-boundary proof pack](docs/phase-66-7-rc-authority-boundary-proof-pack.md) collects Phase 66.1-66.6 evidence and negative observations across Wazuh, Shuffle, AI, tickets, evidence systems, UI cache, demo data, reports, support bundles, release artifacts, verifier output, and issue-lint output while preserving AegisOps records as authority and excluding RC or GA gate, production, commercial replacement, and broad SIEM/SOAR parity claims.
 - [Phase 58.5 upgrade and rollback plan contract](docs/phase-58-5-upgrade-rollback-plan-contract.md) defines reviewed upgrade-plan and rollback-plan evidence fields, failure states, and authority boundaries without implementing live upgrade or rollback execution.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
@@ -119,6 +120,8 @@ The Phase 66.4 AI-assisted triage RC proof is defined by the [Phase 66.4 AI-assi
 The Phase 66.5 report export RC proof is defined by the [Phase 66.5 report export RC proof](docs/phase-66-5-report-export-rc-proof.md).
 
 The Phase 66.6 RC supportability proof is defined by the [Phase 66.6 RC supportability proof](docs/phase-66-6-rc-supportability-proof.md).
+
+The Phase 66.7 RC authority-boundary proof pack is defined by the [Phase 66.7 RC authority-boundary proof pack](docs/phase-66-7-rc-authority-boundary-proof-pack.md).
 
 The Phase 52.1 first-user CLI command contract is defined by the [Phase 52.1 CLI command contract](docs/phase-52-1-cli-command-contract.md).
 

--- a/control-plane/aegisops/control_plane/publishable_paths.py
+++ b/control-plane/aegisops/control_plane/publishable_paths.py
@@ -56,8 +56,9 @@ def is_workstation_local_path(text: str) -> bool:
         candidates.append(json_unescaped_slashes)
 
     for candidate in candidates:
-        if _WSL_WINDOWS_USER_FILE_URI_RE.search(candidate):
-            return True
+        for match in _WSL_WINDOWS_USER_FILE_URI_RE.finditer(candidate):
+            if _has_text_path_boundary(candidate, match.start()):
+                return True
 
         for match in _WSL_WINDOWS_USER_PATH_IN_TEXT_RE.finditer(candidate):
             if _has_text_path_boundary(candidate, match.start()):

--- a/control-plane/aegisops/control_plane/publishable_paths.py
+++ b/control-plane/aegisops/control_plane/publishable_paths.py
@@ -19,6 +19,11 @@ _WSL_WINDOWS_USER_PATH_IN_TEXT_RE = re.compile(
     + _WINDOWS_HOME_SEGMENT_PATTERN
     + r"/[^/\s]+(?:/[^\s]*)?"
 )
+_WSL_WINDOWS_USER_FILE_URI_RE = re.compile(
+    r"(?i)file:(?://(?:localhost)?/|/+)mnt/[a-z]/"
+    + _WINDOWS_HOME_SEGMENT_PATTERN
+    + r"/[^/\s]+(?:/[^\s]*)?"
+)
 _WINDOWS_USER_PATH_IN_TEXT_RE = re.compile(
     r"(?i)[A-Z]:[\\/]+Users[\\/]+[^\\/\s]+(?:[\\/][^\s]*)?"
 )
@@ -51,6 +56,9 @@ def is_workstation_local_path(text: str) -> bool:
         candidates.append(json_unescaped_slashes)
 
     for candidate in candidates:
+        if _WSL_WINDOWS_USER_FILE_URI_RE.search(candidate):
+            return True
+
         for match in _WSL_WINDOWS_USER_PATH_IN_TEXT_RE.finditer(candidate):
             if _has_text_path_boundary(candidate, match.start()):
                 return True

--- a/control-plane/aegisops/control_plane/publishable_paths.py
+++ b/control-plane/aegisops/control_plane/publishable_paths.py
@@ -8,10 +8,16 @@ from pathlib import PureWindowsPath
 REDACTED_LOCAL_PATH_TOKEN = "<redacted-local-path>"
 ALLOWLIST_MARKER = "publishable-path-hygiene: allowlist"
 _MAC_HOME_PREFIX = "/" + "Users" + "/"
+_WINDOWS_HOME_SEGMENT_PATTERN = "Users"
 
 _WINDOWS_USER_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]+Users[\\/]+[^\\/]+(?:[\\/](?P<rest>.*))?$")
 _UNIX_USER_PATH_IN_TEXT_RE = re.compile(
     r"(?:/(?:Users|home)/[^/\s]+(?:/[^\s]*)?|/root/[^\s]*)"
+)
+_WSL_WINDOWS_USER_PATH_IN_TEXT_RE = re.compile(
+    r"(?i)/mnt/[a-z]/"
+    + _WINDOWS_HOME_SEGMENT_PATTERN
+    + r"/[^/\s]+(?:/[^\s]*)?"
 )
 _WINDOWS_USER_PATH_IN_TEXT_RE = re.compile(
     r"(?i)[A-Z]:[\\/]+Users[\\/]+[^\\/\s]+(?:[\\/][^\s]*)?"
@@ -45,6 +51,10 @@ def is_workstation_local_path(text: str) -> bool:
         candidates.append(json_unescaped_slashes)
 
     for candidate in candidates:
+        for match in _WSL_WINDOWS_USER_PATH_IN_TEXT_RE.finditer(candidate):
+            if _has_text_path_boundary(candidate, match.start()):
+                return True
+
         for match in _WINDOWS_USER_PATH_IN_TEXT_RE.finditer(candidate):
             if _has_text_path_boundary(candidate, match.start()):
                 return True

--- a/control-plane/tests/test_publishable_path_hygiene.py
+++ b/control-plane/tests/test_publishable_path_hygiene.py
@@ -25,6 +25,7 @@ UNIX_HOME_PATH = f"/{LINUX_HOME_SEGMENT}/alice/project/docs"
 WINDOWS_USERS_PATH = rf"C:\{WINDOWS_HOME_SEGMENT}\alice\project\docs"
 WINDOWS_USERS_PATH_POSIX = f"C:/{WINDOWS_HOME_SEGMENT}/alice/project/docs"
 WSL_USERS_PATH = f"/mnt/c/{WINDOWS_HOME_SEGMENT}/alice/project/docs"
+WSL_USERS_FILE_URI = f"file://{WSL_USERS_PATH}"
 OFFENDER_PATH = f"/{MACOS_HOME_SEGMENT}/alice/private/project"
 ROOT_SEGMENT = "root"
 ROOT_PATH = f"/{ROOT_SEGMENT}/private/project"
@@ -43,6 +44,12 @@ class PublishablePathHygieneTests(unittest.TestCase):
         self.assertTrue(is_workstation_local_path(f"path:{WINDOWS_USERS_PATH_POSIX}"))
         self.assertTrue(is_workstation_local_path(WSL_USERS_PATH))
         self.assertTrue(is_workstation_local_path(f"artifact={WSL_USERS_PATH}"))
+        self.assertTrue(is_workstation_local_path(WSL_USERS_FILE_URI))
+        self.assertTrue(
+            is_workstation_local_path(
+                f"file://localhost{WSL_USERS_PATH}"
+            )
+        )
         self.assertTrue(
             is_workstation_local_path(
                 f"path:{escaped_slash}Users{escaped_slash}alice"
@@ -70,6 +77,13 @@ class PublishablePathHygieneTests(unittest.TestCase):
             is_workstation_local_path(
                 f"artifact={escaped_slash}mnt{escaped_slash}c{escaped_slash}Users"
                 f"{escaped_slash}alice{escaped_slash}project{escaped_slash}docs"
+            )
+        )
+        self.assertTrue(
+            is_workstation_local_path(
+                f"file:{escaped_slash}{escaped_slash}{escaped_slash}mnt"
+                f"{escaped_slash}c{escaped_slash}Users{escaped_slash}alice"
+                f"{escaped_slash}project{escaped_slash}docs"
             )
         )
 

--- a/control-plane/tests/test_publishable_path_hygiene.py
+++ b/control-plane/tests/test_publishable_path_hygiene.py
@@ -24,6 +24,7 @@ UNIX_USERS_PATH = f"/{MACOS_HOME_SEGMENT}/alice/project/docs"
 UNIX_HOME_PATH = f"/{LINUX_HOME_SEGMENT}/alice/project/docs"
 WINDOWS_USERS_PATH = rf"C:\{WINDOWS_HOME_SEGMENT}\alice\project\docs"
 WINDOWS_USERS_PATH_POSIX = f"C:/{WINDOWS_HOME_SEGMENT}/alice/project/docs"
+WSL_USERS_PATH = f"/mnt/c/{WINDOWS_HOME_SEGMENT}/alice/project/docs"
 OFFENDER_PATH = f"/{MACOS_HOME_SEGMENT}/alice/private/project"
 ROOT_SEGMENT = "root"
 ROOT_PATH = f"/{ROOT_SEGMENT}/private/project"
@@ -40,6 +41,8 @@ class PublishablePathHygieneTests(unittest.TestCase):
         self.assertTrue(is_workstation_local_path(WINDOWS_USERS_PATH))
         self.assertTrue(is_workstation_local_path(f"path={WINDOWS_USERS_PATH_POSIX}"))
         self.assertTrue(is_workstation_local_path(f"path:{WINDOWS_USERS_PATH_POSIX}"))
+        self.assertTrue(is_workstation_local_path(WSL_USERS_PATH))
+        self.assertTrue(is_workstation_local_path(f"artifact={WSL_USERS_PATH}"))
         self.assertTrue(
             is_workstation_local_path(
                 f"path:{escaped_slash}Users{escaped_slash}alice"
@@ -63,6 +66,12 @@ class PublishablePathHygieneTests(unittest.TestCase):
                 f"{escaped_slash}project{escaped_slash}docs"
             )
         )
+        self.assertTrue(
+            is_workstation_local_path(
+                f"artifact={escaped_slash}mnt{escaped_slash}c{escaped_slash}Users"
+                f"{escaped_slash}alice{escaped_slash}project{escaped_slash}docs"
+            )
+        )
 
     def test_ignores_urls_and_non_user_windows_paths(self) -> None:
         self.assertFalse(
@@ -73,6 +82,11 @@ class PublishablePathHygieneTests(unittest.TestCase):
         self.assertFalse(
             is_workstation_local_path(
                 f"https://example.com/C:/{WINDOWS_HOME_SEGMENT}/alice/project/docs"
+            )
+        )
+        self.assertFalse(
+            is_workstation_local_path(
+                f"https://example.com/mnt/c/{WINDOWS_HOME_SEGMENT}/alice/project/docs"
             )
         )
         self.assertFalse(is_workstation_local_path(r"D:\Program Files\AegisOps"))

--- a/control-plane/tests/test_publishable_path_hygiene.py
+++ b/control-plane/tests/test_publishable_path_hygiene.py
@@ -45,6 +45,7 @@ class PublishablePathHygieneTests(unittest.TestCase):
         self.assertTrue(is_workstation_local_path(WSL_USERS_PATH))
         self.assertTrue(is_workstation_local_path(f"artifact={WSL_USERS_PATH}"))
         self.assertTrue(is_workstation_local_path(WSL_USERS_FILE_URI))
+        self.assertTrue(is_workstation_local_path(f"artifact={WSL_USERS_FILE_URI}"))
         self.assertTrue(
             is_workstation_local_path(
                 f"file://localhost{WSL_USERS_PATH}"
@@ -101,6 +102,16 @@ class PublishablePathHygieneTests(unittest.TestCase):
         self.assertFalse(
             is_workstation_local_path(
                 f"https://example.com/mnt/c/{WINDOWS_HOME_SEGMENT}/alice/project/docs"
+            )
+        )
+        self.assertFalse(
+            is_workstation_local_path(
+                f"https://example.com/{WSL_USERS_FILE_URI}"
+            )
+        )
+        self.assertFalse(
+            is_workstation_local_path(
+                f"prefix{WSL_USERS_FILE_URI}"
             )
         )
         self.assertFalse(is_workstation_local_path(r"D:\Program Files\AegisOps"))

--- a/docs/phase-66-7-rc-authority-boundary-proof-pack.md
+++ b/docs/phase-66-7-rc-authority-boundary-proof-pack.md
@@ -89,11 +89,11 @@ Passing one negative observation cannot compensate for a missing surface. Missin
 
 Each Phase 66.1-66.6 evidence value must record `evidence_id`, `evidence_reference`, `verifier`, `result=passed`, `journey_run_id`, and `repository_revision`. The evidence reference and verifier path must be the repository-owned proof document and focused verifier for that phase slice.
 
-Each Phase 66.1-66.6 `evidence_id` must be `sha256:<digest>` for the exact referenced proof document bytes at `repository_revision`. A caller-supplied label, mutable path content, or digest from the packet-storing commit is not a resolved evidence identity.
+Each Phase 66.1-66.6 `evidence_id` must be `sha256:<digest>` for the exact referenced proof document Git blob bytes at `repository_revision`. A caller-supplied label, mutable path content, symlink target, or digest from the packet-storing commit is not a resolved evidence identity.
 
-The top-level `repository_revision` identifies the evidence-producing commit, not the commit that later stores the proof packet. It must resolve to a commit that is an ancestor of the checkout being verified. The verifier must check out that exact revision in an isolated worktree, resolve each required evidence reference there, and execute every Phase 66.1-66.6 focused verifier there. Packet labels or a declared `result=passed` cannot substitute for resolved proof surfaces and successful verifier execution.
+The top-level `repository_revision` identifies the evidence-producing commit, not the commit that later stores the proof packet. It must resolve to a commit that is an ancestor of the checkout being verified. The verifier must check out that exact revision in an isolated worktree, require every referenced proof surface and prerequisite verifier to be a regular Git blob in that commit, bind evidence digests to those Git blob bytes, and execute every Phase 66.1-66.6 focused verifier there. Packet labels, symlink targets, or a declared `result=passed` cannot substitute for repository-owned proof surfaces and successful verifier execution.
 
-Each prerequisite verifier must leave the isolated worktree at `repository_revision` with no tracked or untracked changes. A verifier that changes the worktree revision or mutates any worktree content fails closed.
+Each prerequisite verifier must leave the isolated worktree at `repository_revision` with no tracked, untracked, or ignored changes. A verifier that changes the worktree revision or leaves any worktree content behind fails closed.
 
 The same isolated worktree must resolve the negative-observation manifest, bind its exact bytes to every negative `evidence_id`, and match every packet observation to one manifest record. A syntactically valid negative observation without that immutable record fails closed.
 

--- a/docs/phase-66-7-rc-authority-boundary-proof-pack.md
+++ b/docs/phase-66-7-rc-authority-boundary-proof-pack.md
@@ -33,13 +33,13 @@ Every materialized Phase 66.7 proof packet must include exactly one value for ev
 | Field | Required evidence | Fail-closed rule |
 | --- | --- | --- |
 | `journey_run_id` | The Phase 66.1 journey run shared by every collected proof and negative observation. | Missing, placeholder, or mixed journey identifiers fail the packet. |
-| `repository_revision` | One immutable 40-character repository revision shared by every collected proof and negative observation. | Mutable, abbreviated, missing, or mixed revisions fail the packet. |
-| `phase_66_1_evidence` | Phase 66.1 evidence id, verifier path, passed result, journey run, and repository revision. | Missing, failed, or unbound clean-host journey evidence fails the packet. |
-| `phase_66_2_evidence` | Phase 66.2 evidence id, verifier path, passed result, journey run, and repository revision. | Missing, failed, or unbound Wazuh proof evidence fails the packet. |
-| `phase_66_3_evidence` | Phase 66.3 evidence id, verifier path, passed result, journey run, and repository revision. | Missing, failed, or unbound Shuffle proof evidence fails the packet. |
-| `phase_66_4_evidence` | Phase 66.4 evidence id, verifier path, passed result, journey run, and repository revision. | Missing, failed, or unbound AI proof evidence fails the packet. |
-| `phase_66_5_evidence` | Phase 66.5 evidence id, verifier path, passed result, journey run, and repository revision. | Missing, failed, or unbound report-export proof evidence fails the packet. |
-| `phase_66_6_evidence` | Phase 66.6 evidence id, verifier path, passed result, journey run, and repository revision. | Missing, failed, or unbound supportability proof evidence fails the packet. |
+| `repository_revision` | One immutable 40-character evidence-producing repository revision shared by every collected proof and negative observation. | Mutable, abbreviated, missing, mixed, unknown, or non-ancestor revisions fail the packet. The revision need not equal the later commit that stores the packet. |
+| `phase_66_1_evidence` | Phase 66.1 evidence id, proof-document reference, verifier path, passed result, journey run, and repository revision. | Missing, failed, unresolved, or unbound clean-host journey evidence fails the packet. |
+| `phase_66_2_evidence` | Phase 66.2 evidence id, proof-document reference, verifier path, passed result, journey run, and repository revision. | Missing, failed, unresolved, or unbound Wazuh proof evidence fails the packet. |
+| `phase_66_3_evidence` | Phase 66.3 evidence id, proof-document reference, verifier path, passed result, journey run, and repository revision. | Missing, failed, unresolved, or unbound Shuffle proof evidence fails the packet. |
+| `phase_66_4_evidence` | Phase 66.4 evidence id, proof-document reference, verifier path, passed result, journey run, and repository revision. | Missing, failed, unresolved, or unbound AI proof evidence fails the packet. |
+| `phase_66_5_evidence` | Phase 66.5 evidence id, proof-document reference, verifier path, passed result, journey run, and repository revision. | Missing, failed, unresolved, or unbound report-export proof evidence fails the packet. |
+| `phase_66_6_evidence` | Phase 66.6 evidence id, proof-document reference, verifier path, passed result, journey run, and repository revision. | Missing, failed, unresolved, or unbound supportability proof evidence fails the packet. |
 | `wazuh_negative_evidence` | Rejected Wazuh source-truth-promotion attempt with authoritative AegisOps record linkage. | Wazuh state cannot become alert, case, evidence, release, or gate truth. |
 | `shuffle_negative_evidence` | Rejected Shuffle execution-receipt-promotion attempt with authoritative AegisOps record linkage. | Workflow status cannot bypass approval, action request, receipt, or reconciliation. |
 | `ai_negative_evidence` | Rejected AI approval-bypass attempt with authoritative AegisOps record linkage. | AI output cannot approve, execute, reconcile, or close a case. |
@@ -83,7 +83,11 @@ Passing one negative observation cannot compensate for a missing surface. Missin
 
 ## 4. Evidence Binding And Secret Hygiene
 
-Each Phase 66.1-66.6 evidence value must record `evidence_id`, `verifier`, `result=passed`, `journey_run_id`, and `repository_revision`. The verifier path must be the repository-owned focused verifier for that phase slice.
+Each Phase 66.1-66.6 evidence value must record `evidence_id`, `evidence_reference`, `verifier`, `result=passed`, `journey_run_id`, and `repository_revision`. The evidence reference and verifier path must be the repository-owned proof document and focused verifier for that phase slice.
+
+Each Phase 66.1-66.6 `evidence_id` must be `sha256:<digest>` for the exact referenced proof document bytes at `repository_revision`. A caller-supplied label, mutable path content, or digest from the packet-storing commit is not a resolved evidence identity.
+
+The top-level `repository_revision` identifies the evidence-producing commit, not the commit that later stores the proof packet. It must resolve to a commit that is an ancestor of the checkout being verified. The verifier must check out that exact revision in an isolated worktree, resolve each required evidence reference there, and execute every Phase 66.1-66.6 focused verifier there. Packet labels or a declared `result=passed` cannot substitute for resolved proof surfaces and successful verifier execution.
 
 All materialized timestamps must be no more than 24 hours old at verification time and must not be more than five minutes in the future. The owner review and every negative observation must satisfy this freshness window.
 
@@ -128,4 +132,3 @@ Run `node <codex-supervisor-root>/dist/index.js issue-lint 1404 --config <superv
 ## 8. Non-Goals
 
 Phase 66.7 does not add runtime feature breadth, execute production operations, grant new AI or integration authority, prove real design-partner outcomes, complete production rollout, implement commercial billing or entitlement enforcement, prove Phase 67 GA readiness, or claim broad enterprise SIEM/SOAR parity.
-

--- a/docs/phase-66-7-rc-authority-boundary-proof-pack.md
+++ b/docs/phase-66-7-rc-authority-boundary-proof-pack.md
@@ -1,0 +1,131 @@
+# Phase 66.7 RC Authority-Boundary Proof Pack
+
+**Status**: Accepted as the Phase 66.7 RC authority-boundary proof-pack contract for release-candidate evidence planning only.
+
+**Date**: 2026-07-23
+
+**Related Issues**: #1397, #1404
+
+## 1. Purpose And Evidence Inputs
+
+This contract defines the Phase 66.7 RC authority-boundary proof pack.
+
+The proof pack depends on the Phase 66.1-66.6 proof surfaces and the Phase 51.6 authority-boundary negative-test policy. It collects their evidence under one run and revision; it does not replace, reinterpret, or independently satisfy those contracts.
+
+The required repository-owned inputs are:
+
+- `docs/phase-66-1-clean-host-rc-e2e-harness.md`
+- `docs/phase-66-2-wazuh-sample-signal-rc-proof.md`
+- `docs/phase-66-3-shuffle-sample-execution-rc-proof.md`
+- `docs/phase-66-4-ai-assisted-triage-rc-proof.md`
+- `docs/phase-66-5-report-export-rc-proof.md`
+- `docs/phase-66-6-rc-supportability-proof.md`
+- `docs/phase-51-6-authority-boundary-negative-test-policy.md`
+- `docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md`
+- `docs/phase-65-closeout-evaluation.md`
+
+This proof pack is RC evidence only. It cannot grant an RC gate pass, a GA gate pass, production authority, production rollout readiness, commercial replacement readiness, or broad enterprise SIEM/SOAR parity.
+
+## 2. Required Proof Packet
+
+Every materialized Phase 66.7 proof packet must include exactly one value for every field below:
+
+| Field | Required evidence | Fail-closed rule |
+| --- | --- | --- |
+| `journey_run_id` | The Phase 66.1 journey run shared by every collected proof and negative observation. | Missing, placeholder, or mixed journey identifiers fail the packet. |
+| `repository_revision` | One immutable 40-character repository revision shared by every collected proof and negative observation. | Mutable, abbreviated, missing, or mixed revisions fail the packet. |
+| `phase_66_1_evidence` | Phase 66.1 evidence id, verifier path, passed result, journey run, and repository revision. | Missing, failed, or unbound clean-host journey evidence fails the packet. |
+| `phase_66_2_evidence` | Phase 66.2 evidence id, verifier path, passed result, journey run, and repository revision. | Missing, failed, or unbound Wazuh proof evidence fails the packet. |
+| `phase_66_3_evidence` | Phase 66.3 evidence id, verifier path, passed result, journey run, and repository revision. | Missing, failed, or unbound Shuffle proof evidence fails the packet. |
+| `phase_66_4_evidence` | Phase 66.4 evidence id, verifier path, passed result, journey run, and repository revision. | Missing, failed, or unbound AI proof evidence fails the packet. |
+| `phase_66_5_evidence` | Phase 66.5 evidence id, verifier path, passed result, journey run, and repository revision. | Missing, failed, or unbound report-export proof evidence fails the packet. |
+| `phase_66_6_evidence` | Phase 66.6 evidence id, verifier path, passed result, journey run, and repository revision. | Missing, failed, or unbound supportability proof evidence fails the packet. |
+| `wazuh_negative_evidence` | Rejected Wazuh source-truth-promotion attempt with authoritative AegisOps record linkage. | Wazuh state cannot become alert, case, evidence, release, or gate truth. |
+| `shuffle_negative_evidence` | Rejected Shuffle execution-receipt-promotion attempt with authoritative AegisOps record linkage. | Workflow status cannot bypass approval, action request, receipt, or reconciliation. |
+| `ai_negative_evidence` | Rejected AI approval-bypass attempt with authoritative AegisOps record linkage. | AI output cannot approve, execute, reconcile, or close a case. |
+| `ticket_negative_evidence` | Rejected ticket case-closure-shortcut attempt with authoritative AegisOps record linkage. | Ticket state remains coordination context only. |
+| `evidence_system_negative_evidence` | Rejected external-evidence-truth-promotion attempt with custody and authoritative AegisOps record linkage. | Optional or external evidence cannot become evidence or source truth by itself. |
+| `ui_cache_negative_evidence` | Rejected UI-cache workflow-truth-promotion attempt with authoritative AegisOps record linkage. | Browser or UI cache cannot become workflow or gate truth. |
+| `demo_data_negative_evidence` | Rejected demo-data release-truth-promotion attempt with authoritative AegisOps record linkage. | Seed or demo data cannot prove live, release, or readiness truth. |
+| `report_negative_evidence` | Rejected report gate-truth-promotion attempt with authoritative AegisOps record linkage. | A derived report cannot become workflow, compliance, release, or gate truth. |
+| `support_bundle_negative_evidence` | Rejected support-bundle limitation-truth-promotion attempt with authoritative AegisOps record linkage. | A support bundle cannot own support, limitation, restore, release, or gate truth. |
+| `release_artifact_negative_evidence` | Rejected release-artifact readiness-truth-promotion attempt with authoritative AegisOps record linkage. | Packaging, integrity, signing, or channel artifacts cannot prove RC or GA readiness. |
+| `verifier_output_negative_evidence` | Rejected verifier-output RC-gate-promotion attempt with authoritative AegisOps record linkage. | Verifier output is test evidence, not a release or readiness decision. |
+| `issue_lint_output_negative_evidence` | Rejected issue-lint-output RC-gate-promotion attempt with authoritative AegisOps record linkage. | Issue-lint output is planning evidence, not a release or readiness decision. |
+| `owner_review` | Accountable reviewer, review timestamp, accepted disposition, and follow-up owner. | Artifact self-approval, rejected review, missing ownership, or stale review fails the packet. |
+| `limitation_references` | Reviewed limitation ids, owner, decision timestamp, and follow-up timestamp. | Hidden, unowned, placeholder, or undated limitations fail the packet. |
+| `non_claims` | All required RC, GA, production, commercial, parity, and subordinate-truth non-claim labels. | Missing non-claims or positive readiness claims fail the packet. |
+
+A proof packet is fail-closed: once any required field is materialized, every required field must be present, non-placeholder, internally complete, and bound to the same journey run and immutable repository revision.
+
+Materialized proof packets are accepted only as `field=value` assignment lines or Markdown `Field | Value` rows. JSON, YAML, and object-literal evidence syntax is rejected rather than partially interpreted.
+
+## 3. Negative Evidence Matrix
+
+Every negative observation must record `evidence_id`, `surface`, `attempt`, `result=rejected`, `authoritative_record`, `observed_at`, `journey_run_id`, and `repository_revision`.
+
+| Surface | Required rejected attempt | Authoritative fallback |
+| --- | --- | --- |
+| Wazuh | `source-truth-promotion` | An admitted and linked AegisOps alert, case, or evidence record. |
+| Shuffle | `execution-receipt-promotion` | AegisOps approval, action request, execution receipt, and reconciliation records. |
+| AI | `approval-bypass` | A reviewed AegisOps recommendation and explicit human decision. |
+| Tickets | `case-closure-shortcut` | AegisOps case state and linked audit record. |
+| Evidence systems | `external-evidence-truth-promotion` | AegisOps evidence custody, parser, scope, and record linkage. |
+| UI cache | `workflow-truth-promotion` | Durable AegisOps workflow and gate records. |
+| Demo data | `release-truth-promotion` | Reviewed non-demo release and limitation records. |
+| Reports | `gate-truth-promotion` | AegisOps source records plus an explicit gate decision. |
+| Support bundle | `limitation-truth-promotion` | AegisOps limitation, restore acceptance, and audit records. |
+| Release artifacts | `readiness-truth-promotion` | Reviewed AegisOps release and gate records. |
+| Verifier output | `rc-gate-promotion` | An explicit AegisOps RC gate decision. |
+| Issue-lint output | `rc-gate-promotion` | An explicit AegisOps RC gate decision. |
+
+Passing one negative observation cannot compensate for a missing surface. Missing, malformed, placeholder-backed, stale, future-dated, mixed-run, mixed-revision, or non-rejected observations fail the whole packet.
+
+## 4. Evidence Binding And Secret Hygiene
+
+Each Phase 66.1-66.6 evidence value must record `evidence_id`, `verifier`, `result=passed`, `journey_run_id`, and `repository_revision`. The verifier path must be the repository-owned focused verifier for that phase slice.
+
+All materialized timestamps must be no more than 24 hours old at verification time and must not be more than five minutes in the future. The owner review and every negative observation must satisfy this freshness window.
+
+The proof pack must not contain production secrets, credentials, authorization material, certificates, key material, raw customer-private data, ticket-private content, customer identifiers, email addresses, or workstation-local paths. Redaction assertions do not permit retaining the forbidden value beside the assertion.
+
+## 5. Authority Boundary
+
+AegisOps records remain authoritative for alert, case, evidence, recommendation, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, restore acceptance, and closeout truth.
+
+Wazuh, Shuffle, AI, tickets, evidence systems, browser state, UI cache, demo data, reports, support bundles, release artifacts, verifier output, issue-lint output, and optional evidence remain subordinate evidence or context only.
+
+The proof pack must reject subordinate-truth promotion, approval bypass, execution bypass, reconciliation bypass, case-closure shortcuts, source-admission shortcuts, inferred RC pass, inferred GA pass, and artifact-driven limitation or closeout decisions.
+
+An accepted owner review records a human disposition; it does not itself grant release authority. Phase 66.8 must evaluate closeout independently against authoritative AegisOps records and accepted limitations.
+
+## 6. Rejection Conditions
+
+The focused verifier rejects:
+
+- missing Phase 66.1-66.6 references, focused verifiers, proof fields, negative surfaces, or README linkage;
+- partial, duplicate, cross-section, mixed-run, mixed-revision, stale, future-dated, failed, or placeholder-backed proof packets;
+- JSON, YAML, or object-literal evidence syntax that could be silently ignored or ambiguously parsed;
+- Wazuh, Shuffle, AI, ticket, evidence-system, UI-cache, demo-data, report, support-bundle, release-artifact, verifier-output, or issue-lint-output truth promotion;
+- approval, execution, reconciliation, source-admission, or case-closure bypasses;
+- production secrets, credentials, authorization material, certificate or key material, customer-private data, ticket-private data, email addresses, and workstation-local paths;
+- RC or GA gate overclaims, production rollout claims, commercial replacement claims, and broad enterprise SIEM/SOAR parity claims.
+
+## 7. Verification
+
+Run `bash scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh`.
+
+Run `bash scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh`.
+
+Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.
+
+Run `bash scripts/verify-publishable-path-hygiene.sh`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1397 --config <supervisor-config-path>`.
+
+Run `node <codex-supervisor-root>/dist/index.js issue-lint 1404 --config <supervisor-config-path>`.
+
+## 8. Non-Goals
+
+Phase 66.7 does not add runtime feature breadth, execute production operations, grant new AI or integration authority, prove real design-partner outcomes, complete production rollout, implement commercial billing or entitlement enforcement, prove Phase 67 GA readiness, or claim broad enterprise SIEM/SOAR parity.
+

--- a/docs/phase-66-7-rc-authority-boundary-proof-pack.md
+++ b/docs/phase-66-7-rc-authority-boundary-proof-pack.md
@@ -52,7 +52,7 @@ Every materialized Phase 66.7 proof packet must include exactly one value for ev
 | `release_artifact_negative_evidence` | Rejected release-artifact readiness-truth-promotion attempt with authoritative AegisOps record linkage. | Packaging, integrity, signing, or channel artifacts cannot prove RC or GA readiness. |
 | `verifier_output_negative_evidence` | Rejected verifier-output RC-gate-promotion attempt with authoritative AegisOps record linkage. | Verifier output is test evidence, not a release or readiness decision. |
 | `issue_lint_output_negative_evidence` | Rejected issue-lint-output RC-gate-promotion attempt with authoritative AegisOps record linkage. | Issue-lint output is planning evidence, not a release or readiness decision. |
-| `owner_review` | Accountable reviewer, review timestamp, accepted disposition, and follow-up owner. | Artifact self-approval, rejected review, missing ownership, or stale review fails the packet. |
+| `owner_review` | Artifact owner, independent accountable reviewer, review timestamp, accepted disposition, and follow-up owner. | Artifact self-approval, rejected review, missing ownership, or stale review fails the packet. |
 | `limitation_references` | Repository-owned limitation-manifest digest and reference, reviewed limitation ids, owner, decision timestamp, and follow-up timestamp. | Unresolved, invented, unaccepted, unowned, placeholder, or undated limitations fail the packet. |
 | `non_claims` | All required RC, GA, production, commercial, parity, and subordinate-truth non-claim labels. | Missing non-claims or positive readiness claims fail the packet. |
 
@@ -94,6 +94,8 @@ Each Phase 66.1-66.6 `evidence_id` must be `sha256:<digest>` for the exact refer
 The top-level `repository_revision` identifies the evidence-producing commit, not the commit that later stores the proof packet. It must resolve to a commit that is an ancestor of the checkout being verified. The verifier must check out that exact revision in an isolated worktree, resolve each required evidence reference there, and execute every Phase 66.1-66.6 focused verifier there. Packet labels or a declared `result=passed` cannot substitute for resolved proof surfaces and successful verifier execution.
 
 The same isolated worktree must resolve the negative-observation manifest, bind its exact bytes to every negative `evidence_id`, and match every packet observation to one manifest record. A syntactically valid negative observation without that immutable record fails closed.
+
+Every `owner_review` value must record `artifact_owner`, `reviewer`, `reviewed_at`, `disposition`, and `follow_up_owner`. Artifact owner and reviewer must be distinct accountable identities. A self-declared review where those identities are equal fails closed.
 
 Every `limitation_references` value must record `evidence_id`, `evidence_reference`, `ids`, `owner`, `decision_at`, and `follow_up_at`. Its `evidence_id` is `sha256:<digest>` for the exact repository-owned manifest bytes at `evidence/phase-66-7/limitations.json` and `repository_revision`.
 

--- a/docs/phase-66-7-rc-authority-boundary-proof-pack.md
+++ b/docs/phase-66-7-rc-authority-boundary-proof-pack.md
@@ -101,7 +101,7 @@ Every `limitation_references` value must record `evidence_id`, `evidence_referen
 
 The limitation manifest uses `schema_version=phase-66-7-limitations/v1` and a `limitations` array. Every limitation record contains exactly `id`, `owner`, `disposition`, `decision_at`, and `follow_up_at`. The isolated worktree must resolve the limitation manifest and match every packet limitation to an accepted repository-owned record. Missing, duplicate, malformed, unaccepted, invented, or packet-mismatched limitation records fail closed.
 
-All materialized timestamps must be no more than 24 hours old at verification time and must not be more than five minutes in the future. The owner review and every negative observation must satisfy this freshness window.
+Observation, review, and decision timestamps must be no more than 24 hours old at verification time and must not be more than five minutes in the future. The owner review and every negative observation must satisfy this freshness window. Scheduled limitation follow-up timestamps are exempt from the five-minute future-skew limit, but must be after `decision_at` and no more than 90 days after it.
 
 The proof pack must not contain production secrets, credentials, authorization material, certificates, key material, raw customer-private data, ticket-private content, customer identifiers, email addresses, or workstation-local paths. Redaction assertions do not permit retaining the forbidden value beside the assertion.
 

--- a/docs/phase-66-7-rc-authority-boundary-proof-pack.md
+++ b/docs/phase-66-7-rc-authority-boundary-proof-pack.md
@@ -53,7 +53,7 @@ Every materialized Phase 66.7 proof packet must include exactly one value for ev
 | `verifier_output_negative_evidence` | Rejected verifier-output RC-gate-promotion attempt with authoritative AegisOps record linkage. | Verifier output is test evidence, not a release or readiness decision. |
 | `issue_lint_output_negative_evidence` | Rejected issue-lint-output RC-gate-promotion attempt with authoritative AegisOps record linkage. | Issue-lint output is planning evidence, not a release or readiness decision. |
 | `owner_review` | Accountable reviewer, review timestamp, accepted disposition, and follow-up owner. | Artifact self-approval, rejected review, missing ownership, or stale review fails the packet. |
-| `limitation_references` | Reviewed limitation ids, owner, decision timestamp, and follow-up timestamp. | Hidden, unowned, placeholder, or undated limitations fail the packet. |
+| `limitation_references` | Repository-owned limitation-manifest digest and reference, reviewed limitation ids, owner, decision timestamp, and follow-up timestamp. | Unresolved, invented, unaccepted, unowned, placeholder, or undated limitations fail the packet. |
 | `non_claims` | All required RC, GA, production, commercial, parity, and subordinate-truth non-claim labels. | Missing non-claims or positive readiness claims fail the packet. |
 
 A proof packet is fail-closed: once any required field is materialized, every required field must be present, non-placeholder, internally complete, and bound to the same journey run and immutable repository revision.
@@ -95,6 +95,10 @@ The top-level `repository_revision` identifies the evidence-producing commit, no
 
 The same isolated worktree must resolve the negative-observation manifest, bind its exact bytes to every negative `evidence_id`, and match every packet observation to one manifest record. A syntactically valid negative observation without that immutable record fails closed.
 
+Every `limitation_references` value must record `evidence_id`, `evidence_reference`, `ids`, `owner`, `decision_at`, and `follow_up_at`. Its `evidence_id` is `sha256:<digest>` for the exact repository-owned manifest bytes at `evidence/phase-66-7/limitations.json` and `repository_revision`.
+
+The limitation manifest uses `schema_version=phase-66-7-limitations/v1` and a `limitations` array. Every limitation record contains exactly `id`, `owner`, `disposition`, `decision_at`, and `follow_up_at`. The isolated worktree must resolve the limitation manifest and match every packet limitation to an accepted repository-owned record. Missing, duplicate, malformed, unaccepted, invented, or packet-mismatched limitation records fail closed.
+
 All materialized timestamps must be no more than 24 hours old at verification time and must not be more than five minutes in the future. The owner review and every negative observation must satisfy this freshness window.
 
 The proof pack must not contain production secrets, credentials, authorization material, certificates, key material, raw customer-private data, ticket-private content, customer identifiers, email addresses, or workstation-local paths. Redaction assertions do not permit retaining the forbidden value beside the assertion.
@@ -115,6 +119,7 @@ The focused verifier rejects:
 
 - missing Phase 66.1-66.6 references, focused verifiers, proof fields, negative surfaces, or README linkage;
 - partial, duplicate, cross-section, mixed-run, mixed-revision, stale, future-dated, failed, unresolved, or placeholder-backed proof packets;
+- unresolved, invented, unaccepted, duplicate, or packet-mismatched limitation records;
 - JSON, YAML, or object-literal evidence syntax that could be silently ignored or ambiguously parsed;
 - Wazuh, Shuffle, AI, ticket, evidence-system, UI-cache, demo-data, report, support-bundle, release-artifact, verifier-output, or issue-lint-output truth promotion;
 - approval, execution, reconciliation, source-admission, or case-closure bypasses;

--- a/docs/phase-66-7-rc-authority-boundary-proof-pack.md
+++ b/docs/phase-66-7-rc-authority-boundary-proof-pack.md
@@ -93,7 +93,7 @@ Each Phase 66.1-66.6 `evidence_id` must be `sha256:<digest>` for the exact refer
 
 The top-level `repository_revision` identifies the evidence-producing commit, not the commit that later stores the proof packet. It must resolve to a commit that is an ancestor of the checkout being verified. The verifier must check out that exact revision in an isolated worktree, require every referenced proof surface and prerequisite verifier to be a regular Git blob in that commit, bind evidence digests to those Git blob bytes, and execute every Phase 66.1-66.6 focused verifier there. Packet labels, symlink targets, or a declared `result=passed` cannot substitute for repository-owned proof surfaces and successful verifier execution.
 
-Each prerequisite verifier must leave the isolated worktree at `repository_revision` with no tracked, untracked, or ignored changes. A verifier that changes the worktree revision or leaves any worktree content behind fails closed.
+Each prerequisite verifier must leave the isolated worktree at `repository_revision` with no tracked, untracked, or ignored changes. The verifier compares both filesystem content and index semantics with the pristine checkout baseline, so index flags cannot conceal a mutation. A verifier that changes the worktree revision or leaves any worktree content behind fails closed.
 
 The same isolated worktree must resolve the negative-observation manifest, bind its exact bytes to every negative `evidence_id`, and match every packet observation to one manifest record. A syntactically valid negative observation without that immutable record fails closed.
 

--- a/docs/phase-66-7-rc-authority-boundary-proof-pack.md
+++ b/docs/phase-66-7-rc-authority-boundary-proof-pack.md
@@ -93,6 +93,8 @@ Each Phase 66.1-66.6 `evidence_id` must be `sha256:<digest>` for the exact refer
 
 The top-level `repository_revision` identifies the evidence-producing commit, not the commit that later stores the proof packet. It must resolve to a commit that is an ancestor of the checkout being verified. The verifier must check out that exact revision in an isolated worktree, resolve each required evidence reference there, and execute every Phase 66.1-66.6 focused verifier there. Packet labels or a declared `result=passed` cannot substitute for resolved proof surfaces and successful verifier execution.
 
+Each prerequisite verifier must leave the isolated worktree at `repository_revision` with no tracked or untracked changes. A verifier that changes the worktree revision or mutates any worktree content fails closed.
+
 The same isolated worktree must resolve the negative-observation manifest, bind its exact bytes to every negative `evidence_id`, and match every packet observation to one manifest record. A syntactically valid negative observation without that immutable record fails closed.
 
 Every `owner_review` value must record `artifact_owner`, `reviewer`, `reviewed_at`, `disposition`, and `follow_up_owner`. Artifact owner and reviewer must be distinct accountable identities. A self-declared review where those identities are equal fails closed.

--- a/docs/phase-66-7-rc-authority-boundary-proof-pack.md
+++ b/docs/phase-66-7-rc-authority-boundary-proof-pack.md
@@ -62,7 +62,11 @@ Materialized proof packets are accepted only as `field=value` assignment lines o
 
 ## 3. Negative Evidence Matrix
 
-Every negative observation must record `evidence_id`, `surface`, `attempt`, `result=rejected`, `authoritative_record`, `observed_at`, `journey_run_id`, and `repository_revision`.
+Every negative observation must record `evidence_id`, `evidence_reference`, `surface`, `attempt`, `result=rejected`, `authoritative_record`, `observed_at`, `journey_run_id`, and `repository_revision`.
+
+Every negative-observation `evidence_id` must be `sha256:<digest>` for the exact repository-owned JSON manifest bytes at `evidence_reference` and `repository_revision`. The manifest must contain exactly one matching immutable record for every required negative surface; packet labels, invented AegisOps URIs, or declared rejection results cannot substitute for a resolved record.
+
+The negative-observation manifest uses `schema_version=phase-66-7-negative-evidence/v1` and a `records` array. Every record contains exactly `field`, `surface`, `attempt`, `result`, `authoritative_record`, `observed_at`, and `journey_run_id`; missing, duplicate, extra, non-string, or packet-mismatched values fail closed.
 
 | Surface | Required rejected attempt | Authoritative fallback |
 | --- | --- | --- |
@@ -89,6 +93,8 @@ Each Phase 66.1-66.6 `evidence_id` must be `sha256:<digest>` for the exact refer
 
 The top-level `repository_revision` identifies the evidence-producing commit, not the commit that later stores the proof packet. It must resolve to a commit that is an ancestor of the checkout being verified. The verifier must check out that exact revision in an isolated worktree, resolve each required evidence reference there, and execute every Phase 66.1-66.6 focused verifier there. Packet labels or a declared `result=passed` cannot substitute for resolved proof surfaces and successful verifier execution.
 
+The same isolated worktree must resolve the negative-observation manifest, bind its exact bytes to every negative `evidence_id`, and match every packet observation to one manifest record. A syntactically valid negative observation without that immutable record fails closed.
+
 All materialized timestamps must be no more than 24 hours old at verification time and must not be more than five minutes in the future. The owner review and every negative observation must satisfy this freshness window.
 
 The proof pack must not contain production secrets, credentials, authorization material, certificates, key material, raw customer-private data, ticket-private content, customer identifiers, email addresses, or workstation-local paths. Redaction assertions do not permit retaining the forbidden value beside the assertion.
@@ -108,7 +114,7 @@ An accepted owner review records a human disposition; it does not itself grant r
 The focused verifier rejects:
 
 - missing Phase 66.1-66.6 references, focused verifiers, proof fields, negative surfaces, or README linkage;
-- partial, duplicate, cross-section, mixed-run, mixed-revision, stale, future-dated, failed, or placeholder-backed proof packets;
+- partial, duplicate, cross-section, mixed-run, mixed-revision, stale, future-dated, failed, unresolved, or placeholder-backed proof packets;
 - JSON, YAML, or object-literal evidence syntax that could be silently ignored or ambiguously parsed;
 - Wazuh, Shuffle, AI, ticket, evidence-system, UI-cache, demo-data, report, support-bundle, release-artifact, verifier-output, or issue-lint-output truth promotion;
 - approval, execution, reconciliation, source-admission, or case-closure bypasses;

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -493,6 +493,40 @@ append_doc_line \
   'journey_<span></span>run_id=rc66-fabricated-001'
 assert_fails_with "${inline_html_field_repo}" "raw HTML evidence syntax is not supported"
 
+details_html_field_repo="${workdir}/details-html-field"
+copy_valid_repo "${details_html_field_repo}"
+append_doc_line \
+  "${details_html_field_repo}" \
+  '<details>journey_run_id=rc66-fabricated-001</details>'
+assert_fails_with "${details_html_field_repo}" "raw HTML evidence syntax is not supported"
+
+multiline_details_html_field_repo="${workdir}/multiline-details-html-field"
+copy_valid_repo "${multiline_details_html_field_repo}"
+append_doc_line \
+  "${multiline_details_html_field_repo}" \
+  $'<details>\nrepository_revision=0000000000000000000000000000000000000000\n</details>'
+assert_fails_with \
+  "${multiline_details_html_field_repo}" \
+  "raw HTML evidence syntax is not supported"
+
+unclosed_details_html_field_repo="${workdir}/unclosed-details-html-field"
+copy_valid_repo "${unclosed_details_html_field_repo}"
+append_doc_line \
+  "${unclosed_details_html_field_repo}" \
+  $'<details>\njourney_run_id=rc66-fabricated-001'
+assert_fails_with \
+  "${unclosed_details_html_field_repo}" \
+  "raw HTML evidence syntax is not supported"
+
+escaped_details_html_field_repo="${workdir}/escaped-details-html-field"
+copy_valid_repo "${escaped_details_html_field_repo}"
+append_doc_line \
+  "${escaped_details_html_field_repo}" \
+  $'<details>\njourney\\_run\\_id=rc66-fabricated-001\n</details>'
+assert_fails_with \
+  "${escaped_details_html_field_repo}" \
+  "raw HTML evidence syntax is not supported"
+
 packet_mutation_case \
   "bad-journey" \
   "journey_run_id" \
@@ -674,6 +708,12 @@ packet_mutation_case \
   "follow_up_at must be after decision_at"
 
 packet_mutation_case \
+  "far-future-follow-up" \
+  "limitation_references" \
+  "evidence_id=sha256:__LIMITATION_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/limitations.json; ids=lim-66-7-001; owner=release-owner; decision_at=${observed_at}; follow_up_at=2999-01-01T00:00:00Z" \
+  "follow_up_at must be no more than 90 days after decision_at"
+
+packet_mutation_case \
   "fabricated-limitation-evidence-id" \
   "limitation_references" \
   "evidence_id=sha256:0000000000000000000000000000000000000000000000000000000000000000; evidence_reference=evidence/phase-66-7/limitations.json; ids=lim-66-7-001; owner=release-owner; decision_at=${observed_at}; follow_up_at=${follow_up_at}" \
@@ -749,6 +789,26 @@ append_complete_packet "${unaccepted_limitation_repo}"
 assert_fails_with \
   "${unaccepted_limitation_repo}" \
   "limitation manifest record lim-66-7-001 must be accepted"
+
+far_future_limitation_manifest_repo="${workdir}/far-future-limitation-manifest"
+copy_valid_repo "${far_future_limitation_manifest_repo}"
+MANIFEST="${far_future_limitation_manifest_repo}/evidence/phase-66-7/limitations.json" \
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["MANIFEST"])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["limitations"][0]["follow_up_at"] = "2999-01-01T00:00:00Z"
+path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+git -C "${far_future_limitation_manifest_repo}" add evidence/phase-66-7/limitations.json
+git -C "${far_future_limitation_manifest_repo}" commit -qm "set far-future limitation follow-up"
+append_complete_packet "${far_future_limitation_manifest_repo}"
+assert_fails_with \
+  "${far_future_limitation_manifest_repo}" \
+  "limitation manifest record lim-66-7-001 follow_up_at must be no more than 90 days after decision_at"
 
 packet_mutation_case \
   "missing-non-claim" \

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -7,7 +7,15 @@ verifier="${repo_root}/scripts/verify-phase-66-7-rc-authority-boundary-proof-pac
 doc_rel="docs/phase-66-7-rc-authority-boundary-proof-pack.md"
 
 workdir="$(mktemp -d)"
-trap 'rm -rf "${workdir}"' EXIT
+real_worktree=""
+
+cleanup() {
+  if [[ -n "${real_worktree}" ]]; then
+    git -C "${repo_root}" worktree remove --force "${real_worktree}" >/dev/null 2>&1 || true
+  fi
+  rm -rf "${workdir}"
+}
+trap cleanup EXIT
 
 pass_stdout="${workdir}/pass.out"
 pass_stderr="${workdir}/pass.err"
@@ -49,12 +57,12 @@ local_user_home="$(printf '/%s/%s/' 'Users' 'example')"
 packet_lines=(
   "journey_run_id=rc66-authority-001"
   "repository_revision=__REPOSITORY_REVISION__"
-  "phase_66_1_evidence=evidence_id=proof:66.1:001; verifier=scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "phase_66_2_evidence=evidence_id=proof:66.2:001; verifier=scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "phase_66_3_evidence=evidence_id=proof:66.3:001; verifier=scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "phase_66_4_evidence=evidence_id=proof:66.4:001; verifier=scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "phase_66_5_evidence=evidence_id=proof:66.5:001; verifier=scripts/verify-phase-66-5-report-export-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "phase_66_6_evidence=evidence_id=proof:66.6:001; verifier=scripts/verify-phase-66-6-rc-supportability-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "phase_66_1_evidence=evidence_id=sha256:__PHASE_66_1_DIGEST__; evidence_reference=docs/phase-66-1-clean-host-rc-e2e-harness.md; verifier=scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "phase_66_2_evidence=evidence_id=sha256:__PHASE_66_2_DIGEST__; evidence_reference=docs/phase-66-2-wazuh-sample-signal-rc-proof.md; verifier=scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "phase_66_3_evidence=evidence_id=sha256:__PHASE_66_3_DIGEST__; evidence_reference=docs/phase-66-3-shuffle-sample-execution-rc-proof.md; verifier=scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "phase_66_4_evidence=evidence_id=sha256:__PHASE_66_4_DIGEST__; evidence_reference=docs/phase-66-4-ai-assisted-triage-rc-proof.md; verifier=scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "phase_66_5_evidence=evidence_id=sha256:__PHASE_66_5_DIGEST__; evidence_reference=docs/phase-66-5-report-export-rc-proof.md; verifier=scripts/verify-phase-66-5-report-export-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "phase_66_6_evidence=evidence_id=sha256:__PHASE_66_6_DIGEST__; evidence_reference=docs/phase-66-6-rc-supportability-proof.md; verifier=scripts/verify-phase-66-6-rc-supportability-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
   "wazuh_negative_evidence=evidence_id=negative:wazuh:001; surface=wazuh; attempt=source-truth-promotion; result=rejected; authoritative_record=aegisops://alerts/alert-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
   "shuffle_negative_evidence=evidence_id=negative:shuffle:001; surface=shuffle; attempt=execution-receipt-promotion; result=rejected; authoritative_record=aegisops://reconciliation/rec-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
   "ai_negative_evidence=evidence_id=negative:ai:001; surface=ai; attempt=approval-bypass; result=rejected; authoritative_record=aegisops://approvals/approval-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
@@ -80,6 +88,13 @@ copy_valid_repo() {
   for path in "${fixture_paths[@]}"; do
     mkdir -p "${target}/$(dirname "${path}")"
     cp "${repo_root}/${path}" "${target}/${path}"
+  done
+  for path in "${target}"/scripts/verify-phase-66-[1-6]-*.sh; do
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      'set -euo pipefail' \
+      'exit 0' >"${path}"
+    chmod +x "${path}"
   done
   git -C "${target}" init -q
   git -C "${target}" config user.name "Phase 66.7 Self Test"
@@ -137,6 +152,40 @@ replace_packet_field() {
     "${target}/${doc_rel}"
 }
 
+materialize_packet_line() {
+  local target="$1"
+  local repository_revision="$2"
+  local line="$3"
+  local phase
+  local placeholder
+  local reference
+  local digest
+
+  line="${line//__REPOSITORY_REVISION__/${repository_revision}}"
+  line="${line//__TARGET_REVISION__/${repository_revision}}"
+  for phase in 1 2 3 4 5 6; do
+    placeholder="__PHASE_66_${phase}_DIGEST__"
+    if [[ "${line}" != *"${placeholder}"* ]]; then
+      continue
+    fi
+    case "${phase}" in
+      1) reference="docs/phase-66-1-clean-host-rc-e2e-harness.md" ;;
+      2) reference="docs/phase-66-2-wazuh-sample-signal-rc-proof.md" ;;
+      3) reference="docs/phase-66-3-shuffle-sample-execution-rc-proof.md" ;;
+      4) reference="docs/phase-66-4-ai-assisted-triage-rc-proof.md" ;;
+      5) reference="docs/phase-66-5-report-export-rc-proof.md" ;;
+      6) reference="docs/phase-66-6-rc-supportability-proof.md" ;;
+    esac
+    digest="$(
+      git -C "${target}" show "${repository_revision}:${reference}" |
+        shasum -a 256 |
+        awk '{print $1}'
+    )"
+    line="${line//${placeholder}/${digest}}"
+  done
+  printf '%s\n' "${line}"
+}
+
 append_complete_packet() {
   local target="$1"
   local repository_revision
@@ -145,7 +194,7 @@ append_complete_packet() {
   repository_revision="$(git -C "${target}" rev-parse HEAD)"
   printf '\n## Test Evidence Packet\n\n' >>"${target}/${doc_rel}"
   for line in "${packet_lines[@]}"; do
-    printf '%s\n' "${line//__REPOSITORY_REVISION__/${repository_revision}}" >>"${target}/${doc_rel}"
+    materialize_packet_line "${target}" "${repository_revision}" "${line}" >>"${target}/${doc_rel}"
   done
 }
 
@@ -159,7 +208,7 @@ append_complete_table_packet() {
   repository_revision="$(git -C "${target}" rev-parse HEAD)"
   printf '\n## Test Table Evidence Packet\n\n| Field | Value |\n| --- | --- |\n' >>"${target}/${doc_rel}"
   for line in "${packet_lines[@]}"; do
-    line="${line//__REPOSITORY_REVISION__/${repository_revision}}"
+    line="$(materialize_packet_line "${target}" "${repository_revision}" "${line}")"
     field="${line%%=*}"
     value="${line#*=}"
     printf '| `%s` | %s |\n' "${field}" "${value}" >>"${target}/${doc_rel}"
@@ -177,7 +226,8 @@ packet_mutation_case() {
   copy_valid_repo "${target}"
   append_complete_packet "${target}"
   target_revision="$(git -C "${target}" rev-parse HEAD)"
-  value="${value//__TARGET_REVISION__/${target_revision}}"
+  value="$(materialize_packet_line "${target}" "${target_revision}" "${field}=${value}")"
+  value="${value#*=}"
   replace_packet_field "${target}" "${field}" "${value}"
   assert_fails_with "${target}" "${expected}"
 }
@@ -216,6 +266,13 @@ table_repo="${workdir}/table"
 copy_valid_repo "${table_repo}"
 append_complete_table_packet "${table_repo}"
 assert_passes "${table_repo}"
+
+committed_packet_repo="${workdir}/committed-packet"
+copy_valid_repo "${committed_packet_repo}"
+append_complete_packet "${committed_packet_repo}"
+git -C "${committed_packet_repo}" add "${doc_rel}"
+git -C "${committed_packet_repo}" commit -qm "store proof packet"
+assert_passes "${committed_packet_repo}"
 
 missing_doc_repo="${workdir}/missing-doc"
 copy_valid_repo "${missing_doc_repo}"
@@ -303,25 +360,50 @@ packet_mutation_case \
   "bad-revision" \
   "repository_revision" \
   "0123456789012345678901234567890123456789" \
-  "does not match repository HEAD"
+  "evidence-producing revision is not a commit in this repository"
 
 packet_mutation_case \
   "mixed-phase-run" \
   "phase_66_2_evidence" \
-  "evidence_id=proof:66.2:001; verifier=scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh; result=passed; journey_run_id=rc66-other-001; repository_revision=__TARGET_REVISION__" \
+  "evidence_id=sha256:__PHASE_66_2_DIGEST__; evidence_reference=docs/phase-66-2-wazuh-sample-signal-rc-proof.md; verifier=scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh; result=passed; journey_run_id=rc66-other-001; repository_revision=__TARGET_REVISION__" \
   "mixed journey_run_id"
 
 packet_mutation_case \
   "wrong-phase-verifier" \
   "phase_66_4_evidence" \
-  "evidence_id=proof:66.4:001; verifier=scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "evidence_id=sha256:__PHASE_66_4_DIGEST__; evidence_reference=docs/phase-66-4-ai-assisted-triage-rc-proof.md; verifier=scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
   "unexpected verifier path"
 
 packet_mutation_case \
   "failed-phase-result" \
   "phase_66_5_evidence" \
-  "evidence_id=proof:66.5:001; verifier=scripts/verify-phase-66-5-report-export-rc-proof.sh; result=failed; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "evidence_id=sha256:__PHASE_66_5_DIGEST__; evidence_reference=docs/phase-66-5-report-export-rc-proof.md; verifier=scripts/verify-phase-66-5-report-export-rc-proof.sh; result=failed; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
   "verifier result must be passed"
+
+packet_mutation_case \
+  "wrong-evidence-reference" \
+  "phase_66_3_evidence" \
+  "evidence_id=sha256:__PHASE_66_3_DIGEST__; evidence_reference=docs/phase-66-2-wazuh-sample-signal-rc-proof.md; verifier=scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "unexpected evidence reference"
+
+packet_mutation_case \
+  "fabricated-evidence-id" \
+  "phase_66_1_evidence" \
+  "evidence_id=sha256:0000000000000000000000000000000000000000000000000000000000000000; evidence_reference=docs/phase-66-1-clean-host-rc-e2e-harness.md; verifier=scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "evidence_id does not match resolved evidence reference"
+
+failing_prerequisite_repo="${workdir}/failing-prerequisite"
+copy_valid_repo "${failing_prerequisite_repo}"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'echo "simulated prerequisite failure" >&2' \
+  'exit 1' \
+  >"${failing_prerequisite_repo}/scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh"
+chmod +x "${failing_prerequisite_repo}/scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh"
+git -C "${failing_prerequisite_repo}" add scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh
+git -C "${failing_prerequisite_repo}" commit -qm "fail prerequisite verifier"
+append_complete_packet "${failing_prerequisite_repo}"
+assert_fails_with "${failing_prerequisite_repo}" "prerequisite verifier failed: simulated prerequisite failure"
 
 packet_mutation_case \
   "wrong-surface" \
@@ -428,6 +510,7 @@ overclaim_case "wazuh-truth" "Wazuh is authoritative alert truth."
 overclaim_case "reverse-wazuh-truth" "Alert truth is owned by Wazuh."
 overclaim_case "shuffle-execution" "Shuffle may execute and close the case."
 overclaim_case "ai-approval" "AI output can approve the action."
+overclaim_case "ai-plural-case-closure" "AI output can close cases."
 overclaim_case "ticket-closure" "Tickets can close the case."
 overclaim_case "external-evidence-truth" "External evidence is evidence truth."
 overclaim_case "ui-cache-truth" "UI cache is workflow truth."
@@ -446,5 +529,28 @@ overclaim_case "execution-bypass" "Execution bypass is supported."
 overclaim_case "reconciliation-bypass" "Reconciliation bypass is valid."
 overclaim_case "case-shortcut" "Case-closure shortcut is accepted."
 overclaim_case "source-shortcut" "Source-admission shortcut is allowed."
+
+real_worktree="${workdir}/real-prerequisite-worktree"
+git -C "${repo_root}" worktree add --detach --quiet "${real_worktree}" HEAD
+git -C "${real_worktree}" config user.name "Phase 66.7 Self Test"
+git -C "${real_worktree}" config user.email "phase-66-7-self-test@invalid.example"
+cp "${repo_root}/${doc_rel}" "${real_worktree}/${doc_rel}"
+cp \
+  "${repo_root}/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh" \
+  "${real_worktree}/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh"
+cp \
+  "${repo_root}/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh" \
+  "${real_worktree}/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh"
+if ! git -C "${real_worktree}" diff --quiet; then
+  git -C "${real_worktree}" add \
+    "${doc_rel}" \
+    scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh \
+    scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+  git -C "${real_worktree}" commit -qm "materialized prerequisite integration fixture"
+fi
+append_complete_packet "${real_worktree}"
+assert_passes "${real_worktree}"
+git -C "${repo_root}" worktree remove --force "${real_worktree}"
+real_worktree=""
 
 echo "Phase 66.7 RC authority-boundary proof-pack verifier self-test passes."

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -963,6 +963,31 @@ leak_case \
   "production secret-looking value detected"
 
 leak_case \
+  "multiline-html-api-key-assignment" \
+  $'<span>api_key</span>\n<span>=supersecretvalue123</span>' \
+  "production secret-looking value detected"
+
+leak_case \
+  "markdown-emphasis-api-key" \
+  "api_*key*=supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "markdown-underscore-emphasis-api-key" \
+  "_API_ key: supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "markdown-link-api-key" \
+  "[API](https://invalid.example) key: supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "markdown-link-uri-credentials" \
+  "[support](https://operator:supersecretvalue123@invalid.example)" \
+  "production secret-looking value detected"
+
+leak_case \
   "html-attribute-api-key" \
   '<span api_key="supersecretvalue123"></span>' \
   "production secret-looking value detected"
@@ -1005,6 +1030,16 @@ leak_case \
 leak_case \
   "html-entity-private-assignment" \
   "customer_name&#61;AcmeCorp" \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "multiline-html-private-assignment" \
+  $'<span>customer_name</span>\n<span>=AcmeCorp</span>' \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "markdown-emphasis-private-assignment" \
+  "customer_*name*=AcmeCorp" \
   "customer-private or ticket-private data detected"
 
 leak_case \
@@ -1121,9 +1156,14 @@ overclaim_case "source-shortcut" "Source-admission shortcut is allowed."
 
 allowed_doc_line_case "redacted-secret" "api_key=redacted"
 allowed_doc_line_case "redacted-markdown-escaped-secret" 'api\_key=redacted'
+allowed_doc_line_case "redacted-markdown-emphasis-secret" "api_*key*=redacted"
 allowed_doc_line_case "redacted-spaced-api-key" "API key: redacted"
 allowed_doc_line_case "redacted-html-split-api-key" "api_key<span></span>=redacted"
+allowed_doc_line_case \
+  "redacted-multiline-html-api-key" \
+  $'<span>api_key</span>\n<span>=redacted</span>'
 allowed_doc_line_case "quoted-removed-private-data" "customer_name=\"removed\""
+allowed_doc_line_case "redacted-markdown-emphasis-private-data" "customer_*name*=redacted"
 allowed_doc_line_case "redacted-customer-data-claim" "The proof pack includes redacted customer data."
 allowed_doc_line_case "absent-customer-data-claim" "The proof pack contains no customer data."
 allowed_doc_line_case "denied-unredacted-customer-data-claim" "The proof pack does not include unredacted customer data."
@@ -1134,6 +1174,7 @@ allowed_doc_line_case "must-not-retain-private-data" "The proof pack must not re
 allowed_doc_line_case "adverbially-denied-private-data" "The proof pack does not intentionally include raw customer payload."
 allowed_doc_line_case "denied-private-data-list" "The proof pack does not include, retain, or publish raw customer payload."
 allowed_doc_line_case "denied-ai-approval" "AI output can not approve the action."
+allowed_doc_line_case "denied-nor-ai-execution" "AI output cannot approve the action, nor can execute the action."
 allowed_doc_line_case "denied-mandatory-ai-approval" "AI output must not approve the action."
 allowed_doc_line_case "denied-advisory-ai-approval" "AI output should not approve the action."
 allowed_doc_line_case "denied-shall-ai-approval" "AI output shall not approve the action."

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -633,6 +633,21 @@ leak_case \
   "production secret-looking value detected"
 
 leak_case \
+  "html-entity-secret-assignment" \
+  "api_key&#61;supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "numeric-html-entity-secret-assignment" \
+  "api_key&#x3d;supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "html-entity-secret-field-and-colon" \
+  "api&#95;key&colon;supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
   "nested-customer-name" \
   "debug_note=reviewed; customer_name=AcmeCorp; disposition=accepted" \
   "customer-private or ticket-private data detected"
@@ -642,10 +657,58 @@ leak_case \
   "customer_name=redacted AcmeCorp" \
   "customer-private or ticket-private data detected"
 
+leak_case \
+  "html-entity-private-assignment" \
+  "customer_name&#61;AcmeCorp" \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "unrelated-denial-before-private-data-claim" \
+  "The proof pack does not preserve formatting and includes raw customer payload." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "denied-then-positive-private-data-claim" \
+  "The proof pack does not include raw customer payload but includes raw customer payload." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "html-entity-private-data-claim" \
+  "The proof pack includes raw&nbsp;customer payload." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "html-entity-email" \
+  "customer_contact=analyst&#64;example.com" \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "html-entity-local-path" \
+  "artifact=&#47;Users&#47;example&#47;proof.json" \
+  "workstation-local path detected"
+
+leak_case \
+  "positive-then-denied-private-data-claim" \
+  "The proof pack includes raw customer payload but does not preserve formatting." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "bare-not-before-private-data-claim" \
+  "The proof pack is not safe because it includes raw customer payload." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "unrelated-never-before-private-data-claim" \
+  "The proof pack never alters formatting then includes raw customer payload." \
+  "customer-private or ticket-private data detected"
+
 overclaim_case "wazuh-truth" "Wazuh is authoritative alert truth."
 overclaim_case "reverse-wazuh-truth" "Alert truth is owned by Wazuh."
 overclaim_case "shuffle-execution" "Shuffle may execute and close the case."
 overclaim_case "ai-approval" "AI output can approve the action."
+overclaim_case "html-entity-ai-approval" "AI&nbsp;output can approve the action."
+overclaim_case "numeric-html-entity-ai-approval" "AI&#32;output can approve the action."
+overclaim_case "html-entity-ai-subject" "A&#73;&nbsp;output can approve the action."
 overclaim_case "direct-ai-approval" "AI output approves the action."
 overclaim_case "unrelated-negation-before-ai-approval" "AI output is not advisory and can approve the action."
 overclaim_case "unrelated-negation-before-pronoun-approval" "AI output is not advisory, but it can approve the action."
@@ -676,6 +739,10 @@ overclaim_case "source-shortcut" "Source-admission shortcut is allowed."
 
 allowed_doc_line_case "redacted-secret" "api_key=redacted"
 allowed_doc_line_case "quoted-removed-private-data" "customer_name=\"removed\""
+allowed_doc_line_case "denied-private-data-claim" "The proof pack does not include raw customer payload."
+allowed_doc_line_case "must-not-retain-private-data" "The proof pack must not retain raw customer payload."
+allowed_doc_line_case "adverbially-denied-private-data" "The proof pack does not intentionally include raw customer payload."
+allowed_doc_line_case "denied-private-data-list" "The proof pack does not include, retain, or publish raw customer payload."
 allowed_doc_line_case "denied-ai-approval" "AI output can not approve the action."
 allowed_doc_line_case "denied-elided-ai-execution" "AI output cannot approve the action; cannot execute the action."
 allowed_doc_line_case "sentence-boundary-no-elision" "AI output cannot approve the action. Can operators execute the action?"

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -296,6 +296,19 @@ append_complete_packet() {
   done
 }
 
+append_complete_link_packet() {
+  local target="$1"
+  local repository_revision
+  local line
+
+  repository_revision="$(git -C "${target}" rev-parse HEAD)"
+  printf '\n## Test Markdown Link Evidence Packet\n\n' >>"${target}/${doc_rel}"
+  for line in "${packet_lines[@]}"; do
+    line="$(materialize_packet_line "${target}" "${repository_revision}" "${line}")"
+    printf '[%s](https://example.invalid/proof)\n' "${line}" >>"${target}/${doc_rel}"
+  done
+}
+
 append_complete_table_packet() {
   local target="$1"
   local repository_revision
@@ -493,6 +506,31 @@ append_doc_line \
   'journey_<span></span>run_id=rc66-fabricated-001'
 assert_fails_with "${inline_html_field_repo}" "raw HTML evidence syntax is not supported"
 
+markdown_link_field_repo="${workdir}/markdown-link-field"
+copy_valid_repo "${markdown_link_field_repo}"
+append_doc_line \
+  "${markdown_link_field_repo}" \
+  '[journey_run_id=rc66-fabricated-001](https://example.invalid/proof)'
+assert_fails_with \
+  "${markdown_link_field_repo}" \
+  "Markdown link evidence syntax is not supported"
+
+complete_markdown_link_packet_repo="${workdir}/complete-markdown-link-packet"
+copy_valid_repo "${complete_markdown_link_packet_repo}"
+append_complete_link_packet "${complete_markdown_link_packet_repo}"
+assert_fails_with \
+  "${complete_markdown_link_packet_repo}" \
+  "Markdown link evidence syntax is not supported"
+
+markdown_emphasis_field_repo="${workdir}/markdown-emphasis-field"
+copy_valid_repo "${markdown_emphasis_field_repo}"
+append_doc_line \
+  "${markdown_emphasis_field_repo}" \
+  'journey_*run_id*=rc66-fabricated-001'
+assert_fails_with \
+  "${markdown_emphasis_field_repo}" \
+  "partial evidence packet"
+
 details_html_field_repo="${workdir}/details-html-field"
 copy_valid_repo "${details_html_field_repo}"
 append_doc_line \
@@ -581,6 +619,36 @@ git -C "${failing_prerequisite_repo}" add scripts/verify-phase-66-4-ai-assisted-
 git -C "${failing_prerequisite_repo}" commit -qm "fail prerequisite verifier"
 append_complete_packet "${failing_prerequisite_repo}"
 assert_fails_with "${failing_prerequisite_repo}" "prerequisite verifier failed: simulated prerequisite failure"
+
+mutating_prerequisite_repo="${workdir}/mutating-prerequisite"
+copy_valid_repo "${mutating_prerequisite_repo}"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'printf "mutated evidence\n" >"$1/docs/phase-66-2-wazuh-sample-signal-rc-proof.md"' \
+  >"${mutating_prerequisite_repo}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+chmod +x "${mutating_prerequisite_repo}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+git -C "${mutating_prerequisite_repo}" add scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh
+git -C "${mutating_prerequisite_repo}" commit -qm "mutate later prerequisite evidence"
+append_complete_packet "${mutating_prerequisite_repo}"
+assert_fails_with \
+  "${mutating_prerequisite_repo}" \
+  "prerequisite verifier modified isolated worktree"
+
+committing_prerequisite_repo="${workdir}/committing-prerequisite"
+copy_valid_repo "${committing_prerequisite_repo}"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'git -C "$1" commit --allow-empty -qm "mutate evidence revision"' \
+  >"${committing_prerequisite_repo}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+chmod +x "${committing_prerequisite_repo}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+git -C "${committing_prerequisite_repo}" add scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh
+git -C "${committing_prerequisite_repo}" commit -qm "commit from prerequisite verifier"
+append_complete_packet "${committing_prerequisite_repo}"
+assert_fails_with \
+  "${committing_prerequisite_repo}" \
+  "prerequisite verifier changed isolated worktree revision"
 
 missing_negative_manifest_repo="${workdir}/missing-negative-manifest"
 copy_valid_repo "${missing_negative_manifest_repo}"
@@ -1033,6 +1101,26 @@ leak_case \
   "customer-private or ticket-private data detected"
 
 leak_case \
+  "customer-id-assignment" \
+  "customer_id=cust-123456" \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "spaced-customer-id-assignment" \
+  "customer ID: cust-123456" \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "customer-identifiers-assignment" \
+  "customer_identifiers=cust-123456" \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "tenant-id-assignment" \
+  "tenant-id=tenant-123456" \
+  "customer-private or ticket-private data detected"
+
+leak_case \
   "multiline-html-private-assignment" \
   $'<span>customer_name</span>\n<span>=AcmeCorp</span>' \
   "customer-private or ticket-private data detected"
@@ -1163,6 +1251,9 @@ allowed_doc_line_case \
   "redacted-multiline-html-api-key" \
   $'<span>api_key</span>\n<span>=redacted</span>'
 allowed_doc_line_case "quoted-removed-private-data" "customer_name=\"removed\""
+allowed_doc_line_case "redacted-customer-id" "customer_id=redacted"
+allowed_doc_line_case "redacted-customer-identifiers" "customer identifiers: redacted"
+allowed_doc_line_case "removed-tenant-id" "tenant ID: removed"
 allowed_doc_line_case "redacted-markdown-emphasis-private-data" "customer_*name*=redacted"
 allowed_doc_line_case "redacted-customer-data-claim" "The proof pack includes redacted customer data."
 allowed_doc_line_case "absent-customer-data-claim" "The proof pack contains no customer data."

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -457,6 +457,27 @@ copy_valid_repo "${json_repo}"
 append_doc_line "${json_repo}" '{"repository_revision":"0123456789012345678901234567890123456789"}'
 assert_fails_with "${json_repo}" "JSON, YAML, and object-literal evidence syntax is not supported"
 
+html_table_repo="${workdir}/html-table"
+copy_valid_repo "${html_table_repo}"
+append_doc_line \
+  "${html_table_repo}" \
+  '<table><tr><td>journey_run_id</td><td>rc66-fabricated-001</td></tr><tr><td>repository_revision</td><td>0000000000000000000000000000000000000000</td></tr></table>'
+assert_fails_with "${html_table_repo}" "raw HTML evidence syntax is not supported"
+
+multiline_html_table_repo="${workdir}/multiline-html-table"
+copy_valid_repo "${multiline_html_table_repo}"
+append_doc_line \
+  "${multiline_html_table_repo}" \
+  $'<table>\n<tr><td>journey_run_id</td><td>rc66-fabricated-001</td></tr>\n</table>'
+assert_fails_with "${multiline_html_table_repo}" "raw HTML evidence syntax is not supported"
+
+inline_html_field_repo="${workdir}/inline-html-field"
+copy_valid_repo "${inline_html_field_repo}"
+append_doc_line \
+  "${inline_html_field_repo}" \
+  'journey_<span></span>run_id=rc66-fabricated-001'
+assert_fails_with "${inline_html_field_repo}" "raw HTML evidence syntax is not supported"
+
 packet_mutation_case \
   "bad-journey" \
   "journey_run_id" \
@@ -795,6 +816,26 @@ leak_case \
   "production secret-looking value detected"
 
 leak_case \
+  "html-tag-split-api-key-assignment" \
+  "api_key<span></span>=supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "html-tag-split-api-key-name" \
+  "API <em></em>key: supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "html-attribute-api-key" \
+  '<span api_key="supersecretvalue123"></span>' \
+  "production secret-looking value detected"
+
+leak_case \
+  "html-comment-api-key" \
+  "<!-- api_key=supersecretvalue123 -->" \
+  "production secret-looking value detected"
+
+leak_case \
   "secret-after-redaction-marker" \
   "api_key=redacted supersecretvalue123" \
   "production secret-looking value detected"
@@ -873,6 +914,16 @@ overclaim_case "wazuh-truth" "Wazuh is authoritative alert truth."
 overclaim_case "reverse-wazuh-truth" "Alert truth is owned by Wazuh."
 overclaim_case "shuffle-execution" "Shuffle may execute and close the case."
 overclaim_case "ai-approval" "AI output can approve the action."
+overclaim_case "mandatory-ai-approval" "AI output must approve the action."
+overclaim_case "advisory-ai-approval" "AI output should approve the action."
+overclaim_case "shall-ai-execution" "AI output shall execute the action."
+overclaim_case "required-ai-approval" "AI output is required to approve the action."
+overclaim_case "obligated-ai-execution" "AI output is obligated to execute the action."
+overclaim_case "ai-has-to-approve" "AI output has to approve the action."
+overclaim_case "ai-needs-to-execute" "AI output needs to execute the action."
+overclaim_case "ai-ought-to-approve" "AI output ought to approve the action."
+overclaim_case "unrelated-denial-before-mandatory-ai-approval" "AI output cannot recommend changes and must approve the action."
+overclaim_case "html-tag-split-mandatory-ai-approval" "AI <span></span>output must approve the action."
 overclaim_case "ai-permitted-approval" "AI output is permitted to approve the action."
 overclaim_case "ai-authorized-execution" "AI output is authorized to execute the action."
 overclaim_case "ai-has-authority" "AI output has authority to approve the action."
@@ -921,12 +972,19 @@ overclaim_case "source-shortcut" "Source-admission shortcut is allowed."
 
 allowed_doc_line_case "redacted-secret" "api_key=redacted"
 allowed_doc_line_case "redacted-spaced-api-key" "API key: redacted"
+allowed_doc_line_case "redacted-html-split-api-key" "api_key<span></span>=redacted"
 allowed_doc_line_case "quoted-removed-private-data" "customer_name=\"removed\""
 allowed_doc_line_case "denied-private-data-claim" "The proof pack does not include raw customer payload."
 allowed_doc_line_case "must-not-retain-private-data" "The proof pack must not retain raw customer payload."
 allowed_doc_line_case "adverbially-denied-private-data" "The proof pack does not intentionally include raw customer payload."
 allowed_doc_line_case "denied-private-data-list" "The proof pack does not include, retain, or publish raw customer payload."
 allowed_doc_line_case "denied-ai-approval" "AI output can not approve the action."
+allowed_doc_line_case "denied-mandatory-ai-approval" "AI output must not approve the action."
+allowed_doc_line_case "denied-advisory-ai-approval" "AI output should not approve the action."
+allowed_doc_line_case "denied-shall-ai-approval" "AI output shall not approve the action."
+allowed_doc_line_case "denied-ai-has-to-approve" "AI output does not have to approve the action."
+allowed_doc_line_case "denied-required-ai-approval" "AI output is not required to approve the action."
+allowed_doc_line_case "denied-html-split-ai-approval" "AI <span></span>output must not approve the action."
 allowed_doc_line_case "denied-ai-permission" "AI output is not permitted to approve the action."
 allowed_doc_line_case "denied-ai-authorization" "AI output cannot be authorized to execute the action."
 allowed_doc_line_case "denied-ai-authority" "AI output does not have authority to approve the action."

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -24,6 +24,8 @@ fail_stderr="${workdir}/fail.err"
 
 fixture_paths=(
   "README.md"
+  "control-plane/aegisops/__init__.py"
+  "control-plane/aegisops/control_plane/publishable_paths.py"
   "docs/phase-66-7-rc-authority-boundary-proof-pack.md"
   "docs/phase-66-1-clean-host-rc-e2e-harness.md"
   "docs/phase-66-2-wazuh-sample-signal-rc-proof.md"
@@ -54,6 +56,7 @@ PY
 )"
 local_user_home="$(printf '/%s/%s/' 'Users' 'example')"
 wsl_user_home="$(printf '/mnt/%s/%s/%s/' 'c' 'Users' 'alice')"
+embedded_wsl_file_uri="https://example.com/file://${wsl_user_home}project"
 
 packet_lines=(
   "journey_run_id=rc66-authority-001"
@@ -159,6 +162,8 @@ copy_valid_repo() {
     mkdir -p "${target}/$(dirname "${path}")"
     cp "${repo_root}/${path}" "${target}/${path}"
   done
+  printf '%s\n' '"""Minimal control-plane test fixture."""' \
+    >"${target}/control-plane/aegisops/control_plane/__init__.py"
   for path in "${target}"/scripts/verify-phase-66-[1-6]-*.sh; do
     printf '%s\n' \
       '#!/usr/bin/env bash' \
@@ -178,7 +183,7 @@ copy_valid_repo() {
 assert_passes() {
   local target="$1"
 
-  if ! PHASE66_7_SKIP_PATH_HYGIENE=1 bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
     echo "Expected verifier to pass for ${target}" >&2
     cat "${pass_stderr}" >&2
     exit 1
@@ -189,7 +194,7 @@ assert_fails_with() {
   local target="$1"
   local expected="$2"
 
-  if PHASE66_7_SKIP_PATH_HYGIENE=1 bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
     echo "Expected verifier to fail for ${target}" >&2
     exit 1
   fi
@@ -650,6 +655,57 @@ assert_fails_with \
   "${committing_prerequisite_repo}" \
   "prerequisite verifier changed isolated worktree revision"
 
+ignored_prerequisite_repo="${workdir}/ignored-prerequisite"
+copy_valid_repo "${ignored_prerequisite_repo}"
+printf '.phase66-7-prerequisite-cache\n' >"${ignored_prerequisite_repo}/.gitignore"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'printf "hidden prerequisite state\n" >"$1/.phase66-7-prerequisite-cache"' \
+  >"${ignored_prerequisite_repo}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+chmod +x "${ignored_prerequisite_repo}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+git -C "${ignored_prerequisite_repo}" add \
+  .gitignore \
+  scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh
+git -C "${ignored_prerequisite_repo}" commit -qm "leave ignored prerequisite state"
+append_complete_packet "${ignored_prerequisite_repo}"
+assert_fails_with \
+  "${ignored_prerequisite_repo}" \
+  "prerequisite verifier modified isolated worktree"
+
+symlinked_phase_reference_repo="${workdir}/symlinked-phase-reference"
+copy_valid_repo "${symlinked_phase_reference_repo}"
+outside_phase_reference="${workdir}/outside-phase-reference.md"
+printf 'mutable external proof\n' >"${outside_phase_reference}"
+rm "${symlinked_phase_reference_repo}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
+ln -s \
+  "${outside_phase_reference}" \
+  "${symlinked_phase_reference_repo}/docs/phase-66-1-clean-host-rc-e2e-harness.md"
+git -C "${symlinked_phase_reference_repo}" add \
+  docs/phase-66-1-clean-host-rc-e2e-harness.md
+git -C "${symlinked_phase_reference_repo}" commit -qm "symlink phase evidence"
+append_complete_packet "${symlinked_phase_reference_repo}"
+assert_fails_with \
+  "${symlinked_phase_reference_repo}" \
+  "evidence reference must resolve to a regular Git blob"
+
+symlinked_phase_verifier_repo="${workdir}/symlinked-phase-verifier"
+copy_valid_repo "${symlinked_phase_verifier_repo}"
+outside_phase_verifier="${workdir}/outside-phase-verifier.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"${outside_phase_verifier}"
+chmod +x "${outside_phase_verifier}"
+rm "${symlinked_phase_verifier_repo}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+ln -s \
+  "${outside_phase_verifier}" \
+  "${symlinked_phase_verifier_repo}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+git -C "${symlinked_phase_verifier_repo}" add \
+  scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh
+git -C "${symlinked_phase_verifier_repo}" commit -qm "symlink prerequisite verifier"
+append_complete_packet "${symlinked_phase_verifier_repo}"
+assert_fails_with \
+  "${symlinked_phase_verifier_repo}" \
+  "verifier must resolve to a regular Git blob"
+
 missing_negative_manifest_repo="${workdir}/missing-negative-manifest"
 copy_valid_repo "${missing_negative_manifest_repo}"
 rm "${missing_negative_manifest_repo}/evidence/phase-66-7/negative-observations.json"
@@ -659,6 +715,24 @@ append_complete_packet "${missing_negative_manifest_repo}"
 assert_fails_with \
   "${missing_negative_manifest_repo}" \
   "negative evidence reference does not resolve at repository_revision"
+
+symlinked_negative_manifest_repo="${workdir}/symlinked-negative-manifest"
+copy_valid_repo "${symlinked_negative_manifest_repo}"
+outside_negative_manifest="${workdir}/outside-negative-observations.json"
+cp \
+  "${symlinked_negative_manifest_repo}/evidence/phase-66-7/negative-observations.json" \
+  "${outside_negative_manifest}"
+rm "${symlinked_negative_manifest_repo}/evidence/phase-66-7/negative-observations.json"
+ln -s \
+  "${outside_negative_manifest}" \
+  "${symlinked_negative_manifest_repo}/evidence/phase-66-7/negative-observations.json"
+git -C "${symlinked_negative_manifest_repo}" add \
+  evidence/phase-66-7/negative-observations.json
+git -C "${symlinked_negative_manifest_repo}" commit -qm "symlink negative evidence manifest"
+append_complete_packet "${symlinked_negative_manifest_repo}"
+assert_fails_with \
+  "${symlinked_negative_manifest_repo}" \
+  "negative evidence reference must resolve to a regular Git blob"
 
 malformed_negative_manifest_repo="${workdir}/malformed-negative-manifest"
 copy_valid_repo "${malformed_negative_manifest_repo}"
@@ -827,6 +901,24 @@ assert_fails_with \
   "${missing_limitation_manifest_repo}" \
   "limitation evidence reference does not resolve at repository_revision"
 
+symlinked_limitation_manifest_repo="${workdir}/symlinked-limitation-manifest"
+copy_valid_repo "${symlinked_limitation_manifest_repo}"
+outside_limitation_manifest="${workdir}/outside-limitations.json"
+cp \
+  "${symlinked_limitation_manifest_repo}/evidence/phase-66-7/limitations.json" \
+  "${outside_limitation_manifest}"
+rm "${symlinked_limitation_manifest_repo}/evidence/phase-66-7/limitations.json"
+ln -s \
+  "${outside_limitation_manifest}" \
+  "${symlinked_limitation_manifest_repo}/evidence/phase-66-7/limitations.json"
+git -C "${symlinked_limitation_manifest_repo}" add \
+  evidence/phase-66-7/limitations.json
+git -C "${symlinked_limitation_manifest_repo}" commit -qm "symlink limitation manifest"
+append_complete_packet "${symlinked_limitation_manifest_repo}"
+assert_fails_with \
+  "${symlinked_limitation_manifest_repo}" \
+  "limitation evidence reference must resolve to a regular Git blob"
+
 malformed_limitation_manifest_repo="${workdir}/malformed-limitation-manifest"
 copy_valid_repo "${malformed_limitation_manifest_repo}"
 printf '{invalid-json\n' \
@@ -914,6 +1006,22 @@ leak_case \
   "wsl-file-uri" \
   "artifact=file://${wsl_user_home}proof.json" \
   "workstation-local path detected"
+
+path_hygiene_bypass_repo="${workdir}/path-hygiene-bypass"
+copy_valid_repo "${path_hygiene_bypass_repo}"
+printf '\nExternal note: %s\n' \
+  "${local_user_home}operator/private.txt" \
+  >>"${path_hygiene_bypass_repo}/README.md"
+if PHASE66_7_SKIP_PATH_HYGIENE=1 \
+  bash "${verifier}" "${path_hygiene_bypass_repo}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+  echo "Expected path hygiene to remain mandatory" >&2
+  exit 1
+fi
+if ! grep -Fq -- "publishable path hygiene failed" "${fail_stderr}"; then
+  echo "Expected mandatory path-hygiene failure" >&2
+  cat "${fail_stderr}" >&2
+  exit 1
+fi
 
 leak_case \
   "email" \
@@ -1003,6 +1111,26 @@ leak_case \
 leak_case \
   "spaced-refresh-token" \
   "refresh token: supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "session-token" \
+  "session_token=abcdefghijklmnopqrstuvwxyz123456" \
+  "production secret-looking value detected"
+
+leak_case \
+  "session-id" \
+  "session-id=abcdefghijklmnopqrstuvwxyz123456" \
+  "production secret-looking value detected"
+
+leak_case \
+  "cookie-header" \
+  "Cookie: session=abcdefghijklmnopqrstuvwxyz123456" \
+  "production secret-looking value detected"
+
+leak_case \
+  "cookie-token" \
+  "cookie_token=abcdefghijklmnopqrstuvwxyz123456" \
   "production secret-looking value detected"
 
 leak_case \
@@ -1146,6 +1274,16 @@ leak_case \
   "customer-private or ticket-private data detected"
 
 leak_case \
+  "markdown-emphasis-private-data-claim" \
+  "The proof pack includes raw **customer** data." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "markdown-link-private-data-claim" \
+  "The proof pack includes [raw customer](https://invalid.example) data." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
   "html-entity-email" \
   "customer_contact=analyst&#64;example.com" \
   "customer-private or ticket-private data detected"
@@ -1186,6 +1324,12 @@ overclaim_case "unrelated-denial-before-mandatory-ai-approval" "AI output cannot
 overclaim_case "html-tag-split-mandatory-ai-approval" "AI <span></span>output must approve the action."
 overclaim_case "ai-permitted-approval" "AI output is permitted to approve the action."
 overclaim_case "ai-authorized-execution" "AI output is authorized to execute the action."
+overclaim_case "ai-capable-of-approval" "AI output is capable of approving the action."
+overclaim_case "ai-able-to-approve" "AI output is able to approve the action."
+overclaim_case "ai-has-ability-to-approve" "AI output has the ability to approve the action."
+overclaim_case "ai-possesses-capability-to-close" "AI output possesses capability to close the case."
+overclaim_case "elided-ai-capability" "AI output cannot approve the action but able to execute the action."
+overclaim_case "unrelated-denial-before-ai-capability" "AI output cannot recommend changes and capable of approving the action."
 overclaim_case "ai-has-authority" "AI output has authority to approve the action."
 overclaim_case "ai-retains-authority" "AI output retains authority to approve the action."
 overclaim_case "ai-retained-authority" "AI output retained authority to approve the action."
@@ -1246,6 +1390,10 @@ allowed_doc_line_case "redacted-secret" "api_key=redacted"
 allowed_doc_line_case "redacted-markdown-escaped-secret" 'api\_key=redacted'
 allowed_doc_line_case "redacted-markdown-emphasis-secret" "api_*key*=redacted"
 allowed_doc_line_case "redacted-spaced-api-key" "API key: redacted"
+allowed_doc_line_case "redacted-session-token" "session_token=redacted"
+allowed_doc_line_case "absent-session-id" "session-id=absent"
+allowed_doc_line_case "redacted-cookie" "Cookie: redacted"
+allowed_doc_line_case "removed-cookie-token" "cookie_token=removed"
 allowed_doc_line_case "redacted-html-split-api-key" "api_key<span></span>=redacted"
 allowed_doc_line_case \
   "redacted-multiline-html-api-key" \
@@ -1256,11 +1404,13 @@ allowed_doc_line_case "redacted-customer-identifiers" "customer identifiers: red
 allowed_doc_line_case "removed-tenant-id" "tenant ID: removed"
 allowed_doc_line_case "redacted-markdown-emphasis-private-data" "customer_*name*=redacted"
 allowed_doc_line_case "redacted-customer-data-claim" "The proof pack includes redacted customer data."
+allowed_doc_line_case "redacted-markdown-customer-data-claim" "The proof pack includes redacted **customer** data."
 allowed_doc_line_case "absent-customer-data-claim" "The proof pack contains no customer data."
 allowed_doc_line_case "denied-unredacted-customer-data-claim" "The proof pack does not include unredacted customer data."
 allowed_doc_line_case "denied-passive-customer-data-claim" "Customer data is not retained in the proof pack."
 allowed_doc_line_case "redacted-passive-customer-data-claim" "Redacted customer data is included in the proof pack."
 allowed_doc_line_case "denied-private-data-claim" "The proof pack does not include raw customer payload."
+allowed_doc_line_case "denied-markdown-private-data-claim" "The proof pack does not include raw **customer** data."
 allowed_doc_line_case "must-not-retain-private-data" "The proof pack must not retain raw customer payload."
 allowed_doc_line_case "adverbially-denied-private-data" "The proof pack does not intentionally include raw customer payload."
 allowed_doc_line_case "denied-private-data-list" "The proof pack does not include, retain, or publish raw customer payload."
@@ -1274,6 +1424,9 @@ allowed_doc_line_case "denied-required-ai-approval" "AI output is not required t
 allowed_doc_line_case "denied-html-split-ai-approval" "AI <span></span>output must not approve the action."
 allowed_doc_line_case "denied-ai-permission" "AI output is not permitted to approve the action."
 allowed_doc_line_case "denied-ai-authorization" "AI output cannot be authorized to execute the action."
+allowed_doc_line_case "denied-ai-capability" "AI output is not capable of approving the action."
+allowed_doc_line_case "denied-ai-ability" "AI output is unable to approve the action."
+allowed_doc_line_case "denied-ai-possessed-ability" "AI output does not have the ability to approve the action."
 allowed_doc_line_case "denied-ai-authority" "AI output does not have authority to approve the action."
 allowed_doc_line_case "denied-retained-ai-authority" "AI output does not retain authority to approve the action."
 allowed_doc_line_case "denied-granted-ai-authority" "AI output is granted no authority to approve the action."
@@ -1285,6 +1438,7 @@ allowed_doc_line_case "denied-ai-truth" "AI output is not approval truth."
 allowed_doc_line_case "denied-release-readiness" "Release artifacts do not prove RC readiness."
 allowed_doc_line_case "denied-production-ready" "This proof pack is not production-ready."
 allowed_doc_line_case "denied-ready-for-production" "This proof pack is not ready for production."
+allowed_doc_line_case "embedded-wsl-file-uri-url" "Reference: ${embedded_wsl_file_uri}"
 
 real_worktree="${workdir}/real-prerequisite-worktree"
 git -C "${repo_root}" worktree add --detach --quiet "${real_worktree}" HEAD

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -536,6 +536,42 @@ assert_fails_with \
   "${markdown_emphasis_field_repo}" \
   "partial evidence packet"
 
+heading_field_repo="${workdir}/heading-field"
+copy_valid_repo "${heading_field_repo}"
+append_doc_line \
+  "${heading_field_repo}" \
+  "### journey_run_id=rc66-fabricated-001"
+assert_fails_with \
+  "${heading_field_repo}" \
+  "Markdown heading evidence syntax is not supported"
+
+heading_field_name_repo="${workdir}/heading-field-name"
+copy_valid_repo "${heading_field_name_repo}"
+append_doc_line \
+  "${heading_field_name_repo}" \
+  "### journey_run_id format"
+assert_fails_with \
+  "${heading_field_name_repo}" \
+  "Markdown heading evidence syntax is not supported"
+
+emphasized_heading_field_repo="${workdir}/emphasized-heading-field"
+copy_valid_repo "${emphasized_heading_field_repo}"
+append_doc_line \
+  "${emphasized_heading_field_repo}" \
+  "### **journey_run_id**: rc66-fabricated-001"
+assert_fails_with \
+  "${emphasized_heading_field_repo}" \
+  "Markdown heading evidence syntax is not supported"
+
+setext_heading_field_repo="${workdir}/setext-heading-field"
+copy_valid_repo "${setext_heading_field_repo}"
+append_doc_line \
+  "${setext_heading_field_repo}" \
+  $'journey_run_id=rc66-fabricated-001\n---'
+assert_fails_with \
+  "${setext_heading_field_repo}" \
+  "Markdown heading evidence syntax is not supported"
+
 details_html_field_repo="${workdir}/details-html-field"
 copy_valid_repo "${details_html_field_repo}"
 append_doc_line \
@@ -671,6 +707,42 @@ git -C "${ignored_prerequisite_repo}" commit -qm "leave ignored prerequisite sta
 append_complete_packet "${ignored_prerequisite_repo}"
 assert_fails_with \
   "${ignored_prerequisite_repo}" \
+  "prerequisite verifier modified isolated worktree"
+
+assume_unchanged_prerequisite_repo="${workdir}/assume-unchanged-prerequisite"
+copy_valid_repo "${assume_unchanged_prerequisite_repo}"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'path="docs/phase-66-2-wazuh-sample-signal-rc-proof.md"' \
+  'git -C "$1" update-index --assume-unchanged -- "$path"' \
+  'printf "index-hidden evidence\n" >"$1/$path"' \
+  >"${assume_unchanged_prerequisite_repo}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+chmod +x "${assume_unchanged_prerequisite_repo}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+git -C "${assume_unchanged_prerequisite_repo}" add \
+  scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh
+git -C "${assume_unchanged_prerequisite_repo}" commit -qm "hide prerequisite mutation from index"
+append_complete_packet "${assume_unchanged_prerequisite_repo}"
+assert_fails_with \
+  "${assume_unchanged_prerequisite_repo}" \
+  "prerequisite verifier modified isolated worktree"
+
+skip_worktree_prerequisite_repo="${workdir}/skip-worktree-prerequisite"
+copy_valid_repo "${skip_worktree_prerequisite_repo}"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'path="docs/phase-66-2-wazuh-sample-signal-rc-proof.md"' \
+  'git -C "$1" update-index --skip-worktree -- "$path"' \
+  'printf "skip-worktree evidence\n" >"$1/$path"' \
+  >"${skip_worktree_prerequisite_repo}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+chmod +x "${skip_worktree_prerequisite_repo}/scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+git -C "${skip_worktree_prerequisite_repo}" add \
+  scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh
+git -C "${skip_worktree_prerequisite_repo}" commit -qm "hide prerequisite mutation with skip-worktree"
+append_complete_packet "${skip_worktree_prerequisite_repo}"
+assert_fails_with \
+  "${skip_worktree_prerequisite_repo}" \
   "prerequisite verifier modified isolated worktree"
 
 symlinked_phase_reference_repo="${workdir}/symlinked-phase-reference"
@@ -1029,6 +1101,21 @@ leak_case \
   "customer-private or ticket-private data detected"
 
 leak_case \
+  "sentence-final-email" \
+  "This packet includes customer email analyst@example.com." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "comma-terminated-email" \
+  "Contact analyst@example.com, then remove the address." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "parenthesized-email" \
+  "Customer contact (analyst@example.com)." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
   "private-ticket" \
   "ticket_private_content=customer-payload" \
   "customer-private or ticket-private data detected"
@@ -1335,6 +1422,13 @@ overclaim_case "ai-retains-authority" "AI output retains authority to approve th
 overclaim_case "ai-retained-authority" "AI output retained authority to approve the action."
 overclaim_case "ai-held-authority" "AI output held authority to approve the action."
 overclaim_case "ai-was-given-permission" "AI output was given permission to execute the action."
+overclaim_case "ai-has-been-given-authority" "AI output has been given authority to approve the action."
+overclaim_case "ai-had-been-granted-permission" "AI output had been granted permission to execute the action."
+overclaim_case "ai-has-been-delegated-authority" "AI output has been delegated authority to approve the action."
+overclaim_case "ai-was-assigned-authority" "AI output was assigned authority to close the case."
+overclaim_case "ai-has-been-entrusted-with-authority" "AI output has been entrusted with authority to reconcile the action."
+overclaim_case "ai-has-been-vested-with-power" "AI output has been vested with power to approve the action."
+overclaim_case "ai-was-accorded-the-right" "AI output was accorded the right to execute the action."
 overclaim_case "ai-maintains-power" "AI output maintains power to close the case."
 overclaim_case "ai-granted-permission" "AI output is granted permission to execute the action."
 overclaim_case "ai-granted-explicit-permission" "AI output is granted explicit permission to execute the action."
@@ -1424,6 +1518,9 @@ allowed_doc_line_case "denied-required-ai-approval" "AI output is not required t
 allowed_doc_line_case "denied-html-split-ai-approval" "AI <span></span>output must not approve the action."
 allowed_doc_line_case "denied-ai-permission" "AI output is not permitted to approve the action."
 allowed_doc_line_case "denied-ai-authorization" "AI output cannot be authorized to execute the action."
+allowed_doc_line_case "denied-completed-ai-delegation" "AI output has not been given authority to approve the action."
+allowed_doc_line_case "no-completed-ai-delegation" "AI output has been given no authority to approve the action."
+allowed_doc_line_case "denied-ai-delegation-record" "AI output has been denied authority to approve the action."
 allowed_doc_line_case "denied-ai-capability" "AI output is not capable of approving the action."
 allowed_doc_line_case "denied-ai-ability" "AI output is unable to approve the action."
 allowed_doc_line_case "denied-ai-possessed-ability" "AI output does not have the ability to approve the action."

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -437,6 +437,13 @@ copy_valid_repo "${partial_repo}"
 append_doc_line "${partial_repo}" $'## Partial Evidence Packet\n\njourney_run_id=rc66-authority-001'
 assert_fails_with "${partial_repo}" "partial evidence packet"
 
+markdown_escaped_partial_repo="${workdir}/markdown-escaped-partial"
+copy_valid_repo "${markdown_escaped_partial_repo}"
+append_doc_line \
+  "${markdown_escaped_partial_repo}" \
+  'journey\_run\_id=rc66-authority-001'
+assert_fails_with "${markdown_escaped_partial_repo}" "partial evidence packet"
+
 cross_section_repo="${workdir}/cross-section"
 copy_valid_repo "${cross_section_repo}"
 append_doc_line "${cross_section_repo}" $'## Packet A\n\njourney_run_id=rc66-authority-001\n\n## Packet B\n\nrepository_revision=0123456789012345678901234567890123456789'
@@ -452,6 +459,13 @@ yaml_repo="${workdir}/yaml"
 copy_valid_repo "${yaml_repo}"
 append_doc_line "${yaml_repo}" "journey_run_id: rc66-authority-001"
 assert_fails_with "${yaml_repo}" "JSON, YAML, and object-literal evidence syntax is not supported"
+
+markdown_escaped_yaml_repo="${workdir}/markdown-escaped-yaml"
+copy_valid_repo "${markdown_escaped_yaml_repo}"
+append_doc_line "${markdown_escaped_yaml_repo}" 'journey\_run\_id: rc66-authority-001'
+assert_fails_with \
+  "${markdown_escaped_yaml_repo}" \
+  "JSON, YAML, and object-literal evidence syntax is not supported"
 
 json_repo="${workdir}/json"
 copy_valid_repo "${json_repo}"
@@ -769,6 +783,11 @@ leak_case \
   "workstation-local path detected"
 
 leak_case \
+  "wsl-file-uri" \
+  "artifact=file://${wsl_user_home}proof.json" \
+  "workstation-local path detected"
+
+leak_case \
   "email" \
   "customer_contact=analyst@example.com" \
   "customer-private or ticket-private data detected"
@@ -821,6 +840,16 @@ leak_case \
 leak_case \
   "hyphenated-api-key" \
   "api-key=supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "markdown-escaped-api-key" \
+  'api\_key=supersecretvalue123' \
+  "production secret-looking value detected"
+
+leak_case \
+  "markdown-escaped-client-secret" \
+  'client\-secret=supersecretvalue123' \
   "production secret-looking value detected"
 
 leak_case \
@@ -1015,6 +1044,13 @@ overclaim_case "verifier-readiness" "Verifier output confirms RC readiness."
 overclaim_case "issue-lint-truth" "Issue-lint output is release truth."
 overclaim_case "ga-overclaim" "Phase 66.7 proves GA readiness."
 overclaim_case "production-overclaim" "Phase 66.7 enables production rollout."
+overclaim_case "production-ready-overclaim" "This proof pack is production-ready."
+overclaim_case "production-ready-spaced-overclaim" "This proof pack is production ready."
+overclaim_case "ready-for-production-overclaim" "This proof pack is ready for production."
+overclaim_case "fit-for-production-overclaim" "This proof pack is fit for production."
+overclaim_case "deploy-in-production-overclaim" "This proof pack is ready to deploy in production."
+overclaim_case "production-grade-overclaim" "This proof pack is production-grade."
+overclaim_case "markdown-escaped-production-ready-overclaim" 'This proof pack is production\-ready.'
 overclaim_case "broad-siem" "Phase 66.7 achieves broad enterprise SIEM parity."
 overclaim_case "broad-soar" "Phase 66.7 achieves broad enterprise SOAR parity."
 overclaim_case "approval-bypass" "Approval bypass is allowed."
@@ -1024,6 +1060,7 @@ overclaim_case "case-shortcut" "Case-closure shortcut is accepted."
 overclaim_case "source-shortcut" "Source-admission shortcut is allowed."
 
 allowed_doc_line_case "redacted-secret" "api_key=redacted"
+allowed_doc_line_case "redacted-markdown-escaped-secret" 'api\_key=redacted'
 allowed_doc_line_case "redacted-spaced-api-key" "API key: redacted"
 allowed_doc_line_case "redacted-html-split-api-key" "api_key<span></span>=redacted"
 allowed_doc_line_case "quoted-removed-private-data" "customer_name=\"removed\""
@@ -1054,6 +1091,8 @@ allowed_doc_line_case "denied-elided-ai-execution" "AI output cannot approve the
 allowed_doc_line_case "sentence-boundary-no-elision" "AI output cannot approve the action. Can operators execute the action?"
 allowed_doc_line_case "denied-ai-truth" "AI output is not approval truth."
 allowed_doc_line_case "denied-release-readiness" "Release artifacts do not prove RC readiness."
+allowed_doc_line_case "denied-production-ready" "This proof pack is not production-ready."
+allowed_doc_line_case "denied-ready-for-production" "This proof pack is not ready for production."
 
 real_worktree="${workdir}/real-prerequisite-worktree"
 git -C "${repo_root}" worktree add --detach --quiet "${real_worktree}" HEAD

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -76,7 +76,7 @@ packet_lines=(
   "verifier_output_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=verifier-output; attempt=rc-gate-promotion; result=rejected; authoritative_record=aegisops://gates/rc-gate-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
   "issue_lint_output_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=issue-lint-output; attempt=rc-gate-promotion; result=rejected; authoritative_record=aegisops://gates/rc-gate-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
   "owner_review=reviewer=security-reviewer; reviewed_at=${observed_at}; disposition=accepted; follow_up_owner=release-owner"
-  "limitation_references=ids=lim-66-7-001; owner=release-owner; decision_at=${observed_at}; follow_up_at=${follow_up_at}"
+  "limitation_references=evidence_id=sha256:__LIMITATION_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/limitations.json; ids=lim-66-7-001; owner=release-owner; decision_at=${observed_at}; follow_up_at=${follow_up_at}"
   "non_claims=rc-evidence-only,not-rc-gate-pass,not-ga,not-production-operations,not-commercial-replacement,not-broad-siem-parity,not-broad-soar-parity,not-subordinate-truth"
 )
 
@@ -123,6 +123,32 @@ path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding=
 PY
 }
 
+write_limitation_manifest() {
+  local target="$1"
+
+  mkdir -p "${target}/evidence/phase-66-7"
+  TARGET="${target}" OBSERVED_AT="${observed_at}" FOLLOW_UP_AT="${follow_up_at}" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+manifest = {
+    "schema_version": "phase-66-7-limitations/v1",
+    "limitations": [
+        {
+            "id": "lim-66-7-001",
+            "owner": "release-owner",
+            "disposition": "accepted",
+            "decision_at": os.environ["OBSERVED_AT"],
+            "follow_up_at": os.environ["FOLLOW_UP_AT"],
+        }
+    ],
+}
+path = Path(os.environ["TARGET"]) / "evidence/phase-66-7/limitations.json"
+path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+}
+
 copy_valid_repo() {
   local target="$1"
   local path
@@ -140,6 +166,7 @@ copy_valid_repo() {
     chmod +x "${path}"
   done
   write_negative_evidence_manifest "${target}"
+  write_limitation_manifest "${target}"
   git -C "${target}" init -q
   git -C "${target}" config user.name "Phase 66.7 Self Test"
   git -C "${target}" config user.email "phase-66-7-self-test@invalid.example"
@@ -239,6 +266,19 @@ materialize_packet_line() {
       digest="0000000000000000000000000000000000000000000000000000000000000000"
     fi
     line="${line//__NEGATIVE_EVIDENCE_DIGEST__/${digest}}"
+  fi
+  if [[ "${line}" == *"__LIMITATION_EVIDENCE_DIGEST__"* ]]; then
+    reference="evidence/phase-66-7/limitations.json"
+    if git -C "${target}" cat-file -e "${repository_revision}:${reference}" 2>/dev/null; then
+      digest="$(
+        git -C "${target}" show "${repository_revision}:${reference}" |
+          shasum -a 256 |
+          awk '{print $1}'
+      )"
+    else
+      digest="0000000000000000000000000000000000000000000000000000000000000000"
+    fi
+    line="${line//__LIMITATION_EVIDENCE_DIGEST__/${digest}}"
   fi
   printf '%s\n' "${line}"
 }
@@ -582,8 +622,85 @@ packet_mutation_case \
 packet_mutation_case \
   "invalid-follow-up" \
   "limitation_references" \
-  "ids=lim-66-7-001; owner=release-owner; decision_at=${observed_at}; follow_up_at=2000-01-01T00:00:00Z" \
+  "evidence_id=sha256:__LIMITATION_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/limitations.json; ids=lim-66-7-001; owner=release-owner; decision_at=${observed_at}; follow_up_at=2000-01-01T00:00:00Z" \
   "follow_up_at must be after decision_at"
+
+packet_mutation_case \
+  "fabricated-limitation-evidence-id" \
+  "limitation_references" \
+  "evidence_id=sha256:0000000000000000000000000000000000000000000000000000000000000000; evidence_reference=evidence/phase-66-7/limitations.json; ids=lim-66-7-001; owner=release-owner; decision_at=${observed_at}; follow_up_at=${follow_up_at}" \
+  "evidence_id does not match resolved evidence reference"
+
+packet_mutation_case \
+  "wrong-limitation-evidence-reference" \
+  "limitation_references" \
+  "evidence_id=sha256:__LIMITATION_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/invented-limitations.json; ids=lim-66-7-001; owner=release-owner; decision_at=${observed_at}; follow_up_at=${follow_up_at}" \
+  "unexpected evidence reference"
+
+packet_mutation_case \
+  "invented-limitation-id" \
+  "limitation_references" \
+  "evidence_id=sha256:__LIMITATION_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/limitations.json; ids=lim-invented-999; owner=release-owner; decision_at=${observed_at}; follow_up_at=${follow_up_at}" \
+  "limitation lim-invented-999 does not resolve at repository_revision"
+
+packet_mutation_case \
+  "invented-limitation-owner" \
+  "limitation_references" \
+  "evidence_id=sha256:__LIMITATION_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/limitations.json; ids=lim-66-7-001; owner=imaginary-owner; decision_at=${observed_at}; follow_up_at=${follow_up_at}" \
+  "resolved limitation record lim-66-7-001 does not match packet"
+
+packet_mutation_case \
+  "automated-limitation-owner" \
+  "limitation_references" \
+  "evidence_id=sha256:__LIMITATION_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/limitations.json; ids=lim-66-7-001; owner=verifier-bot; decision_at=${observed_at}; follow_up_at=${follow_up_at}" \
+  "owner must be accountable"
+
+packet_mutation_case \
+  "noncanonical-limitation-id" \
+  "limitation_references" \
+  "evidence_id=sha256:__LIMITATION_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/limitations.json; ids=LIM-66-7-001; owner=release-owner; decision_at=${observed_at}; follow_up_at=${follow_up_at}" \
+  "ids must be explicit lim-* identifiers"
+
+missing_limitation_manifest_repo="${workdir}/missing-limitation-manifest"
+copy_valid_repo "${missing_limitation_manifest_repo}"
+rm "${missing_limitation_manifest_repo}/evidence/phase-66-7/limitations.json"
+git -C "${missing_limitation_manifest_repo}" add -u
+git -C "${missing_limitation_manifest_repo}" commit -qm "remove limitation manifest"
+append_complete_packet "${missing_limitation_manifest_repo}"
+assert_fails_with \
+  "${missing_limitation_manifest_repo}" \
+  "limitation evidence reference does not resolve at repository_revision"
+
+malformed_limitation_manifest_repo="${workdir}/malformed-limitation-manifest"
+copy_valid_repo "${malformed_limitation_manifest_repo}"
+printf '{invalid-json\n' \
+  >"${malformed_limitation_manifest_repo}/evidence/phase-66-7/limitations.json"
+git -C "${malformed_limitation_manifest_repo}" add evidence/phase-66-7/limitations.json
+git -C "${malformed_limitation_manifest_repo}" commit -qm "malform limitation manifest"
+append_complete_packet "${malformed_limitation_manifest_repo}"
+assert_fails_with \
+  "${malformed_limitation_manifest_repo}" \
+  "limitation evidence reference must contain valid UTF-8 JSON"
+
+unaccepted_limitation_repo="${workdir}/unaccepted-limitation"
+copy_valid_repo "${unaccepted_limitation_repo}"
+MANIFEST="${unaccepted_limitation_repo}/evidence/phase-66-7/limitations.json" \
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["MANIFEST"])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["limitations"][0]["disposition"] = "proposed"
+path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+git -C "${unaccepted_limitation_repo}" add evidence/phase-66-7/limitations.json
+git -C "${unaccepted_limitation_repo}" commit -qm "mark limitation proposed"
+append_complete_packet "${unaccepted_limitation_repo}"
+assert_fails_with \
+  "${unaccepted_limitation_repo}" \
+  "limitation manifest record lim-66-7-001 must be accepted"
 
 packet_mutation_case \
   "missing-non-claim" \
@@ -706,6 +823,16 @@ overclaim_case "wazuh-truth" "Wazuh is authoritative alert truth."
 overclaim_case "reverse-wazuh-truth" "Alert truth is owned by Wazuh."
 overclaim_case "shuffle-execution" "Shuffle may execute and close the case."
 overclaim_case "ai-approval" "AI output can approve the action."
+overclaim_case "ai-permitted-approval" "AI output is permitted to approve the action."
+overclaim_case "ai-authorized-execution" "AI output is authorized to execute the action."
+overclaim_case "ai-has-authority" "AI output has authority to approve the action."
+overclaim_case "ai-granted-permission" "AI output is granted permission to execute the action."
+overclaim_case "ai-granted-explicit-permission" "AI output is granted explicit permission to execute the action."
+overclaim_case "ai-empowered-closure" "AI output is empowered to close the case."
+overclaim_case "ai-has-been-authorized" "AI output has been authorized to execute the action."
+overclaim_case "ai-policy-permission" "AI output is permitted by policy to approve the action."
+overclaim_case "ai-authorized-direct-execution" "AI output is authorized to directly execute the action."
+overclaim_case "unrelated-negation-before-ai-permission" "AI output is not advisory but is permitted to approve the action."
 overclaim_case "html-entity-ai-approval" "AI&nbsp;output can approve the action."
 overclaim_case "numeric-html-entity-ai-approval" "AI&#32;output can approve the action."
 overclaim_case "html-entity-ai-subject" "A&#73;&nbsp;output can approve the action."
@@ -744,6 +871,10 @@ allowed_doc_line_case "must-not-retain-private-data" "The proof pack must not re
 allowed_doc_line_case "adverbially-denied-private-data" "The proof pack does not intentionally include raw customer payload."
 allowed_doc_line_case "denied-private-data-list" "The proof pack does not include, retain, or publish raw customer payload."
 allowed_doc_line_case "denied-ai-approval" "AI output can not approve the action."
+allowed_doc_line_case "denied-ai-permission" "AI output is not permitted to approve the action."
+allowed_doc_line_case "denied-ai-authorization" "AI output cannot be authorized to execute the action."
+allowed_doc_line_case "denied-ai-authority" "AI output does not have authority to approve the action."
+allowed_doc_line_case "denied-granted-ai-authority" "AI output is granted no authority to approve the action."
 allowed_doc_line_case "denied-elided-ai-execution" "AI output cannot approve the action; cannot execute the action."
 allowed_doc_line_case "sentence-boundary-no-elision" "AI output cannot approve the action. Can operators execute the action?"
 allowed_doc_line_case "denied-ai-truth" "AI output is not approval truth."
@@ -754,6 +885,7 @@ git -C "${repo_root}" worktree add --detach --quiet "${real_worktree}" HEAD
 git -C "${real_worktree}" config user.name "Phase 66.7 Self Test"
 git -C "${real_worktree}" config user.email "phase-66-7-self-test@invalid.example"
 write_negative_evidence_manifest "${real_worktree}"
+write_limitation_manifest "${real_worktree}"
 cp "${repo_root}/${doc_rel}" "${real_worktree}/${doc_rel}"
 cp \
   "${repo_root}/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh" \
@@ -761,12 +893,13 @@ cp \
 cp \
   "${repo_root}/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh" \
   "${real_worktree}/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh"
-if ! git -C "${real_worktree}" diff --quiet; then
-  git -C "${real_worktree}" add \
-    "${doc_rel}" \
-    evidence/phase-66-7/negative-observations.json \
-    scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh \
-    scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+git -C "${real_worktree}" add \
+  "${doc_rel}" \
+  evidence/phase-66-7/negative-observations.json \
+  evidence/phase-66-7/limitations.json \
+  scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh \
+  scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+if ! git -C "${real_worktree}" diff --cached --quiet; then
   git -C "${real_worktree}" commit -qm "materialized prerequisite integration fixture"
 fi
 append_complete_packet "${real_worktree}"

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh"
+doc_rel="docs/phase-66-7-rc-authority-boundary-proof-pack.md"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+fixture_paths=(
+  "README.md"
+  "docs/phase-66-7-rc-authority-boundary-proof-pack.md"
+  "docs/phase-66-1-clean-host-rc-e2e-harness.md"
+  "docs/phase-66-2-wazuh-sample-signal-rc-proof.md"
+  "docs/phase-66-3-shuffle-sample-execution-rc-proof.md"
+  "docs/phase-66-4-ai-assisted-triage-rc-proof.md"
+  "docs/phase-66-5-report-export-rc-proof.md"
+  "docs/phase-66-6-rc-supportability-proof.md"
+  "docs/phase-51-6-authority-boundary-negative-test-policy.md"
+  "docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md"
+  "docs/phase-65-closeout-evaluation.md"
+  "scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+  "scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh"
+  "scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh"
+  "scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh"
+  "scripts/verify-phase-66-5-report-export-rc-proof.sh"
+  "scripts/verify-phase-66-6-rc-supportability-proof.sh"
+  "scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh"
+  "scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh"
+  "scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh"
+  "scripts/verify-publishable-path-hygiene.sh"
+)
+
+observed_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+follow_up_at="$(python3 - <<'PY'
+from datetime import datetime, timedelta, timezone
+print((datetime.now(timezone.utc) + timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%SZ"))
+PY
+)"
+local_user_home="$(printf '/%s/%s/' 'Users' 'example')"
+
+packet_lines=(
+  "journey_run_id=rc66-authority-001"
+  "repository_revision=__REPOSITORY_REVISION__"
+  "phase_66_1_evidence=evidence_id=proof:66.1:001; verifier=scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "phase_66_2_evidence=evidence_id=proof:66.2:001; verifier=scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "phase_66_3_evidence=evidence_id=proof:66.3:001; verifier=scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "phase_66_4_evidence=evidence_id=proof:66.4:001; verifier=scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "phase_66_5_evidence=evidence_id=proof:66.5:001; verifier=scripts/verify-phase-66-5-report-export-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "phase_66_6_evidence=evidence_id=proof:66.6:001; verifier=scripts/verify-phase-66-6-rc-supportability-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "wazuh_negative_evidence=evidence_id=negative:wazuh:001; surface=wazuh; attempt=source-truth-promotion; result=rejected; authoritative_record=aegisops://alerts/alert-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "shuffle_negative_evidence=evidence_id=negative:shuffle:001; surface=shuffle; attempt=execution-receipt-promotion; result=rejected; authoritative_record=aegisops://reconciliation/rec-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "ai_negative_evidence=evidence_id=negative:ai:001; surface=ai; attempt=approval-bypass; result=rejected; authoritative_record=aegisops://approvals/approval-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "ticket_negative_evidence=evidence_id=negative:tickets:001; surface=tickets; attempt=case-closure-shortcut; result=rejected; authoritative_record=aegisops://cases/case-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "evidence_system_negative_evidence=evidence_id=negative:evidence:001; surface=evidence-systems; attempt=external-evidence-truth-promotion; result=rejected; authoritative_record=aegisops://evidence/evidence-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "ui_cache_negative_evidence=evidence_id=negative:ui-cache:001; surface=ui-cache; attempt=workflow-truth-promotion; result=rejected; authoritative_record=aegisops://audit/audit-ui-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "demo_data_negative_evidence=evidence_id=negative:demo-data:001; surface=demo-data; attempt=release-truth-promotion; result=rejected; authoritative_record=aegisops://releases/release-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "report_negative_evidence=evidence_id=negative:reports:001; surface=reports; attempt=gate-truth-promotion; result=rejected; authoritative_record=aegisops://gates/rc-gate-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "support_bundle_negative_evidence=evidence_id=negative:support-bundle:001; surface=support-bundle; attempt=limitation-truth-promotion; result=rejected; authoritative_record=aegisops://limitations/lim-66-7-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "release_artifact_negative_evidence=evidence_id=negative:release-artifacts:001; surface=release-artifacts; attempt=readiness-truth-promotion; result=rejected; authoritative_record=aegisops://releases/release-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "verifier_output_negative_evidence=evidence_id=negative:verifier-output:001; surface=verifier-output; attempt=rc-gate-promotion; result=rejected; authoritative_record=aegisops://gates/rc-gate-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "issue_lint_output_negative_evidence=evidence_id=negative:issue-lint:001; surface=issue-lint-output; attempt=rc-gate-promotion; result=rejected; authoritative_record=aegisops://gates/rc-gate-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "owner_review=reviewer=security-reviewer; reviewed_at=${observed_at}; disposition=accepted; follow_up_owner=release-owner"
+  "limitation_references=ids=lim-66-7-001; owner=release-owner; decision_at=${observed_at}; follow_up_at=${follow_up_at}"
+  "non_claims=rc-evidence-only,not-rc-gate-pass,not-ga,not-production-operations,not-commercial-replacement,not-broad-siem-parity,not-broad-soar-parity,not-subordinate-truth"
+)
+
+copy_valid_repo() {
+  local target="$1"
+  local path
+
+  mkdir -p "${target}"
+  for path in "${fixture_paths[@]}"; do
+    mkdir -p "${target}/$(dirname "${path}")"
+    cp "${repo_root}/${path}" "${target}/${path}"
+  done
+  git -C "${target}" init -q
+  git -C "${target}" config user.name "Phase 66.7 Self Test"
+  git -C "${target}" config user.email "phase-66-7-self-test@invalid.example"
+  git -C "${target}" add .
+  git -C "${target}" commit -qm "fixture"
+}
+
+assert_passes() {
+  local target="$1"
+
+  if ! PHASE66_7_SKIP_PATH_HYGIENE=1 bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if PHASE66_7_SKIP_PATH_HYGIENE=1 bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    exit 1
+  fi
+  if ! grep -Fq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+remove_doc_text() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' "${target}/${doc_rel}"
+}
+
+append_doc_line() {
+  local target="$1"
+  local line="$2"
+
+  printf '\n%s\n' "${line}" >>"${target}/${doc_rel}"
+}
+
+replace_packet_field() {
+  local target="$1"
+  local field="$2"
+  local value="$3"
+
+  FIELD="${field}" VALUE="${value}" perl -0pi -e \
+    's/^\Q$ENV{FIELD}\E=.*$/$ENV{FIELD} . "=" . $ENV{VALUE}/me' \
+    "${target}/${doc_rel}"
+}
+
+append_complete_packet() {
+  local target="$1"
+  local repository_revision
+  local line
+
+  repository_revision="$(git -C "${target}" rev-parse HEAD)"
+  printf '\n## Test Evidence Packet\n\n' >>"${target}/${doc_rel}"
+  for line in "${packet_lines[@]}"; do
+    printf '%s\n' "${line//__REPOSITORY_REVISION__/${repository_revision}}" >>"${target}/${doc_rel}"
+  done
+}
+
+append_complete_table_packet() {
+  local target="$1"
+  local repository_revision
+  local line
+  local field
+  local value
+
+  repository_revision="$(git -C "${target}" rev-parse HEAD)"
+  printf '\n## Test Table Evidence Packet\n\n| Field | Value |\n| --- | --- |\n' >>"${target}/${doc_rel}"
+  for line in "${packet_lines[@]}"; do
+    line="${line//__REPOSITORY_REVISION__/${repository_revision}}"
+    field="${line%%=*}"
+    value="${line#*=}"
+    printf '| `%s` | %s |\n' "${field}" "${value}" >>"${target}/${doc_rel}"
+  done
+}
+
+packet_mutation_case() {
+  local name="$1"
+  local field="$2"
+  local value="$3"
+  local expected="$4"
+  local target="${workdir}/${name}"
+  local target_revision
+
+  copy_valid_repo "${target}"
+  append_complete_packet "${target}"
+  target_revision="$(git -C "${target}" rev-parse HEAD)"
+  value="${value//__TARGET_REVISION__/${target_revision}}"
+  replace_packet_field "${target}" "${field}" "${value}"
+  assert_fails_with "${target}" "${expected}"
+}
+
+leak_case() {
+  local name="$1"
+  local value="$2"
+  local expected="$3"
+  local target="${workdir}/${name}"
+
+  copy_valid_repo "${target}"
+  append_doc_line "${target}" "${value}"
+  assert_fails_with "${target}" "${expected}"
+}
+
+overclaim_case() {
+  local name="$1"
+  local claim="$2"
+  local target="${workdir}/${name}"
+
+  copy_valid_repo "${target}"
+  append_doc_line "${target}" "${claim}"
+  assert_fails_with "${target}" "authority or readiness overclaim detected"
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+assignment_repo="${workdir}/assignment"
+copy_valid_repo "${assignment_repo}"
+append_complete_packet "${assignment_repo}"
+assert_passes "${assignment_repo}"
+
+table_repo="${workdir}/table"
+copy_valid_repo "${table_repo}"
+append_complete_table_packet "${table_repo}"
+assert_passes "${table_repo}"
+
+missing_doc_repo="${workdir}/missing-doc"
+copy_valid_repo "${missing_doc_repo}"
+rm "${missing_doc_repo}/${doc_rel}"
+assert_fails_with "${missing_doc_repo}" "Missing Phase 66.7 RC authority-boundary proof pack"
+
+missing_reference_repo="${workdir}/missing-reference"
+copy_valid_repo "${missing_reference_repo}"
+rm "${missing_reference_repo}/docs/phase-66-4-ai-assisted-triage-rc-proof.md"
+assert_fails_with "${missing_reference_repo}" "Missing Phase 66.7 reference"
+
+missing_script_repo="${workdir}/missing-script"
+copy_valid_repo "${missing_script_repo}"
+rm "${missing_script_repo}/scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh"
+assert_fails_with "${missing_script_repo}" "Missing Phase 66.7 verifier script"
+
+missing_readme_repo="${workdir}/missing-readme"
+copy_valid_repo "${missing_readme_repo}"
+TEXT="- [Phase 66.7 RC authority-boundary proof pack]" perl -0pi -e \
+  's/^\Q$ENV{TEXT}\E.*\n//m' "${missing_readme_repo}/README.md"
+assert_fails_with "${missing_readme_repo}" "Missing README canonical Phase 66.7 boundary statement"
+
+missing_statement_repo="${workdir}/missing-statement"
+copy_valid_repo "${missing_statement_repo}"
+remove_doc_text "${missing_statement_repo}" "Passing one negative observation cannot compensate for a missing surface."
+assert_fails_with "${missing_statement_repo}" "Missing Phase 66.7 RC authority-boundary proof-pack statement"
+
+commented_statement_repo="${workdir}/commented-statement"
+copy_valid_repo "${commented_statement_repo}"
+remove_doc_text "${commented_statement_repo}" "Passing one negative observation cannot compensate for a missing surface."
+append_doc_line "${commented_statement_repo}" "<!-- Passing one negative observation cannot compensate for a missing surface. -->"
+assert_fails_with "${commented_statement_repo}" "Missing Phase 66.7 RC authority-boundary proof-pack statement"
+
+fenced_statement_repo="${workdir}/fenced-statement"
+copy_valid_repo "${fenced_statement_repo}"
+remove_doc_text "${fenced_statement_repo}" "Passing one negative observation cannot compensate for a missing surface."
+append_doc_line "${fenced_statement_repo}" $'```\nPassing one negative observation cannot compensate for a missing surface.\n```'
+assert_fails_with "${fenced_statement_repo}" "Missing Phase 66.7 RC authority-boundary proof-pack statement"
+
+missing_schema_repo="${workdir}/missing-schema"
+copy_valid_repo "${missing_schema_repo}"
+TEXT='| `ai_negative_evidence` |' perl -0pi -e 's/^\Q$ENV{TEXT}\E.*\n//m' \
+  "${missing_schema_repo}/${doc_rel}"
+assert_fails_with "${missing_schema_repo}" "missing proof-packet field ai_negative_evidence"
+
+missing_matrix_repo="${workdir}/missing-matrix"
+copy_valid_repo "${missing_matrix_repo}"
+TEXT='| UI cache | `workflow-truth-promotion` |' perl -0pi -e 's/^\Q$ENV{TEXT}\E.*\n//m' \
+  "${missing_matrix_repo}/${doc_rel}"
+assert_fails_with "${missing_matrix_repo}" "missing negative evidence matrix row for UI cache"
+
+partial_repo="${workdir}/partial"
+copy_valid_repo "${partial_repo}"
+append_doc_line "${partial_repo}" $'## Partial Evidence Packet\n\njourney_run_id=rc66-authority-001'
+assert_fails_with "${partial_repo}" "partial evidence packet"
+
+cross_section_repo="${workdir}/cross-section"
+copy_valid_repo "${cross_section_repo}"
+append_doc_line "${cross_section_repo}" $'## Packet A\n\njourney_run_id=rc66-authority-001\n\n## Packet B\n\nrepository_revision=0123456789012345678901234567890123456789'
+assert_fails_with "${cross_section_repo}" "partial evidence packet in"
+
+duplicate_repo="${workdir}/duplicate"
+copy_valid_repo "${duplicate_repo}"
+append_complete_packet "${duplicate_repo}"
+append_complete_packet "${duplicate_repo}"
+assert_fails_with "${duplicate_repo}" "multiple materialized values across evidence packets"
+
+yaml_repo="${workdir}/yaml"
+copy_valid_repo "${yaml_repo}"
+append_doc_line "${yaml_repo}" "journey_run_id: rc66-authority-001"
+assert_fails_with "${yaml_repo}" "JSON, YAML, and object-literal evidence syntax is not supported"
+
+json_repo="${workdir}/json"
+copy_valid_repo "${json_repo}"
+append_doc_line "${json_repo}" '{"repository_revision":"0123456789012345678901234567890123456789"}'
+assert_fails_with "${json_repo}" "JSON, YAML, and object-literal evidence syntax is not supported"
+
+packet_mutation_case \
+  "bad-journey" \
+  "journey_run_id" \
+  "run-001" \
+  "invalid journey_run_id"
+
+packet_mutation_case \
+  "bad-revision" \
+  "repository_revision" \
+  "0123456789012345678901234567890123456789" \
+  "does not match repository HEAD"
+
+packet_mutation_case \
+  "mixed-phase-run" \
+  "phase_66_2_evidence" \
+  "evidence_id=proof:66.2:001; verifier=scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh; result=passed; journey_run_id=rc66-other-001; repository_revision=__TARGET_REVISION__" \
+  "mixed journey_run_id"
+
+packet_mutation_case \
+  "wrong-phase-verifier" \
+  "phase_66_4_evidence" \
+  "evidence_id=proof:66.4:001; verifier=scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "unexpected verifier path"
+
+packet_mutation_case \
+  "failed-phase-result" \
+  "phase_66_5_evidence" \
+  "evidence_id=proof:66.5:001; verifier=scripts/verify-phase-66-5-report-export-rc-proof.sh; result=failed; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "verifier result must be passed"
+
+packet_mutation_case \
+  "wrong-surface" \
+  "ai_negative_evidence" \
+  "evidence_id=negative:ai:001; surface=wazuh; attempt=approval-bypass; result=rejected; authoritative_record=aegisops://approvals/approval-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "expected surface ai"
+
+packet_mutation_case \
+  "wrong-attempt" \
+  "ticket_negative_evidence" \
+  "evidence_id=negative:tickets:001; surface=tickets; attempt=workflow-truth-promotion; result=rejected; authoritative_record=aegisops://cases/case-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "expected rejected attempt case-closure-shortcut"
+
+packet_mutation_case \
+  "non-rejected-result" \
+  "shuffle_negative_evidence" \
+  "evidence_id=negative:shuffle:001; surface=shuffle; attempt=execution-receipt-promotion; result=accepted; authoritative_record=aegisops://reconciliation/rec-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "result must be rejected"
+
+packet_mutation_case \
+  "invalid-authority-record" \
+  "report_negative_evidence" \
+  "evidence_id=negative:reports:001; surface=reports; attempt=gate-truth-promotion; result=rejected; authoritative_record=report-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "must be a specific aegisops:// reference"
+
+packet_mutation_case \
+  "stale-observation" \
+  "wazuh_negative_evidence" \
+  "evidence_id=negative:wazuh:001; surface=wazuh; attempt=source-truth-promotion; result=rejected; authoritative_record=aegisops://alerts/alert-001; observed_at=2000-01-01T00:00:00Z; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "timestamp is stale"
+
+packet_mutation_case \
+  "future-observation" \
+  "wazuh_negative_evidence" \
+  "evidence_id=negative:wazuh:001; surface=wazuh; attempt=source-truth-promotion; result=rejected; authoritative_record=aegisops://alerts/alert-001; observed_at=2999-01-01T00:00:00Z; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "timestamp is too far in the future"
+
+packet_mutation_case \
+  "rejected-owner-review" \
+  "owner_review" \
+  "reviewer=security-reviewer; reviewed_at=${observed_at}; disposition=rejected; follow_up_owner=release-owner" \
+  "disposition must be accepted"
+
+packet_mutation_case \
+  "artifact-reviewer" \
+  "owner_review" \
+  "reviewer=verifier-bot; reviewed_at=${observed_at}; disposition=accepted; follow_up_owner=release-owner" \
+  "reviewer must be accountable"
+
+packet_mutation_case \
+  "invalid-follow-up" \
+  "limitation_references" \
+  "ids=lim-66-7-001; owner=release-owner; decision_at=${observed_at}; follow_up_at=2000-01-01T00:00:00Z" \
+  "follow_up_at must be after decision_at"
+
+packet_mutation_case \
+  "missing-non-claim" \
+  "non_claims" \
+  "rc-evidence-only,not-rc-gate-pass,not-ga,not-production-operations,not-commercial-replacement,not-broad-siem-parity,not-broad-soar-parity" \
+  "missing not-subordinate-truth"
+
+packet_mutation_case \
+  "extra-non-claim" \
+  "non_claims" \
+  "rc-evidence-only,not-rc-gate-pass,not-ga,not-production-operations,not-commercial-replacement,not-broad-siem-parity,not-broad-soar-parity,not-subordinate-truth,ready" \
+  "unexpected ready"
+
+leak_case \
+  "access-key" \
+  "authorization=Bearer AKIA1234567890ABCDEF" \
+  "production secret-looking value detected"
+
+leak_case \
+  "private-key" \
+  "-----BEGIN PRIVATE KEY-----" \
+  "production secret-looking value detected"
+
+leak_case \
+  "local-path" \
+  "artifact=${local_user_home}operator/proof.json" \
+  "workstation-local path detected"
+
+leak_case \
+  "email" \
+  "customer_contact=analyst@example.com" \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "private-ticket" \
+  "ticket_private_content=customer-payload" \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "nested-api-key" \
+  "debug_note=reviewed; api_key=supersecretvalue123; disposition=accepted" \
+  "production secret-looking value detected"
+
+leak_case \
+  "nested-customer-name" \
+  "debug_note=reviewed; customer_name=AcmeCorp; disposition=accepted" \
+  "customer-private or ticket-private data detected"
+
+overclaim_case "wazuh-truth" "Wazuh is authoritative alert truth."
+overclaim_case "reverse-wazuh-truth" "Alert truth is owned by Wazuh."
+overclaim_case "shuffle-execution" "Shuffle may execute and close the case."
+overclaim_case "ai-approval" "AI output can approve the action."
+overclaim_case "ticket-closure" "Tickets can close the case."
+overclaim_case "external-evidence-truth" "External evidence is evidence truth."
+overclaim_case "ui-cache-truth" "UI cache is workflow truth."
+overclaim_case "demo-data-truth" "Demo data is release truth."
+overclaim_case "report-gate" "Reports are gate truth."
+overclaim_case "support-truth" "Support bundles are limitation truth."
+overclaim_case "release-readiness" "Release artifacts prove RC readiness."
+overclaim_case "verifier-readiness" "Verifier output confirms RC readiness."
+overclaim_case "issue-lint-truth" "Issue-lint output is release truth."
+overclaim_case "ga-overclaim" "Phase 66.7 proves GA readiness."
+overclaim_case "production-overclaim" "Phase 66.7 enables production rollout."
+overclaim_case "broad-siem" "Phase 66.7 achieves broad enterprise SIEM parity."
+overclaim_case "broad-soar" "Phase 66.7 achieves broad enterprise SOAR parity."
+overclaim_case "approval-bypass" "Approval bypass is allowed."
+overclaim_case "execution-bypass" "Execution bypass is supported."
+overclaim_case "reconciliation-bypass" "Reconciliation bypass is valid."
+overclaim_case "case-shortcut" "Case-closure shortcut is accepted."
+overclaim_case "source-shortcut" "Source-admission shortcut is allowed."
+
+echo "Phase 66.7 RC authority-boundary proof-pack verifier self-test passes."

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -63,22 +63,65 @@ packet_lines=(
   "phase_66_4_evidence=evidence_id=sha256:__PHASE_66_4_DIGEST__; evidence_reference=docs/phase-66-4-ai-assisted-triage-rc-proof.md; verifier=scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
   "phase_66_5_evidence=evidence_id=sha256:__PHASE_66_5_DIGEST__; evidence_reference=docs/phase-66-5-report-export-rc-proof.md; verifier=scripts/verify-phase-66-5-report-export-rc-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
   "phase_66_6_evidence=evidence_id=sha256:__PHASE_66_6_DIGEST__; evidence_reference=docs/phase-66-6-rc-supportability-proof.md; verifier=scripts/verify-phase-66-6-rc-supportability-proof.sh; result=passed; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "wazuh_negative_evidence=evidence_id=negative:wazuh:001; surface=wazuh; attempt=source-truth-promotion; result=rejected; authoritative_record=aegisops://alerts/alert-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "shuffle_negative_evidence=evidence_id=negative:shuffle:001; surface=shuffle; attempt=execution-receipt-promotion; result=rejected; authoritative_record=aegisops://reconciliation/rec-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "ai_negative_evidence=evidence_id=negative:ai:001; surface=ai; attempt=approval-bypass; result=rejected; authoritative_record=aegisops://approvals/approval-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "ticket_negative_evidence=evidence_id=negative:tickets:001; surface=tickets; attempt=case-closure-shortcut; result=rejected; authoritative_record=aegisops://cases/case-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "evidence_system_negative_evidence=evidence_id=negative:evidence:001; surface=evidence-systems; attempt=external-evidence-truth-promotion; result=rejected; authoritative_record=aegisops://evidence/evidence-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "ui_cache_negative_evidence=evidence_id=negative:ui-cache:001; surface=ui-cache; attempt=workflow-truth-promotion; result=rejected; authoritative_record=aegisops://audit/audit-ui-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "demo_data_negative_evidence=evidence_id=negative:demo-data:001; surface=demo-data; attempt=release-truth-promotion; result=rejected; authoritative_record=aegisops://releases/release-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "report_negative_evidence=evidence_id=negative:reports:001; surface=reports; attempt=gate-truth-promotion; result=rejected; authoritative_record=aegisops://gates/rc-gate-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "support_bundle_negative_evidence=evidence_id=negative:support-bundle:001; surface=support-bundle; attempt=limitation-truth-promotion; result=rejected; authoritative_record=aegisops://limitations/lim-66-7-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "release_artifact_negative_evidence=evidence_id=negative:release-artifacts:001; surface=release-artifacts; attempt=readiness-truth-promotion; result=rejected; authoritative_record=aegisops://releases/release-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "verifier_output_negative_evidence=evidence_id=negative:verifier-output:001; surface=verifier-output; attempt=rc-gate-promotion; result=rejected; authoritative_record=aegisops://gates/rc-gate-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "issue_lint_output_negative_evidence=evidence_id=negative:issue-lint:001; surface=issue-lint-output; attempt=rc-gate-promotion; result=rejected; authoritative_record=aegisops://gates/rc-gate-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "wazuh_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=wazuh; attempt=source-truth-promotion; result=rejected; authoritative_record=aegisops://alerts/alert-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "shuffle_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=shuffle; attempt=execution-receipt-promotion; result=rejected; authoritative_record=aegisops://reconciliation/rec-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "ai_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=ai; attempt=approval-bypass; result=rejected; authoritative_record=aegisops://approvals/approval-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "ticket_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=tickets; attempt=case-closure-shortcut; result=rejected; authoritative_record=aegisops://cases/case-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "evidence_system_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=evidence-systems; attempt=external-evidence-truth-promotion; result=rejected; authoritative_record=aegisops://evidence/evidence-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "ui_cache_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=ui-cache; attempt=workflow-truth-promotion; result=rejected; authoritative_record=aegisops://audit/audit-ui-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "demo_data_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=demo-data; attempt=release-truth-promotion; result=rejected; authoritative_record=aegisops://releases/release-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "report_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=reports; attempt=gate-truth-promotion; result=rejected; authoritative_record=aegisops://gates/rc-gate-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "support_bundle_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=support-bundle; attempt=limitation-truth-promotion; result=rejected; authoritative_record=aegisops://limitations/lim-66-7-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "release_artifact_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=release-artifacts; attempt=readiness-truth-promotion; result=rejected; authoritative_record=aegisops://releases/release-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "verifier_output_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=verifier-output; attempt=rc-gate-promotion; result=rejected; authoritative_record=aegisops://gates/rc-gate-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
+  "issue_lint_output_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=issue-lint-output; attempt=rc-gate-promotion; result=rejected; authoritative_record=aegisops://gates/rc-gate-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
   "owner_review=reviewer=security-reviewer; reviewed_at=${observed_at}; disposition=accepted; follow_up_owner=release-owner"
   "limitation_references=ids=lim-66-7-001; owner=release-owner; decision_at=${observed_at}; follow_up_at=${follow_up_at}"
   "non_claims=rc-evidence-only,not-rc-gate-pass,not-ga,not-production-operations,not-commercial-replacement,not-broad-siem-parity,not-broad-soar-parity,not-subordinate-truth"
 )
+
+write_negative_evidence_manifest() {
+  local target="$1"
+
+  mkdir -p "${target}/evidence/phase-66-7"
+  TARGET="${target}" OBSERVED_AT="${observed_at}" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+records = [
+    ("wazuh_negative_evidence", "wazuh", "source-truth-promotion", "aegisops://alerts/alert-001"),
+    ("shuffle_negative_evidence", "shuffle", "execution-receipt-promotion", "aegisops://reconciliation/rec-001"),
+    ("ai_negative_evidence", "ai", "approval-bypass", "aegisops://approvals/approval-001"),
+    ("ticket_negative_evidence", "tickets", "case-closure-shortcut", "aegisops://cases/case-001"),
+    ("evidence_system_negative_evidence", "evidence-systems", "external-evidence-truth-promotion", "aegisops://evidence/evidence-001"),
+    ("ui_cache_negative_evidence", "ui-cache", "workflow-truth-promotion", "aegisops://audit/audit-ui-001"),
+    ("demo_data_negative_evidence", "demo-data", "release-truth-promotion", "aegisops://releases/release-001"),
+    ("report_negative_evidence", "reports", "gate-truth-promotion", "aegisops://gates/rc-gate-001"),
+    ("support_bundle_negative_evidence", "support-bundle", "limitation-truth-promotion", "aegisops://limitations/lim-66-7-001"),
+    ("release_artifact_negative_evidence", "release-artifacts", "readiness-truth-promotion", "aegisops://releases/release-001"),
+    ("verifier_output_negative_evidence", "verifier-output", "rc-gate-promotion", "aegisops://gates/rc-gate-001"),
+    ("issue_lint_output_negative_evidence", "issue-lint-output", "rc-gate-promotion", "aegisops://gates/rc-gate-001"),
+]
+manifest = {
+    "schema_version": "phase-66-7-negative-evidence/v1",
+    "records": [
+        {
+            "field": field,
+            "surface": surface,
+            "attempt": attempt,
+            "result": "rejected",
+            "authoritative_record": authoritative_record,
+            "observed_at": os.environ["OBSERVED_AT"],
+            "journey_run_id": "rc66-authority-001",
+        }
+        for field, surface, attempt, authoritative_record in records
+    ],
+}
+path = Path(os.environ["TARGET"]) / "evidence/phase-66-7/negative-observations.json"
+path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+}
 
 copy_valid_repo() {
   local target="$1"
@@ -96,6 +139,7 @@ copy_valid_repo() {
       'exit 0' >"${path}"
     chmod +x "${path}"
   done
+  write_negative_evidence_manifest "${target}"
   git -C "${target}" init -q
   git -C "${target}" config user.name "Phase 66.7 Self Test"
   git -C "${target}" config user.email "phase-66-7-self-test@invalid.example"
@@ -183,6 +227,19 @@ materialize_packet_line() {
     )"
     line="${line//${placeholder}/${digest}}"
   done
+  if [[ "${line}" == *"__NEGATIVE_EVIDENCE_DIGEST__"* ]]; then
+    reference="evidence/phase-66-7/negative-observations.json"
+    if git -C "${target}" cat-file -e "${repository_revision}:${reference}" 2>/dev/null; then
+      digest="$(
+        git -C "${target}" show "${repository_revision}:${reference}" |
+          shasum -a 256 |
+          awk '{print $1}'
+      )"
+    else
+      digest="0000000000000000000000000000000000000000000000000000000000000000"
+    fi
+    line="${line//__NEGATIVE_EVIDENCE_DIGEST__/${digest}}"
+  fi
   printf '%s\n' "${line}"
 }
 
@@ -415,41 +472,100 @@ git -C "${failing_prerequisite_repo}" commit -qm "fail prerequisite verifier"
 append_complete_packet "${failing_prerequisite_repo}"
 assert_fails_with "${failing_prerequisite_repo}" "prerequisite verifier failed: simulated prerequisite failure"
 
+missing_negative_manifest_repo="${workdir}/missing-negative-manifest"
+copy_valid_repo "${missing_negative_manifest_repo}"
+rm "${missing_negative_manifest_repo}/evidence/phase-66-7/negative-observations.json"
+git -C "${missing_negative_manifest_repo}" add -u
+git -C "${missing_negative_manifest_repo}" commit -qm "remove negative evidence manifest"
+append_complete_packet "${missing_negative_manifest_repo}"
+assert_fails_with \
+  "${missing_negative_manifest_repo}" \
+  "negative evidence reference does not resolve at repository_revision"
+
+malformed_negative_manifest_repo="${workdir}/malformed-negative-manifest"
+copy_valid_repo "${malformed_negative_manifest_repo}"
+printf '{invalid-json\n' \
+  >"${malformed_negative_manifest_repo}/evidence/phase-66-7/negative-observations.json"
+git -C "${malformed_negative_manifest_repo}" add evidence/phase-66-7/negative-observations.json
+git -C "${malformed_negative_manifest_repo}" commit -qm "malform negative evidence manifest"
+append_complete_packet "${malformed_negative_manifest_repo}"
+assert_fails_with \
+  "${malformed_negative_manifest_repo}" \
+  "negative evidence reference must contain valid UTF-8 JSON"
+
+incomplete_negative_manifest_repo="${workdir}/incomplete-negative-manifest"
+copy_valid_repo "${incomplete_negative_manifest_repo}"
+MANIFEST="${incomplete_negative_manifest_repo}/evidence/phase-66-7/negative-observations.json" \
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["MANIFEST"])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["records"].pop()
+path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+git -C "${incomplete_negative_manifest_repo}" add evidence/phase-66-7/negative-observations.json
+git -C "${incomplete_negative_manifest_repo}" commit -qm "drop negative evidence record"
+append_complete_packet "${incomplete_negative_manifest_repo}"
+assert_fails_with \
+  "${incomplete_negative_manifest_repo}" \
+  "negative evidence manifest must contain exactly one record for every required surface"
+
 packet_mutation_case \
   "wrong-surface" \
   "ai_negative_evidence" \
-  "evidence_id=negative:ai:001; surface=wazuh; attempt=approval-bypass; result=rejected; authoritative_record=aegisops://approvals/approval-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=wazuh; attempt=approval-bypass; result=rejected; authoritative_record=aegisops://approvals/approval-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
   "expected surface ai"
 
 packet_mutation_case \
   "wrong-attempt" \
   "ticket_negative_evidence" \
-  "evidence_id=negative:tickets:001; surface=tickets; attempt=workflow-truth-promotion; result=rejected; authoritative_record=aegisops://cases/case-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=tickets; attempt=workflow-truth-promotion; result=rejected; authoritative_record=aegisops://cases/case-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
   "expected rejected attempt case-closure-shortcut"
 
 packet_mutation_case \
   "non-rejected-result" \
   "shuffle_negative_evidence" \
-  "evidence_id=negative:shuffle:001; surface=shuffle; attempt=execution-receipt-promotion; result=accepted; authoritative_record=aegisops://reconciliation/rec-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=shuffle; attempt=execution-receipt-promotion; result=accepted; authoritative_record=aegisops://reconciliation/rec-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
   "result must be rejected"
 
 packet_mutation_case \
   "invalid-authority-record" \
   "report_negative_evidence" \
-  "evidence_id=negative:reports:001; surface=reports; attempt=gate-truth-promotion; result=rejected; authoritative_record=report-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=reports; attempt=gate-truth-promotion; result=rejected; authoritative_record=report-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
   "must be a specific aegisops:// reference"
 
 packet_mutation_case \
   "stale-observation" \
   "wazuh_negative_evidence" \
-  "evidence_id=negative:wazuh:001; surface=wazuh; attempt=source-truth-promotion; result=rejected; authoritative_record=aegisops://alerts/alert-001; observed_at=2000-01-01T00:00:00Z; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=wazuh; attempt=source-truth-promotion; result=rejected; authoritative_record=aegisops://alerts/alert-001; observed_at=2000-01-01T00:00:00Z; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
   "timestamp is stale"
 
 packet_mutation_case \
   "future-observation" \
   "wazuh_negative_evidence" \
-  "evidence_id=negative:wazuh:001; surface=wazuh; attempt=source-truth-promotion; result=rejected; authoritative_record=aegisops://alerts/alert-001; observed_at=2999-01-01T00:00:00Z; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=wazuh; attempt=source-truth-promotion; result=rejected; authoritative_record=aegisops://alerts/alert-001; observed_at=2999-01-01T00:00:00Z; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
   "timestamp is too far in the future"
+
+packet_mutation_case \
+  "fabricated-negative-evidence-id" \
+  "ai_negative_evidence" \
+  "evidence_id=sha256:0000000000000000000000000000000000000000000000000000000000000000; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=ai; attempt=approval-bypass; result=rejected; authoritative_record=aegisops://approvals/approval-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "evidence_id does not match resolved evidence reference"
+
+packet_mutation_case \
+  "wrong-negative-evidence-reference" \
+  "ai_negative_evidence" \
+  "evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/invented.json; surface=ai; attempt=approval-bypass; result=rejected; authoritative_record=aegisops://approvals/approval-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "unexpected evidence reference"
+
+packet_mutation_case \
+  "invented-authoritative-record" \
+  "wazuh_negative_evidence" \
+  "evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=wazuh; attempt=source-truth-promotion; result=rejected; authoritative_record=aegisops://alerts/invented-999; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__TARGET_REVISION__" \
+  "resolved negative evidence record does not match packet"
 
 packet_mutation_case \
   "rejected-owner-review" \
@@ -534,6 +650,10 @@ overclaim_case "direct-ai-approval" "AI output approves the action."
 overclaim_case "unrelated-negation-before-ai-approval" "AI output is not advisory and can approve the action."
 overclaim_case "unrelated-negation-before-pronoun-approval" "AI output is not advisory, but it can approve the action."
 overclaim_case "unrelated-negation-before-direct-approval" "AI output is not advisory and independently approves the action."
+overclaim_case "elided-ai-execution" "AI output cannot approve the action; can execute the action."
+overclaim_case "elided-direct-ai-execution" "AI output cannot approve the action; independently executes the action."
+overclaim_case "adversative-elided-ai-execution" "AI output cannot approve the action but can execute the action."
+overclaim_case "elided-ai-truth" "AI output is not authoritative; is approval truth."
 overclaim_case "ai-plural-case-closure" "AI output can close cases."
 overclaim_case "ticket-closure" "Tickets can close the case."
 overclaim_case "external-evidence-truth" "External evidence is evidence truth."
@@ -557,6 +677,8 @@ overclaim_case "source-shortcut" "Source-admission shortcut is allowed."
 allowed_doc_line_case "redacted-secret" "api_key=redacted"
 allowed_doc_line_case "quoted-removed-private-data" "customer_name=\"removed\""
 allowed_doc_line_case "denied-ai-approval" "AI output can not approve the action."
+allowed_doc_line_case "denied-elided-ai-execution" "AI output cannot approve the action; cannot execute the action."
+allowed_doc_line_case "sentence-boundary-no-elision" "AI output cannot approve the action. Can operators execute the action?"
 allowed_doc_line_case "denied-ai-truth" "AI output is not approval truth."
 allowed_doc_line_case "denied-release-readiness" "Release artifacts do not prove RC readiness."
 
@@ -564,6 +686,7 @@ real_worktree="${workdir}/real-prerequisite-worktree"
 git -C "${repo_root}" worktree add --detach --quiet "${real_worktree}" HEAD
 git -C "${real_worktree}" config user.name "Phase 66.7 Self Test"
 git -C "${real_worktree}" config user.email "phase-66-7-self-test@invalid.example"
+write_negative_evidence_manifest "${real_worktree}"
 cp "${repo_root}/${doc_rel}" "${real_worktree}/${doc_rel}"
 cp \
   "${repo_root}/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh" \
@@ -574,6 +697,7 @@ cp \
 if ! git -C "${real_worktree}" diff --quiet; then
   git -C "${real_worktree}" add \
     "${doc_rel}" \
+    evidence/phase-66-7/negative-observations.json \
     scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh \
     scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
   git -C "${real_worktree}" commit -qm "materialized prerequisite integration fixture"

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -253,6 +253,16 @@ overclaim_case() {
   assert_fails_with "${target}" "authority or readiness overclaim detected"
 }
 
+allowed_doc_line_case() {
+  local name="$1"
+  local claim="$2"
+  local target="${workdir}/${name}"
+
+  copy_valid_repo "${target}"
+  append_doc_line "${target}" "${claim}"
+  assert_passes "${target}"
+}
+
 valid_repo="${workdir}/valid"
 copy_valid_repo "${valid_repo}"
 assert_passes "${valid_repo}"
@@ -502,14 +512,28 @@ leak_case \
   "production secret-looking value detected"
 
 leak_case \
+  "secret-after-redaction-marker" \
+  "api_key=redacted supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
   "nested-customer-name" \
   "debug_note=reviewed; customer_name=AcmeCorp; disposition=accepted" \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "private-data-after-redaction-marker" \
+  "customer_name=redacted AcmeCorp" \
   "customer-private or ticket-private data detected"
 
 overclaim_case "wazuh-truth" "Wazuh is authoritative alert truth."
 overclaim_case "reverse-wazuh-truth" "Alert truth is owned by Wazuh."
 overclaim_case "shuffle-execution" "Shuffle may execute and close the case."
 overclaim_case "ai-approval" "AI output can approve the action."
+overclaim_case "direct-ai-approval" "AI output approves the action."
+overclaim_case "unrelated-negation-before-ai-approval" "AI output is not advisory and can approve the action."
+overclaim_case "unrelated-negation-before-pronoun-approval" "AI output is not advisory, but it can approve the action."
+overclaim_case "unrelated-negation-before-direct-approval" "AI output is not advisory and independently approves the action."
 overclaim_case "ai-plural-case-closure" "AI output can close cases."
 overclaim_case "ticket-closure" "Tickets can close the case."
 overclaim_case "external-evidence-truth" "External evidence is evidence truth."
@@ -529,6 +553,12 @@ overclaim_case "execution-bypass" "Execution bypass is supported."
 overclaim_case "reconciliation-bypass" "Reconciliation bypass is valid."
 overclaim_case "case-shortcut" "Case-closure shortcut is accepted."
 overclaim_case "source-shortcut" "Source-admission shortcut is allowed."
+
+allowed_doc_line_case "redacted-secret" "api_key=redacted"
+allowed_doc_line_case "quoted-removed-private-data" "customer_name=\"removed\""
+allowed_doc_line_case "denied-ai-approval" "AI output can not approve the action."
+allowed_doc_line_case "denied-ai-truth" "AI output is not approval truth."
+allowed_doc_line_case "denied-release-readiness" "Release artifacts do not prove RC readiness."
 
 real_worktree="${workdir}/real-prerequisite-worktree"
 git -C "${repo_root}" worktree add --detach --quiet "${real_worktree}" HEAD

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -53,6 +53,7 @@ print((datetime.now(timezone.utc) + timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:
 PY
 )"
 local_user_home="$(printf '/%s/%s/' 'Users' 'example')"
+wsl_user_home="$(printf '/mnt/%s/%s/%s/' 'c' 'Users' 'alice')"
 
 packet_lines=(
   "journey_run_id=rc66-authority-001"
@@ -75,7 +76,7 @@ packet_lines=(
   "release_artifact_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=release-artifacts; attempt=readiness-truth-promotion; result=rejected; authoritative_record=aegisops://releases/release-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
   "verifier_output_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=verifier-output; attempt=rc-gate-promotion; result=rejected; authoritative_record=aegisops://gates/rc-gate-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
   "issue_lint_output_negative_evidence=evidence_id=sha256:__NEGATIVE_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/negative-observations.json; surface=issue-lint-output; attempt=rc-gate-promotion; result=rejected; authoritative_record=aegisops://gates/rc-gate-001; observed_at=${observed_at}; journey_run_id=rc66-authority-001; repository_revision=__REPOSITORY_REVISION__"
-  "owner_review=reviewer=security-reviewer; reviewed_at=${observed_at}; disposition=accepted; follow_up_owner=release-owner"
+  "owner_review=artifact_owner=proof-author; reviewer=security-reviewer; reviewed_at=${observed_at}; disposition=accepted; follow_up_owner=release-owner"
   "limitation_references=evidence_id=sha256:__LIMITATION_EVIDENCE_DIGEST__; evidence_reference=evidence/phase-66-7/limitations.json; ids=lim-66-7-001; owner=release-owner; decision_at=${observed_at}; follow_up_at=${follow_up_at}"
   "non_claims=rc-evidence-only,not-rc-gate-pass,not-ga,not-production-operations,not-commercial-replacement,not-broad-siem-parity,not-broad-soar-parity,not-subordinate-truth"
 )
@@ -631,14 +632,26 @@ packet_mutation_case \
 packet_mutation_case \
   "rejected-owner-review" \
   "owner_review" \
-  "reviewer=security-reviewer; reviewed_at=${observed_at}; disposition=rejected; follow_up_owner=release-owner" \
+  "artifact_owner=proof-author; reviewer=security-reviewer; reviewed_at=${observed_at}; disposition=rejected; follow_up_owner=release-owner" \
   "disposition must be accepted"
 
 packet_mutation_case \
   "artifact-reviewer" \
   "owner_review" \
-  "reviewer=verifier-bot; reviewed_at=${observed_at}; disposition=accepted; follow_up_owner=release-owner" \
+  "artifact_owner=proof-author; reviewer=verifier-bot; reviewed_at=${observed_at}; disposition=accepted; follow_up_owner=release-owner" \
   "reviewer must be accountable"
+
+packet_mutation_case \
+  "self-owner-review" \
+  "owner_review" \
+  "artifact_owner=security-reviewer; reviewer=Security-Reviewer; reviewed_at=${observed_at}; disposition=accepted; follow_up_owner=release-owner" \
+  "artifact_owner and reviewer must be distinct"
+
+packet_mutation_case \
+  "missing-artifact-owner" \
+  "owner_review" \
+  "reviewer=security-reviewer; reviewed_at=${observed_at}; disposition=accepted; follow_up_owner=release-owner" \
+  "missing components artifact_owner"
 
 packet_mutation_case \
   "invalid-follow-up" \
@@ -751,6 +764,11 @@ leak_case \
   "workstation-local path detected"
 
 leak_case \
+  "wsl-local-path" \
+  "artifact=${wsl_user_home}proof.json" \
+  "workstation-local path detected"
+
+leak_case \
   "email" \
   "customer_contact=analyst@example.com" \
   "customer-private or ticket-private data detected"
@@ -758,6 +776,36 @@ leak_case \
 leak_case \
   "private-ticket" \
   "ticket_private_content=customer-payload" \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "unredacted-customer-data-claim" \
+  "The proof pack includes unredacted customer data." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "ordinary-customer-data-claim" \
+  "The proof pack retains customer data." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "private-customer-information-claim" \
+  "The proof pack stores private customer information." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "ticket-data-claim" \
+  "The proof pack exports ticket data." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "passive-customer-data-claim" \
+  "Customer data is retained in the proof pack." \
+  "customer-private or ticket-private data detected"
+
+leak_case \
+  "passive-private-ticket-data-claim" \
+  "Private ticket information was published by the proof pack." \
   "customer-private or ticket-private data detected"
 
 leak_case \
@@ -927,6 +975,11 @@ overclaim_case "html-tag-split-mandatory-ai-approval" "AI <span></span>output mu
 overclaim_case "ai-permitted-approval" "AI output is permitted to approve the action."
 overclaim_case "ai-authorized-execution" "AI output is authorized to execute the action."
 overclaim_case "ai-has-authority" "AI output has authority to approve the action."
+overclaim_case "ai-retains-authority" "AI output retains authority to approve the action."
+overclaim_case "ai-retained-authority" "AI output retained authority to approve the action."
+overclaim_case "ai-held-authority" "AI output held authority to approve the action."
+overclaim_case "ai-was-given-permission" "AI output was given permission to execute the action."
+overclaim_case "ai-maintains-power" "AI output maintains power to close the case."
 overclaim_case "ai-granted-permission" "AI output is granted permission to execute the action."
 overclaim_case "ai-granted-explicit-permission" "AI output is granted explicit permission to execute the action."
 overclaim_case "ai-empowered-closure" "AI output is empowered to close the case."
@@ -974,6 +1027,11 @@ allowed_doc_line_case "redacted-secret" "api_key=redacted"
 allowed_doc_line_case "redacted-spaced-api-key" "API key: redacted"
 allowed_doc_line_case "redacted-html-split-api-key" "api_key<span></span>=redacted"
 allowed_doc_line_case "quoted-removed-private-data" "customer_name=\"removed\""
+allowed_doc_line_case "redacted-customer-data-claim" "The proof pack includes redacted customer data."
+allowed_doc_line_case "absent-customer-data-claim" "The proof pack contains no customer data."
+allowed_doc_line_case "denied-unredacted-customer-data-claim" "The proof pack does not include unredacted customer data."
+allowed_doc_line_case "denied-passive-customer-data-claim" "Customer data is not retained in the proof pack."
+allowed_doc_line_case "redacted-passive-customer-data-claim" "Redacted customer data is included in the proof pack."
 allowed_doc_line_case "denied-private-data-claim" "The proof pack does not include raw customer payload."
 allowed_doc_line_case "must-not-retain-private-data" "The proof pack must not retain raw customer payload."
 allowed_doc_line_case "adverbially-denied-private-data" "The proof pack does not intentionally include raw customer payload."
@@ -988,6 +1046,7 @@ allowed_doc_line_case "denied-html-split-ai-approval" "AI <span></span>output mu
 allowed_doc_line_case "denied-ai-permission" "AI output is not permitted to approve the action."
 allowed_doc_line_case "denied-ai-authorization" "AI output cannot be authorized to execute the action."
 allowed_doc_line_case "denied-ai-authority" "AI output does not have authority to approve the action."
+allowed_doc_line_case "denied-retained-ai-authority" "AI output does not retain authority to approve the action."
 allowed_doc_line_case "denied-granted-ai-authority" "AI output is granted no authority to approve the action."
 allowed_doc_line_case "denied-ai-article-case-closure" "AI output cannot close a case."
 allowed_doc_line_case "denied-ai-individual-case-closure" "AI output cannot close an individual case."

--- a/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -745,6 +745,56 @@ leak_case \
   "production secret-looking value detected"
 
 leak_case \
+  "spaced-api-key" \
+  "API key: supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "hyphenated-api-key" \
+  "api-key=supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "connected-api-key" \
+  "APIKey=supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "prefixed-api-key" \
+  "X-API-Key=supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "spaced-client-secret" \
+  "client secret: supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "hyphenated-access-token" \
+  "access-token=supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "spaced-refresh-token" \
+  "refresh token: supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "spaced-secret-key" \
+  "secret key: supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "spaced-private-key" \
+  "private key: supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
+  "html-entity-spaced-api-key" \
+  "API&nbsp;key&colon;supersecretvalue123" \
+  "production secret-looking value detected"
+
+leak_case \
   "secret-after-redaction-marker" \
   "api_key=redacted supersecretvalue123" \
   "production secret-looking value detected"
@@ -845,6 +895,11 @@ overclaim_case "elided-direct-ai-execution" "AI output cannot approve the action
 overclaim_case "adversative-elided-ai-execution" "AI output cannot approve the action but can execute the action."
 overclaim_case "elided-ai-truth" "AI output is not authoritative; is approval truth."
 overclaim_case "ai-plural-case-closure" "AI output can close cases."
+overclaim_case "ai-article-case-closure" "AI output can close a case."
+overclaim_case "direct-ai-demonstrative-case-closure" "AI output closes this case."
+overclaim_case "authorized-ai-any-case-closure" "AI output is authorized to close any case."
+overclaim_case "ai-individual-case-closure" "AI output can close an individual case."
+overclaim_case "direct-ai-single-case-closure" "AI output closes a single case."
 overclaim_case "ticket-closure" "Tickets can close the case."
 overclaim_case "external-evidence-truth" "External evidence is evidence truth."
 overclaim_case "ui-cache-truth" "UI cache is workflow truth."
@@ -865,6 +920,7 @@ overclaim_case "case-shortcut" "Case-closure shortcut is accepted."
 overclaim_case "source-shortcut" "Source-admission shortcut is allowed."
 
 allowed_doc_line_case "redacted-secret" "api_key=redacted"
+allowed_doc_line_case "redacted-spaced-api-key" "API key: redacted"
 allowed_doc_line_case "quoted-removed-private-data" "customer_name=\"removed\""
 allowed_doc_line_case "denied-private-data-claim" "The proof pack does not include raw customer payload."
 allowed_doc_line_case "must-not-retain-private-data" "The proof pack must not retain raw customer payload."
@@ -875,6 +931,8 @@ allowed_doc_line_case "denied-ai-permission" "AI output is not permitted to appr
 allowed_doc_line_case "denied-ai-authorization" "AI output cannot be authorized to execute the action."
 allowed_doc_line_case "denied-ai-authority" "AI output does not have authority to approve the action."
 allowed_doc_line_case "denied-granted-ai-authority" "AI output is granted no authority to approve the action."
+allowed_doc_line_case "denied-ai-article-case-closure" "AI output cannot close a case."
+allowed_doc_line_case "denied-ai-individual-case-closure" "AI output cannot close an individual case."
 allowed_doc_line_case "denied-elided-ai-execution" "AI output cannot approve the action; cannot execute the action."
 allowed_doc_line_case "sentence-boundary-no-elision" "AI output cannot approve the action. Can operators execute the action?"
 allowed_doc_line_case "denied-ai-truth" "AI output is not approval truth."

--- a/scripts/test-verify-publishable-path-hygiene.sh
+++ b/scripts/test-verify-publishable-path-hygiene.sh
@@ -83,6 +83,14 @@ create_repo \
   "control-plane/tests/test_docs.py" "EXPECTED_PATH = 'docs/phase-25.md'"
 assert_fails_with "${failing_repo}" "docs/phase-25.md:1:"
 
+wsl_failing_repo="${workdir}/wsl-failing"
+create_repo \
+  "${wsl_failing_repo}" \
+  "README.md" "# WSL failing fixture" \
+  "docs/phase-25.md" "Leaked path: /mnt/c/Users""/alice/private/project" \
+  "control-plane/tests/test_docs.py" "EXPECTED_PATH = 'docs/phase-25.md'"
+assert_fails_with "${wsl_failing_repo}" "docs/phase-25.md:1:"
+
 script_failing_repo="${workdir}/script-failing"
 create_repo \
   "${script_failing_repo}" \

--- a/scripts/test-verify-publishable-path-hygiene.sh
+++ b/scripts/test-verify-publishable-path-hygiene.sh
@@ -66,6 +66,13 @@ create_repo \
   "control-plane/tests/test_docs.py" "EXPECTED_PATH = 'docs/phase-25.md'"
 assert_passes "${clean_repo}"
 
+embedded_wsl_uri_repo="${workdir}/embedded-wsl-uri"
+create_repo \
+  "${embedded_wsl_uri_repo}" \
+  "README.md" "# Embedded WSL URI fixture" \
+  "docs/phase-25.md" "Reference URL: https://example.com/file:///mnt/c/Users""/alice/project"
+assert_passes "${embedded_wsl_uri_repo}"
+
 allowlisted_repo="${workdir}/allowlisted"
 macos_user_segment="Users"
 create_repo \

--- a/scripts/test-verify-publishable-path-hygiene.sh
+++ b/scripts/test-verify-publishable-path-hygiene.sh
@@ -91,6 +91,14 @@ create_repo \
   "control-plane/tests/test_docs.py" "EXPECTED_PATH = 'docs/phase-25.md'"
 assert_fails_with "${wsl_failing_repo}" "docs/phase-25.md:1:"
 
+wsl_uri_failing_repo="${workdir}/wsl-uri-failing"
+create_repo \
+  "${wsl_uri_failing_repo}" \
+  "README.md" "# WSL URI failing fixture" \
+  "docs/phase-25.md" "Leaked path: file:///mnt/c/Users""/alice/private/project" \
+  "control-plane/tests/test_docs.py" "EXPECTED_PATH = 'docs/phase-25.md'"
+assert_fails_with "${wsl_uri_failing_repo}" "docs/phase-25.md:1:"
+
 script_failing_repo="${workdir}/script-failing"
 create_repo \
   "${script_failing_repo}" \

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -82,6 +82,16 @@ def visible_text(text: str) -> str:
     return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
 
 
+markdown_escapable_punctuation = r"""!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"""
+markdown_escape_pattern = re.compile(
+    rf"\\([{re.escape(markdown_escapable_punctuation)}])"
+)
+
+
+def normalize_markdown_escapes(text: str) -> str:
+    return markdown_escape_pattern.sub(r"\1", text)
+
+
 class VisibleHTMLTextRenderer(HTMLParser):
     block_tags = {
         "address",
@@ -155,12 +165,15 @@ def rendered_text(text: str) -> str:
     parser = VisibleHTMLTextRenderer()
     parser.feed(visible_text(text))
     parser.close()
-    return re.sub(r"[^\S\r\n]", " ", html.unescape("".join(parser.parts)))
+    rendered = re.sub(r"[^\S\r\n]", " ", html.unescape("".join(parser.parts)))
+    return normalize_markdown_escapes(rendered)
 
 
 rendered_doc_raw = rendered_text(doc_raw)
 rendered_readme_raw = rendered_text(readme_raw)
-rendered_source_doc_raw = re.sub(r"[^\S\r\n]", " ", html.unescape(doc_raw))
+rendered_source_doc_raw = normalize_markdown_escapes(
+    re.sub(r"[^\S\r\n]", " ", html.unescape(doc_raw))
+)
 
 
 def semantic_text(text: str) -> str:
@@ -327,7 +340,7 @@ structured_key_pattern = re.compile(
     rf"(?m)(?:^[ \t]*(?:-\s+)?|[\{{\[,]?\s*)[\"'`]?(?:{field_alternation})[\"'`]?\s*:",
     re.IGNORECASE,
 )
-if structured_key_pattern.search(doc_raw):
+if structured_key_pattern.search(normalize_markdown_escapes(doc_raw)):
     fail("JSON, YAML, and object-literal evidence syntax is not supported")
 
 unsupported_structural_html = re.compile(
@@ -342,7 +355,7 @@ inline_html_tag = re.compile(
     r"<\s*/?\s*(?:b|code|em|i|mark|small|span|strong|sub|sup)\b[^>]*>",
     re.IGNORECASE,
 )
-for raw_line in visible_text(doc_raw).splitlines():
+for raw_line in normalize_markdown_escapes(visible_text(doc_raw)).splitlines():
     if not inline_html_tag.search(raw_line):
         continue
     rendered_line = rendered_text(raw_line)
@@ -368,7 +381,7 @@ assignment_pattern = re.compile(
 current_section = "document-preamble"
 section_index = 0
 in_fence = False
-for raw_line in visible_text(doc_raw).splitlines():
+for raw_line in normalize_markdown_escapes(visible_text(doc_raw)).splitlines():
     stripped = raw_line.strip()
     if re.match(r"^(```|~~~)", stripped):
         in_fence = not in_fence
@@ -941,6 +954,12 @@ workstation_patterns = (
         + r"/[^\s`\"'()<>/]+/",
         re.IGNORECASE,
     ),
+    re.compile(
+        r"file:(?://(?:localhost)?/|/+)mnt/[a-z]/"
+        + wsl_windows_home_segment
+        + r"/[^\s`\"'()<>/]+/",
+        re.IGNORECASE,
+    ),
     re.compile(r"(?:^|[\s`\"'(<:=])~/(?:[^\s`\"'()<>]+)", re.IGNORECASE),
     re.compile(r"(?:^|[\s`\"'(<:=])[A-Za-z]:[\\/]Users[\\/][^\s`\"'()<>\\/]+[\\/]", re.IGNORECASE),
     re.compile(r"file://(?:[^\s`\"'()<>]*/)?(?:(?:Users|home)/[^\s`\"'()<>/]+|root)/", re.IGNORECASE),
@@ -1025,7 +1044,10 @@ truth_outcome = (
 )
 readiness_outcome = (
     r"(?:rc\s+(?:gate\s+pass|readiness)|release[- ]candidate\s+readiness|ga(?:\s+readiness|\s+gate\s+pass)?|"
-    r"general\s+availability|production\s+(?:readiness|rollout|operations)|commercial\s+replacement|"
+    r"general\s+availability|production(?:\s+(?:readiness|rollout|operations)|[- ](?:ready|grade|capable))|"
+    r"(?:ready|fit|suitable)\s+for\s+production|"
+    r"ready\s+to\s+(?:deploy|operate|run|ship)\s+(?:in|to)\s+production|"
+    r"commercial\s+replacement|"
     r"broad\s+(?:enterprise\s+)?(?:siem|soar)(?:\s+parity)?)"
 )
 authority_action = (

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -619,8 +619,9 @@ if materialized_fields:
             detail.append("unexpected " + ", ".join(extra))
         fail("invalid non_claims: " + "; ".join(detail))
 
+redaction_marker = re.compile(r"(?:redacted|absent|rejected|forbidden|removed)", re.IGNORECASE)
 sensitive_assignment = re.compile(
-    r"(?:^|[;,\s{|])`?(?:password|passwd|secret|client_secret|api_key|access_token|refresh_token|private_key|authorization)`?\s*[:=]\s*(?!\s*(?:redacted|absent|rejected|forbidden|removed)\b)(?:[\"'][^\"'\r\n]{4,}[\"']|[^\s;,|}]{4,})",
+    r"(?:^|[;,\s{|])`?(?:password|passwd|secret|client_secret|api_key|access_token|refresh_token|private_key|authorization)`?\s*[:=]\s*(?P<value>[^;,|}\r\n]+)",
     re.IGNORECASE,
 )
 secret_patterns = (
@@ -631,7 +632,21 @@ secret_patterns = (
     re.compile(r"[A-Za-z][A-Za-z0-9+.-]*://[^\s/:@]+:[^\s@]+@"),
     re.compile(r"-----(?:BEGIN|END) [A-Z0-9 ._-]*(?:KEY|CERTIFICATE)[A-Z0-9 ._-]*-----", re.IGNORECASE),
 )
-if any(sensitive_assignment.search(line) for line in doc_raw.splitlines()) or any(
+def assignment_contains_forbidden_value(pattern: re.Pattern, line: str) -> bool:
+    for match in pattern.finditer(line):
+        value = match.group("value").strip()
+        if len(value) >= 2 and (value[0], value[-1]) in {
+            ("`", "`"),
+            ('"', '"'),
+            ("'", "'"),
+        }:
+            value = value[1:-1].strip()
+        if not redaction_marker.fullmatch(value):
+            return True
+    return False
+
+
+if any(assignment_contains_forbidden_value(sensitive_assignment, line) for line in doc_raw.splitlines()) or any(
     pattern.search(doc_raw) for pattern in secret_patterns
 ):
     fail("production secret-looking value detected")
@@ -650,14 +665,16 @@ email_pattern = re.compile(
     r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![A-Za-z0-9.-])"
 )
 private_assignment = re.compile(
-    r"(?:^|[;,\s{|])`?(?:customer[_ -]?(?:name|identifier|private_data|private_payload)|tenant[_ -]?(?:name|identifier)|ticket[_ -]?private[_ -]?content|raw[_ -]?(?:customer|ticket)[_ -]?(?:data|payload|content))`?\s*[:=]\s*(?!\s*(?:redacted|absent|rejected|forbidden|removed)\b)(?:[\"'][^\"'\r\n]{2,}[\"']|[^\s;,|}]{2,})",
+    r"(?:^|[;,\s{|])`?(?:customer[_ -]?(?:name|identifier|private_data|private_payload)|tenant[_ -]?(?:name|identifier)|ticket[_ -]?private[_ -]?content|raw[_ -]?(?:customer|ticket)[_ -]?(?:data|payload|content))`?\s*[:=]\s*(?P<value>[^;,|}\r\n]+)",
     re.IGNORECASE,
 )
 private_data_claim = re.compile(
     r"\b(?:includes?|contains?|retains?|stores?|embeds?|exports?|captures?|publishes?)\b.{0,60}\b(?:raw customer|customer[- ]private|private ticket|raw ticket|raw payload|customer identifier)",
     re.IGNORECASE,
 )
-if email_pattern.search(doc_raw) or any(private_assignment.search(line) for line in doc_raw.splitlines()):
+if email_pattern.search(doc_raw) or any(
+    assignment_contains_forbidden_value(private_assignment, line) for line in doc_raw.splitlines()
+):
     fail("customer-private or ticket-private data detected")
 for line in doc_raw.splitlines():
     match = private_data_claim.search(line)
@@ -687,6 +704,11 @@ authority_action = (
     r"clos(?:e|es|ed|ing)(?:\s+the)?\s+cases?|admit(?:s|ted|ting)?|"
     r"releas(?:e|es|ed|ing)|gat(?:e|es|ed|ing)|overrid(?:e|es|den|ing))"
 )
+direct_authority_action = (
+    r"(?:approv(?:es|ed|ing)|execut(?:es|ed|ing)|reconcil(?:es|ed|ing)|"
+    r"clos(?:es|ed|ing)(?:\s+the)?\s+cases?|admit(?:s|ted|ting)|"
+    r"releas(?:es|ed|ing)|gat(?:es|ed|ing)|overrid(?:es|den|ing))"
+)
 claim_patterns = (
     re.compile(
         rf"\b{subordinate_subject}\b.{{0,120}}\b(?:is|are|becomes?|serves?\s+as|acts?\s+as|owns?|defines?|determines?)\b.{{0,80}}\b{truth_outcome}\b",
@@ -694,6 +716,10 @@ claim_patterns = (
     ),
     re.compile(
         rf"\b{subordinate_subject}\b.{{0,100}}\b(?:can|could|may|might|will|would|does|do|automatically|independently|directly)\b.{{0,60}}\b{authority_action}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b{subordinate_subject}\b\s+(?:(?:automatically|independently|directly)\s+)?{direct_authority_action}\b",
         re.IGNORECASE,
     ),
     re.compile(
@@ -721,10 +747,24 @@ claim_patterns = (
         re.IGNORECASE,
     ),
 )
-denial_pattern = re.compile(
-    r"\b(?:cannot|can't|does\s+not|do\s+not|did\s+not|will\s+not|would\s+not|should\s+not|"
-    r"may\s+not|must\s+not|not|never|no\s+longer|reject(?:s|ed|ing)?|forbid(?:s|den|ding)?|"
-    r"exclud(?:e|es|ed|ing)|without|remains?\s+subordinate|evidence\s+only)\b",
+denial_scope_boundary = (
+    rf"(?:[,;]|\b(?:and|or|but|however|yet|although|though|while|whereas|because|since)\b)\s*"
+    rf"(?:(?:{subordinate_subject}|it|they|this)\b\s*)?"
+    r"(?:can|could|may|might|will|would|does|do|is|are|automatically|independently|directly|"
+    r"becomes?|serves?|acts?|"
+    r"owns?|defines?|determines?|proves?|confirms?|establishes?|satisfies?|passes?|"
+    r"grants?|achieves?|certifies?|validates?|delivers?|enables?|provides?)\b"
+)
+denied_claim_target = (
+    rf"(?:{authority_action}|{truth_outcome}|{readiness_outcome}|"
+    r"proven|confirmed|established|satisfied|passed|achieved|validated|"
+    r"owned|defined|provided|determined|controlled|allowed|accepted|supported|valid)"
+)
+scoped_denial_pattern = re.compile(
+    rf"\b(?:cannot|can't|does\s+not|do\s+not|did\s+not|will\s+not|would\s+not|should\s+not|"
+    rf"may\s+not|must\s+not|not|never|no\s+longer|reject(?:s|ed|ing)?|forbid(?:s|den|ding)?|"
+    rf"exclud(?:e|es|ed|ing)|without|remains?\s+subordinate|evidence\s+only)\b"
+    rf"(?:(?!{denial_scope_boundary}).){{0,120}}\b{denied_claim_target}\b",
     re.IGNORECASE,
 )
 
@@ -765,7 +805,7 @@ for claim_input in claim_inputs:
     for clause in claim_clauses(claim_input):
         for pattern in claim_patterns:
             match = pattern.search(clause)
-            if match and not denial_pattern.search(match.group(0)):
+            if match and not scoped_denial_pattern.search(match.group(0)):
                 if os.environ.get("PHASE66_7_DEBUG") == "1":
                     print(f"Matched overclaim: {match.group(0)}", file=sys.stderr)
                 fail("authority or readiness overclaim detected")

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -1,0 +1,688 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+repo_root="$(cd "${repo_root}" && pwd -P)"
+
+doc_rel="docs/phase-66-7-rc-authority-boundary-proof-pack.md"
+doc_path="${repo_root}/${doc_rel}"
+readme_path="${repo_root}/README.md"
+
+required_reference_paths=(
+  "docs/phase-66-1-clean-host-rc-e2e-harness.md"
+  "docs/phase-66-2-wazuh-sample-signal-rc-proof.md"
+  "docs/phase-66-3-shuffle-sample-execution-rc-proof.md"
+  "docs/phase-66-4-ai-assisted-triage-rc-proof.md"
+  "docs/phase-66-5-report-export-rc-proof.md"
+  "docs/phase-66-6-rc-supportability-proof.md"
+  "docs/phase-51-6-authority-boundary-negative-test-policy.md"
+  "docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md"
+  "docs/phase-65-closeout-evaluation.md"
+)
+
+required_verifier_scripts=(
+  "scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+  "scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh"
+  "scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh"
+  "scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh"
+  "scripts/verify-phase-66-5-report-export-rc-proof.sh"
+  "scripts/verify-phase-66-6-rc-supportability-proof.sh"
+  "scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh"
+  "scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh"
+  "scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh"
+  "scripts/verify-publishable-path-hygiene.sh"
+)
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -s "${path}" ]]; then
+    echo "Missing ${description}: ${path#"${repo_root}/"}" >&2
+    exit 1
+  fi
+}
+
+require_file "${doc_path}" "Phase 66.7 RC authority-boundary proof pack"
+require_file "${readme_path}" "README for Phase 66.7 link check"
+
+for reference_path in "${required_reference_paths[@]}"; do
+  require_file "${repo_root}/${reference_path}" "Phase 66.7 reference ${reference_path}"
+done
+
+for verifier_script in "${required_verifier_scripts[@]}"; do
+  require_file "${repo_root}/${verifier_script}" "Phase 66.7 verifier script ${verifier_script}"
+done
+
+python3 - "${doc_path}" "${readme_path}" "${repo_root}" <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+doc_path = Path(sys.argv[1])
+readme_path = Path(sys.argv[2])
+repo_root = Path(sys.argv[3])
+doc_raw = doc_path.read_text(encoding="utf-8")
+readme_raw = readme_path.read_text(encoding="utf-8")
+
+
+def visible_text(text: str) -> str:
+    return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+
+
+def semantic_text(text: str) -> str:
+    text = visible_text(text)
+    return re.sub(
+        r"^[ \t]*(```|~~~)[^\n]*\n.*?^[ \t]*\1[^\n]*(?:\n|$)",
+        "",
+        text,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+
+
+def fail(detail: str) -> None:
+    print(f"Forbidden Phase 66.7 RC authority-boundary proof pack: {detail}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+doc_semantic = semantic_text(doc_raw)
+readme_semantic = semantic_text(readme_raw)
+
+readme_phrases = (
+    "- [Phase 66.7 RC authority-boundary proof pack](docs/phase-66-7-rc-authority-boundary-proof-pack.md) collects Phase 66.1-66.6 evidence and negative observations across Wazuh, Shuffle, AI, tickets, evidence systems, UI cache, demo data, reports, support bundles, release artifacts, verifier output, and issue-lint output while preserving AegisOps records as authority and excluding RC or GA gate, production, commercial replacement, and broad SIEM/SOAR parity claims.",
+    "The Phase 66.7 RC authority-boundary proof pack is defined by the [Phase 66.7 RC authority-boundary proof pack](docs/phase-66-7-rc-authority-boundary-proof-pack.md).",
+)
+
+for phrase in readme_phrases:
+    if phrase not in readme_semantic:
+        print(f"Missing README canonical Phase 66.7 boundary statement: {phrase}", file=sys.stderr)
+        raise SystemExit(1)
+
+required_phrases = (
+    "# Phase 66.7 RC Authority-Boundary Proof Pack",
+    "**Status**: Accepted as the Phase 66.7 RC authority-boundary proof-pack contract for release-candidate evidence planning only.",
+    "**Related Issues**: #1397, #1404",
+    "This contract defines the Phase 66.7 RC authority-boundary proof pack.",
+    "The proof pack depends on the Phase 66.1-66.6 proof surfaces and the Phase 51.6 authority-boundary negative-test policy.",
+    "This proof pack is RC evidence only.",
+    "A proof packet is fail-closed: once any required field is materialized, every required field must be present, non-placeholder, internally complete, and bound to the same journey run and immutable repository revision.",
+    "Materialized proof packets are accepted only as `field=value` assignment lines or Markdown `Field | Value` rows.",
+    "Every negative observation must record `evidence_id`, `surface`, `attempt`, `result=rejected`, `authoritative_record`, `observed_at`, `journey_run_id`, and `repository_revision`.",
+    "Passing one negative observation cannot compensate for a missing surface.",
+    "Each Phase 66.1-66.6 evidence value must record `evidence_id`, `verifier`, `result=passed`, `journey_run_id`, and `repository_revision`.",
+    "All materialized timestamps must be no more than 24 hours old at verification time and must not be more than five minutes in the future.",
+    "AegisOps records remain authoritative for alert, case, evidence, recommendation, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, restore acceptance, and closeout truth.",
+    "Wazuh, Shuffle, AI, tickets, evidence systems, browser state, UI cache, demo data, reports, support bundles, release artifacts, verifier output, issue-lint output, and optional evidence remain subordinate evidence or context only.",
+    "The proof pack must reject subordinate-truth promotion, approval bypass, execution bypass, reconciliation bypass, case-closure shortcuts, source-admission shortcuts, inferred RC pass, inferred GA pass, and artifact-driven limitation or closeout decisions.",
+    "Phase 66.8 must evaluate closeout independently against authoritative AegisOps records and accepted limitations.",
+    "Phase 66.7 does not add runtime feature breadth, execute production operations, grant new AI or integration authority, prove real design-partner outcomes, complete production rollout, implement commercial billing or entitlement enforcement, prove Phase 67 GA readiness, or claim broad enterprise SIEM/SOAR parity.",
+    "Run `bash scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh`.",
+    "Run `bash scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh`.",
+    "Run `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`.",
+    "Run `bash scripts/verify-publishable-path-hygiene.sh`.",
+    "Run `node <codex-supervisor-root>/dist/index.js issue-lint 1397 --config <supervisor-config-path>`.",
+    "Run `node <codex-supervisor-root>/dist/index.js issue-lint 1404 --config <supervisor-config-path>`.",
+)
+
+for phrase in required_phrases:
+    if phrase not in doc_semantic:
+        print(f"Missing Phase 66.7 RC authority-boundary proof-pack statement: {phrase}", file=sys.stderr)
+        raise SystemExit(1)
+
+if not re.search(r"^\*\*Date\*\*: [0-9]{4}-[0-9]{2}-[0-9]{2}$", doc_semantic, re.MULTILINE):
+    fail("missing or invalid date line")
+
+required_references = (
+    "docs/phase-66-1-clean-host-rc-e2e-harness.md",
+    "docs/phase-66-2-wazuh-sample-signal-rc-proof.md",
+    "docs/phase-66-3-shuffle-sample-execution-rc-proof.md",
+    "docs/phase-66-4-ai-assisted-triage-rc-proof.md",
+    "docs/phase-66-5-report-export-rc-proof.md",
+    "docs/phase-66-6-rc-supportability-proof.md",
+    "docs/phase-51-6-authority-boundary-negative-test-policy.md",
+    "docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md",
+    "docs/phase-65-closeout-evaluation.md",
+)
+for reference in required_references:
+    if f"`{reference}`" not in doc_semantic:
+        print(f"Missing Phase 66.7 proof-pack reference: {reference}", file=sys.stderr)
+        raise SystemExit(1)
+
+surface_expectations = (
+    ("Wazuh", "source-truth-promotion"),
+    ("Shuffle", "execution-receipt-promotion"),
+    ("AI", "approval-bypass"),
+    ("Tickets", "case-closure-shortcut"),
+    ("Evidence systems", "external-evidence-truth-promotion"),
+    ("UI cache", "workflow-truth-promotion"),
+    ("Demo data", "release-truth-promotion"),
+    ("Reports", "gate-truth-promotion"),
+    ("Support bundle", "limitation-truth-promotion"),
+    ("Release artifacts", "readiness-truth-promotion"),
+    ("Verifier output", "rc-gate-promotion"),
+    ("Issue-lint output", "rc-gate-promotion"),
+)
+matrix_match = re.search(
+    r"## 3\. Negative Evidence Matrix\s+(.*?)\s+## 4\. Evidence Binding And Secret Hygiene",
+    doc_semantic,
+    re.DOTALL,
+)
+if not matrix_match:
+    fail("missing negative evidence matrix")
+matrix = matrix_match.group(1)
+for surface, attempt in surface_expectations:
+    row_pattern = rf"(?m)^\|\s*{re.escape(surface)}\s*\|\s*`{re.escape(attempt)}`\s*\|"
+    if not re.search(row_pattern, matrix):
+        fail(f"missing negative evidence matrix row for {surface}")
+
+required_fields = (
+    "journey_run_id",
+    "repository_revision",
+    "phase_66_1_evidence",
+    "phase_66_2_evidence",
+    "phase_66_3_evidence",
+    "phase_66_4_evidence",
+    "phase_66_5_evidence",
+    "phase_66_6_evidence",
+    "wazuh_negative_evidence",
+    "shuffle_negative_evidence",
+    "ai_negative_evidence",
+    "ticket_negative_evidence",
+    "evidence_system_negative_evidence",
+    "ui_cache_negative_evidence",
+    "demo_data_negative_evidence",
+    "report_negative_evidence",
+    "support_bundle_negative_evidence",
+    "release_artifact_negative_evidence",
+    "verifier_output_negative_evidence",
+    "issue_lint_output_negative_evidence",
+    "owner_review",
+    "limitation_references",
+    "non_claims",
+)
+required_field_set = set(required_fields)
+field_alternation = "|".join(map(re.escape, required_fields))
+
+schema_match = re.search(
+    r"## 2\. Required Proof Packet\s+(.*?)\s+## 3\. Negative Evidence Matrix",
+    doc_semantic,
+    re.DOTALL,
+)
+if not schema_match:
+    fail("missing required proof-packet schema")
+schema = schema_match.group(1)
+for field in required_fields:
+    if not re.search(rf"(?m)^\|\s*`{re.escape(field)}`\s*\|", schema):
+        fail(f"missing proof-packet field {field}")
+
+structured_key_pattern = re.compile(
+    rf"(?m)(?:^[ \t]*(?:-\s+)?|[\{{\[,]?\s*)[\"'`]?(?:{field_alternation})[\"'`]?\s*:",
+    re.IGNORECASE,
+)
+if structured_key_pattern.search(doc_raw):
+    fail("JSON, YAML, and object-literal evidence syntax is not supported")
+
+
+def markdown_cells(line: str) -> list[str]:
+    cells = re.split(r"(?<!\\)\|", line.strip())
+    if cells and not cells[0]:
+        cells = cells[1:]
+    if cells and not cells[-1]:
+        cells = cells[:-1]
+    return [cell.strip() for cell in cells]
+
+
+field_values: dict[str, list[str]] = {field: [] for field in required_fields}
+section_values: dict[str, dict[str, list[str]]] = {}
+assignment_pattern = re.compile(
+    rf"^\s*(?:[-*>]\s*)?`?({field_alternation})`?\s*=\s*(.*?)\s*$",
+    re.IGNORECASE,
+)
+current_section = "document-preamble"
+section_index = 0
+in_fence = False
+for raw_line in visible_text(doc_raw).splitlines():
+    stripped = raw_line.strip()
+    if re.match(r"^(```|~~~)", stripped):
+        in_fence = not in_fence
+        continue
+    if in_fence:
+        continue
+    if stripped.startswith("## "):
+        section_index += 1
+        current_section = f"{section_index}:{stripped}"
+
+    field = ""
+    value = ""
+    assignment = assignment_pattern.match(raw_line)
+    if assignment:
+        field = assignment.group(1).lower()
+        value = assignment.group(2).strip().strip("`")
+    elif stripped.startswith("|"):
+        cells = markdown_cells(raw_line)
+        if len(cells) == 2:
+            candidate = cells[0].strip("`").lower()
+            if candidate in required_field_set and candidate != "field":
+                field = candidate
+                value = cells[1].strip().strip("`")
+    if not field:
+        continue
+    field_values[field].append(value)
+    values = section_values.setdefault(
+        current_section,
+        {required_field: [] for required_field in required_fields},
+    )
+    values[field].append(value)
+
+for section_name, values in section_values.items():
+    materialized = {field for field, items in values.items() if items}
+    if not materialized:
+        continue
+    missing = sorted(required_field_set - materialized)
+    if missing:
+        fail(
+            "partial evidence packet in "
+            + section_name.split(":", 1)[-1]
+            + "; missing "
+            + ", ".join(missing)
+        )
+    duplicates = sorted(field for field, items in values.items() if len(items) != 1)
+    if duplicates:
+        fail(
+            "multiple materialized values in "
+            + section_name.split(":", 1)[-1]
+            + " for "
+            + ", ".join(duplicates)
+        )
+
+materialized_fields = {field for field, values in field_values.items() if values}
+if materialized_fields:
+    missing = sorted(required_field_set - materialized_fields)
+    if missing:
+        fail("partial evidence packet; missing " + ", ".join(missing))
+    duplicates = sorted(field for field, values in field_values.items() if len(values) != 1)
+    if duplicates:
+        fail("multiple materialized values across evidence packets for " + ", ".join(duplicates))
+
+placeholder_pattern = re.compile(
+    r"(?:^|[^a-z0-9])(?:todo|tbd|tbc|unknown|null|n/?a|pending|fake|placeholder|omitted|missing|unavailable|not[- _]?available)(?:$|[^a-z0-9])",
+    re.IGNORECASE,
+)
+
+
+def field_value(field: str) -> str:
+    return field_values[field][0]
+
+
+def reject_placeholder(field: str, value: str) -> None:
+    normalized = value.strip().strip("`").lower()
+    if not normalized or normalized in {"sample", "example"} or placeholder_pattern.search(value):
+        fail(f"invalid {field}: placeholder or empty value")
+
+
+def parse_components(field: str, value: str) -> dict[str, str]:
+    reject_placeholder(field, value)
+    parts: dict[str, str] = {}
+    for item in re.split(r"\s*;\s*", value):
+        if not item:
+            continue
+        if "=" not in item:
+            fail(f"invalid {field}: unstructured component {item!r}")
+        key, component = item.split("=", 1)
+        key = key.strip().lower()
+        component = component.strip().strip("`")
+        if not re.fullmatch(r"[a-z][a-z0-9_]*", key):
+            fail(f"invalid {field}: invalid component name {key!r}")
+        if key in parts:
+            fail(f"invalid {field}: duplicate component {key}")
+        reject_placeholder(field, component)
+        parts[key] = component
+    return parts
+
+
+def require_components(field: str, required: tuple[str, ...]) -> dict[str, str]:
+    parts = parse_components(field, field_value(field))
+    missing = [name for name in required if name not in parts]
+    extra = sorted(set(parts) - set(required))
+    if missing:
+        fail(f"invalid {field}: missing components {', '.join(missing)}")
+    if extra:
+        fail(f"invalid {field}: unexpected components {', '.join(extra)}")
+    return parts
+
+
+def parse_timestamp(
+    field: str,
+    value: str,
+    *,
+    fresh: bool = True,
+    allow_future: bool = False,
+) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        fail(f"invalid {field}: timestamp must be ISO-8601")
+    if parsed.tzinfo is None:
+        fail(f"invalid {field}: timestamp must include timezone")
+    parsed = parsed.astimezone(timezone.utc)
+    now = datetime.now(timezone.utc)
+    if not allow_future and parsed > now + timedelta(minutes=5):
+        fail(f"invalid {field}: timestamp is too far in the future")
+    if fresh and parsed < now - timedelta(hours=24):
+        fail(f"invalid {field}: timestamp is stale")
+    return parsed
+
+
+if materialized_fields:
+    journey_run_id = field_value("journey_run_id")
+    repository_revision = field_value("repository_revision").lower()
+    reject_placeholder("journey_run_id", journey_run_id)
+    if not re.fullmatch(r"rc66-[a-z0-9][a-z0-9._-]{5,80}", journey_run_id, re.IGNORECASE):
+        fail("invalid journey_run_id: expected rc66-* identifier")
+    if not re.fullmatch(r"[0-9a-f]{40}", repository_revision):
+        fail("invalid repository_revision: expected immutable 40-character revision")
+    try:
+        head_revision = subprocess.check_output(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip().lower()
+    except (OSError, subprocess.CalledProcessError):
+        fail("cannot resolve repository HEAD for evidence binding")
+    if repository_revision != head_revision:
+        fail("invalid repository_revision: does not match repository HEAD")
+
+    phase_verifiers = {
+        "phase_66_1_evidence": "scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh",
+        "phase_66_2_evidence": "scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh",
+        "phase_66_3_evidence": "scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh",
+        "phase_66_4_evidence": "scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh",
+        "phase_66_5_evidence": "scripts/verify-phase-66-5-report-export-rc-proof.sh",
+        "phase_66_6_evidence": "scripts/verify-phase-66-6-rc-supportability-proof.sh",
+    }
+    for field, expected_verifier in phase_verifiers.items():
+        parts = require_components(
+            field,
+            ("evidence_id", "verifier", "result", "journey_run_id", "repository_revision"),
+        )
+        if not re.fullmatch(r"[a-z0-9][a-z0-9._:-]{5,120}", parts["evidence_id"], re.IGNORECASE):
+            fail(f"invalid {field}: malformed evidence_id")
+        if parts["verifier"] != expected_verifier:
+            fail(f"invalid {field}: unexpected verifier path")
+        if parts["result"].lower() != "passed":
+            fail(f"invalid {field}: verifier result must be passed")
+        if parts["journey_run_id"] != journey_run_id:
+            fail(f"invalid {field}: mixed journey_run_id")
+        if parts["repository_revision"].lower() != repository_revision:
+            fail(f"invalid {field}: mixed repository_revision")
+
+    negative_expectations = {
+        "wazuh_negative_evidence": ("wazuh", "source-truth-promotion"),
+        "shuffle_negative_evidence": ("shuffle", "execution-receipt-promotion"),
+        "ai_negative_evidence": ("ai", "approval-bypass"),
+        "ticket_negative_evidence": ("tickets", "case-closure-shortcut"),
+        "evidence_system_negative_evidence": ("evidence-systems", "external-evidence-truth-promotion"),
+        "ui_cache_negative_evidence": ("ui-cache", "workflow-truth-promotion"),
+        "demo_data_negative_evidence": ("demo-data", "release-truth-promotion"),
+        "report_negative_evidence": ("reports", "gate-truth-promotion"),
+        "support_bundle_negative_evidence": ("support-bundle", "limitation-truth-promotion"),
+        "release_artifact_negative_evidence": ("release-artifacts", "readiness-truth-promotion"),
+        "verifier_output_negative_evidence": ("verifier-output", "rc-gate-promotion"),
+        "issue_lint_output_negative_evidence": ("issue-lint-output", "rc-gate-promotion"),
+    }
+    for field, (expected_surface, expected_attempt) in negative_expectations.items():
+        parts = require_components(
+            field,
+            (
+                "evidence_id",
+                "surface",
+                "attempt",
+                "result",
+                "authoritative_record",
+                "observed_at",
+                "journey_run_id",
+                "repository_revision",
+            ),
+        )
+        if not re.fullmatch(r"[a-z0-9][a-z0-9._:-]{5,120}", parts["evidence_id"], re.IGNORECASE):
+            fail(f"invalid {field}: malformed evidence_id")
+        if parts["surface"].lower() != expected_surface:
+            fail(f"invalid {field}: expected surface {expected_surface}")
+        if parts["attempt"].lower() != expected_attempt:
+            fail(f"invalid {field}: expected rejected attempt {expected_attempt}")
+        if parts["result"].lower() != "rejected":
+            fail(f"invalid {field}: result must be rejected")
+        if not re.fullmatch(r"aegisops://[a-z0-9][a-z0-9._/-]{5,180}", parts["authoritative_record"], re.IGNORECASE):
+            fail(f"invalid {field}: authoritative_record must be a specific aegisops:// reference")
+        parse_timestamp(field, parts["observed_at"])
+        if parts["journey_run_id"] != journey_run_id:
+            fail(f"invalid {field}: mixed journey_run_id")
+        if parts["repository_revision"].lower() != repository_revision:
+            fail(f"invalid {field}: mixed repository_revision")
+
+    owner_review = require_components(
+        "owner_review",
+        ("reviewer", "reviewed_at", "disposition", "follow_up_owner"),
+    )
+    for identity_field in ("reviewer", "follow_up_owner"):
+        identity = owner_review[identity_field]
+        if not re.fullmatch(r"[a-z0-9][a-z0-9._@-]{2,80}", identity, re.IGNORECASE):
+            fail(f"invalid owner_review: malformed {identity_field}")
+        if re.search(r"\b(?:artifact|verifier|issue-lint|bot|automation)\b", identity, re.IGNORECASE):
+            fail(f"invalid owner_review: {identity_field} must be accountable")
+    if owner_review["disposition"].lower() != "accepted":
+        fail("invalid owner_review: disposition must be accepted")
+    parse_timestamp("owner_review", owner_review["reviewed_at"])
+
+    limitations = require_components(
+        "limitation_references",
+        ("ids", "owner", "decision_at", "follow_up_at"),
+    )
+    if not re.fullmatch(r"lim-[a-z0-9._-]+(?:,lim-[a-z0-9._-]+)*", limitations["ids"], re.IGNORECASE):
+        fail("invalid limitation_references: ids must be explicit lim-* identifiers")
+    if not re.fullmatch(r"[a-z0-9][a-z0-9._@-]{2,80}", limitations["owner"], re.IGNORECASE):
+        fail("invalid limitation_references: owner must be accountable")
+    decision_at = parse_timestamp("limitation_references", limitations["decision_at"])
+    follow_up_at = parse_timestamp(
+        "limitation_references",
+        limitations["follow_up_at"],
+        fresh=False,
+        allow_future=True,
+    )
+    if follow_up_at <= decision_at:
+        fail("invalid limitation_references: follow_up_at must be after decision_at")
+
+    required_non_claims = {
+        "rc-evidence-only",
+        "not-rc-gate-pass",
+        "not-ga",
+        "not-production-operations",
+        "not-commercial-replacement",
+        "not-broad-siem-parity",
+        "not-broad-soar-parity",
+        "not-subordinate-truth",
+    }
+    non_claims = {item.strip().lower() for item in field_value("non_claims").split(",") if item.strip()}
+    if non_claims != required_non_claims:
+        missing = sorted(required_non_claims - non_claims)
+        extra = sorted(non_claims - required_non_claims)
+        detail = []
+        if missing:
+            detail.append("missing " + ", ".join(missing))
+        if extra:
+            detail.append("unexpected " + ", ".join(extra))
+        fail("invalid non_claims: " + "; ".join(detail))
+
+sensitive_assignment = re.compile(
+    r"(?:^|[;,\s{|])`?(?:password|passwd|secret|client_secret|api_key|access_token|refresh_token|private_key|authorization)`?\s*[:=]\s*(?!\s*(?:redacted|absent|rejected|forbidden|removed)\b)(?:[\"'][^\"'\r\n]{4,}[\"']|[^\s;,|}]{4,})",
+    re.IGNORECASE,
+)
+secret_patterns = (
+    re.compile(r"\bauthorization\s*[:=]\s*(?:bearer|basic)\s+[A-Za-z0-9_+./=-]{12,}", re.IGNORECASE),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\b(?:ghp_|github_pat_)[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b"),
+    re.compile(r"[A-Za-z][A-Za-z0-9+.-]*://[^\s/:@]+:[^\s@]+@"),
+    re.compile(r"-----(?:BEGIN|END) [A-Z0-9 ._-]*(?:KEY|CERTIFICATE)[A-Z0-9 ._-]*-----", re.IGNORECASE),
+)
+if any(sensitive_assignment.search(line) for line in doc_raw.splitlines()) or any(
+    pattern.search(doc_raw) for pattern in secret_patterns
+):
+    fail("production secret-looking value detected")
+
+workstation_patterns = (
+    re.compile(r"(?:^|[\s`\"'(<:=])/(?:Users|home)/[^\s`\"'()<>/]+/", re.IGNORECASE),
+    re.compile(r"(?:^|[\s`\"'(<:=])/(?:root)(?:/|$)", re.IGNORECASE),
+    re.compile(r"(?:^|[\s`\"'(<:=])~/(?:[^\s`\"'()<>]+)", re.IGNORECASE),
+    re.compile(r"(?:^|[\s`\"'(<:=])[A-Za-z]:[\\/]Users[\\/][^\s`\"'()<>\\/]+[\\/]", re.IGNORECASE),
+    re.compile(r"file://(?:[^\s`\"'()<>]*/)?(?:(?:Users|home)/[^\s`\"'()<>/]+|root)/", re.IGNORECASE),
+)
+if any(pattern.search(doc_raw) for pattern in workstation_patterns):
+    fail("workstation-local path detected")
+
+email_pattern = re.compile(
+    r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![A-Za-z0-9.-])"
+)
+private_assignment = re.compile(
+    r"(?:^|[;,\s{|])`?(?:customer[_ -]?(?:name|identifier|private_data|private_payload)|tenant[_ -]?(?:name|identifier)|ticket[_ -]?private[_ -]?content|raw[_ -]?(?:customer|ticket)[_ -]?(?:data|payload|content))`?\s*[:=]\s*(?!\s*(?:redacted|absent|rejected|forbidden|removed)\b)(?:[\"'][^\"'\r\n]{2,}[\"']|[^\s;,|}]{2,})",
+    re.IGNORECASE,
+)
+private_data_claim = re.compile(
+    r"\b(?:includes?|contains?|retains?|stores?|embeds?|exports?|captures?|publishes?)\b.{0,60}\b(?:raw customer|customer[- ]private|private ticket|raw ticket|raw payload|customer identifier)",
+    re.IGNORECASE,
+)
+if email_pattern.search(doc_raw) or any(private_assignment.search(line) for line in doc_raw.splitlines()):
+    fail("customer-private or ticket-private data detected")
+for line in doc_raw.splitlines():
+    match = private_data_claim.search(line)
+    if match and not re.search(
+        r"\b(?:cannot|does not|must not|never|rejects?|forbids?|without|redacts?|removes?)\b",
+        line[: match.end()],
+        re.IGNORECASE,
+    ):
+        fail("customer-private or ticket-private data detected")
+
+subordinate_subject = (
+    r"(?:this\s+proof(?:\s+pack)?|phase\s+66\.7|proof\s+pack|wazuh|shuffle|ai(?:\s+output)?|tickets?|"
+    r"evidence\s+systems?|external\s+evidence|browser\s+state|ui\s+cache|demo\s+data|reports?|"
+    r"support\s+bundles?|release\s+artifacts?|verifier\s+output|issue-lint\s+output)"
+)
+truth_outcome = (
+    r"(?:authoritative|(?:workflow|alert|case|evidence|approval|execution|reconciliation|release|gate|"
+    r"limitation|readiness|closeout|source)\s+truth|source\s+of\s+truth|rc\s+gate\s+(?:pass|decision))"
+)
+readiness_outcome = (
+    r"(?:rc\s+(?:gate\s+pass|readiness)|release[- ]candidate\s+readiness|ga(?:\s+readiness|\s+gate\s+pass)?|"
+    r"general\s+availability|production\s+(?:readiness|rollout|operations)|commercial\s+replacement|"
+    r"broad\s+(?:enterprise\s+)?(?:siem|soar)(?:\s+parity)?)"
+)
+authority_action = (
+    r"(?:approv(?:e|es|ed|ing)|execut(?:e|es|ed|ing)|reconcil(?:e|es|ed|ing)|"
+    r"clos(?:e|es|ed|ing)(?:\s+the)?\s+case|admit(?:s|ted|ting)?|"
+    r"releas(?:e|es|ed|ing)|gat(?:e|es|ed|ing)|overrid(?:e|es|den|ing))"
+)
+claim_patterns = (
+    re.compile(
+        rf"\b{subordinate_subject}\b.{{0,120}}\b(?:is|are|becomes?|serves?\s+as|acts?\s+as|owns?|defines?|determines?)\b.{{0,80}}\b{truth_outcome}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b{subordinate_subject}\b.{{0,100}}\b(?:can|could|may|might|will|would|does|do|automatically|independently|directly)\b.{{0,60}}\b{authority_action}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b{subordinate_subject}\b.{{0,100}}\b(?:proves?|confirms?|establishes?|satisfies?|passes?|grants?|achieves?|certifies?|validates?)\b.{{0,100}}\b{readiness_outcome}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b{readiness_outcome}\b.{{0,100}}\b(?:is|are|was|were|has\s+been|have\s+been)\s+(?:proven|confirmed|established|satisfied|passed|achieved|validated)\b.{{0,100}}\bby\b.{{0,80}}\b{subordinate_subject}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b{truth_outcome}\b.{{0,80}}\b(?:is|are|was|were|has\s+been|have\s+been)\s+(?:owned|defined|provided|established|determined|controlled)\b.{{0,80}}\bby\b.{{0,80}}\b{subordinate_subject}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b(?:aegisops|phase\s+66\.7|this\s+proof(?:\s+pack)?|proof\s+pack)\b.{{0,80}}\b(?:is|are|becomes?|delivers?|enables?|provides?)\b.{{0,80}}\b{readiness_outcome}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:approval|execution|reconciliation)\s+bypass\b.{0,50}\b(?:is|are|becomes?|remains?)\s+(?:allowed|accepted|supported|valid)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:case[- ]closure|source[- ]admission)\s+shortcut\b.{0,50}\b(?:is|are|becomes?|remains?)\s+(?:allowed|accepted|supported|valid)\b",
+        re.IGNORECASE,
+    ),
+)
+denial_pattern = re.compile(
+    r"\b(?:cannot|can't|does\s+not|do\s+not|did\s+not|will\s+not|would\s+not|should\s+not|"
+    r"may\s+not|must\s+not|not|never|no\s+longer|reject(?:s|ed|ing)?|forbid(?:s|den|ding)?|"
+    r"exclud(?:e|es|ed|ing)|without|remains?\s+subordinate|evidence\s+only)\b",
+    re.IGNORECASE,
+)
+
+
+def claim_clauses(text: str):
+    normalized = re.sub(r"[`*_#|]", " ", text)
+    normalized = re.sub(r"\s+", " ", normalized)
+    inherited_subject = ""
+    for clause in re.split(
+        r"\s*(?:(?<!\d)[.!?](?!\d)|;|\bbut\b|\bhowever\b|\byet\b|\balthough\b|\bthough\b)\s*",
+        normalized,
+        flags=re.IGNORECASE,
+    ):
+        clause = clause.strip()
+        if not clause:
+            continue
+        subject_match = re.search(subordinate_subject, clause, re.IGNORECASE)
+        if subject_match:
+            inherited_subject = subject_match.group(0)
+        elif inherited_subject and re.match(r"^(?:it|they|this)\b", clause, re.IGNORECASE):
+            clause = re.sub(r"^(?:it|they|this)\b", inherited_subject, clause, flags=re.IGNORECASE)
+        yield clause
+
+
+claim_scan_doc = doc_raw.replace(
+    "Phase 66.7 does not add runtime feature breadth, execute production operations, grant new AI or integration authority, prove real design-partner outcomes, complete production rollout, implement commercial billing or entitlement enforcement, prove Phase 67 GA readiness, or claim broad enterprise SIEM/SOAR parity.",
+    "",
+)
+claim_inputs = (
+    claim_scan_doc,
+    "\n".join(
+        line
+        for line in readme_raw.splitlines()
+        if re.search(r"phase\s+66\.7|authority-boundary\s+proof\s+pack", line, re.IGNORECASE)
+    ),
+)
+for claim_input in claim_inputs:
+    for clause in claim_clauses(claim_input):
+        for pattern in claim_patterns:
+            match = pattern.search(clause)
+            if match and not denial_pattern.search(match.group(0)):
+                if os.environ.get("PHASE66_7_DEBUG") == "1":
+                    print(f"Matched overclaim: {match.group(0)}", file=sys.stderr)
+                fail("authority or readiness overclaim detected")
+
+print("Phase 66.7 proof-pack document, evidence schema, secret hygiene, and authority checks pass.")
+PY
+
+if [[ "${PHASE66_7_SKIP_PATH_HYGIENE:-0}" != "1" ]]; then
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "${tmp_dir}"' EXIT
+  path_hygiene_stderr="${tmp_dir}/path-hygiene.err"
+  if ! bash "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" >/dev/null 2>"${path_hygiene_stderr}"; then
+    cat "${path_hygiene_stderr}" >&2
+    echo "Forbidden Phase 66.7 RC authority-boundary proof pack: publishable path hygiene failed" >&2
+    exit 1
+  fi
+fi
+
+echo "Phase 66.7 RC authority-boundary proof-pack contract and focused negative checks pass."

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -238,12 +238,12 @@ required_phrases = (
     "Every record contains exactly `field`, `surface`, `attempt`, `result`, `authoritative_record`, `observed_at`, and `journey_run_id`; missing, duplicate, extra, non-string, or packet-mismatched values fail closed.",
     "Passing one negative observation cannot compensate for a missing surface.",
     "Each Phase 66.1-66.6 evidence value must record `evidence_id`, `evidence_reference`, `verifier`, `result=passed`, `journey_run_id`, and `repository_revision`.",
-    "Each Phase 66.1-66.6 `evidence_id` must be `sha256:<digest>` for the exact referenced proof document bytes at `repository_revision`.",
+    "Each Phase 66.1-66.6 `evidence_id` must be `sha256:<digest>` for the exact referenced proof document Git blob bytes at `repository_revision`.",
     "The top-level `repository_revision` identifies the evidence-producing commit, not the commit that later stores the proof packet.",
-    "The verifier must check out that exact revision in an isolated worktree, resolve each required evidence reference there, and execute every Phase 66.1-66.6 focused verifier there.",
-    "Packet labels or a declared `result=passed` cannot substitute for resolved proof surfaces and successful verifier execution.",
-    "Each prerequisite verifier must leave the isolated worktree at `repository_revision` with no tracked or untracked changes.",
-    "A verifier that changes the worktree revision or mutates any worktree content fails closed.",
+    "The verifier must check out that exact revision in an isolated worktree, require every referenced proof surface and prerequisite verifier to be a regular Git blob in that commit, bind evidence digests to those Git blob bytes, and execute every Phase 66.1-66.6 focused verifier there.",
+    "Packet labels, symlink targets, or a declared `result=passed` cannot substitute for repository-owned proof surfaces and successful verifier execution.",
+    "Each prerequisite verifier must leave the isolated worktree at `repository_revision` with no tracked, untracked, or ignored changes.",
+    "A verifier that changes the worktree revision or leaves any worktree content behind fails closed.",
     "The same isolated worktree must resolve the negative-observation manifest, bind its exact bytes to every negative `evidence_id`, and match every packet observation to one manifest record.",
     "A syntactically valid negative observation without that immutable record fails closed.",
     "Every `owner_review` value must record `artifact_owner`, `reviewer`, `reviewed_at`, `disposition`, and `follow_up_owner`.",
@@ -794,6 +794,53 @@ if materialized_fields:
         )
         worktree_added = True
 
+        def resolve_regular_git_blob(reference: str, description: str) -> bytes:
+            tree_result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo_root),
+                    "ls-tree",
+                    "-z",
+                    "--full-tree",
+                    repository_revision,
+                    "--",
+                    reference,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            entries = [entry for entry in tree_result.stdout.split(b"\0") if entry]
+            if tree_result.returncode != 0 or len(entries) != 1:
+                fail(f"{description} does not resolve at repository_revision")
+            try:
+                metadata, resolved_path = entries[0].split(b"\t", 1)
+                mode, object_type, object_id = metadata.split()
+            except ValueError:
+                fail(f"{description} does not resolve at repository_revision")
+            if resolved_path != reference.encode("utf-8"):
+                fail(f"{description} does not resolve at repository_revision")
+            if mode not in {b"100644", b"100755"} or object_type != b"blob":
+                fail(
+                    f"{description} must resolve to a regular Git blob at "
+                    "repository_revision"
+                )
+            blob_result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo_root),
+                    "cat-file",
+                    "blob",
+                    object_id.decode("ascii"),
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            if blob_result.returncode != 0 or not blob_result.stdout:
+                fail(f"{description} does not resolve at repository_revision")
+            return blob_result.stdout
+
         def assert_evidence_worktree_immutable(field: str) -> None:
             head_result = subprocess.run(
                 ["git", "-C", str(evidence_worktree), "rev-parse", "HEAD"],
@@ -817,6 +864,7 @@ if materialized_fields:
                     "status",
                     "--porcelain=v1",
                     "--untracked-files=all",
+                    "--ignored=matching",
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -830,15 +878,26 @@ if materialized_fields:
 
         for field, (expected_reference, expected_verifier) in phase_verifiers.items():
             assert_evidence_worktree_immutable(field)
-            reference_path = evidence_worktree / expected_reference
+            reference_bytes = resolve_regular_git_blob(
+                expected_reference,
+                f"invalid {field}: evidence reference",
+            )
+            verifier_bytes = resolve_regular_git_blob(
+                expected_verifier,
+                f"invalid {field}: verifier",
+            )
             verifier_path = evidence_worktree / expected_verifier
-            if not reference_path.is_file() or reference_path.stat().st_size == 0:
-                fail(f"invalid {field}: evidence reference does not resolve at repository_revision")
-            resolved_evidence_id = "sha256:" + hashlib.sha256(reference_path.read_bytes()).hexdigest()
+            resolved_evidence_id = "sha256:" + hashlib.sha256(reference_bytes).hexdigest()
             if phase_evidence_parts[field]["evidence_id"].lower() != resolved_evidence_id:
                 fail(f"invalid {field}: evidence_id does not match resolved evidence reference")
-            if not verifier_path.is_file() or verifier_path.stat().st_size == 0:
+            if verifier_path.is_symlink() or not verifier_path.is_file():
                 fail(f"invalid {field}: verifier does not resolve at repository_revision")
+            try:
+                checked_out_verifier_bytes = verifier_path.read_bytes()
+            except OSError:
+                fail(f"invalid {field}: verifier does not resolve at repository_revision")
+            if checked_out_verifier_bytes != verifier_bytes:
+                fail(f"invalid {field}: verifier does not match repository_revision")
             verifier_result = subprocess.run(
                 ["bash", str(verifier_path), str(evidence_worktree)],
                 stdout=subprocess.PIPE,
@@ -851,18 +910,19 @@ if materialized_fields:
                 fail(f"invalid {field}: prerequisite verifier failed: {diagnostic}")
             assert_evidence_worktree_immutable(field)
 
-        negative_manifest_path = evidence_worktree / negative_manifest_reference
-        if not negative_manifest_path.is_file() or negative_manifest_path.stat().st_size == 0:
-            fail("negative evidence reference does not resolve at repository_revision")
+        negative_manifest_bytes = resolve_regular_git_blob(
+            negative_manifest_reference,
+            "negative evidence reference",
+        )
         resolved_negative_evidence_id = (
-            "sha256:" + hashlib.sha256(negative_manifest_path.read_bytes()).hexdigest()
+            "sha256:" + hashlib.sha256(negative_manifest_bytes).hexdigest()
         )
         for field, parts in negative_evidence_parts.items():
             if parts["evidence_id"].lower() != resolved_negative_evidence_id:
                 fail(f"invalid {field}: evidence_id does not match resolved evidence reference")
         try:
-            negative_manifest = json.loads(negative_manifest_path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeError, json.JSONDecodeError):
+            negative_manifest = json.loads(negative_manifest_bytes.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError):
             fail("negative evidence reference must contain valid UTF-8 JSON")
         if not isinstance(negative_manifest, dict) or set(negative_manifest) != {
             "schema_version",
@@ -908,17 +968,18 @@ if materialized_fields:
             if records_by_field[field] != expected_record:
                 fail(f"invalid {field}: resolved negative evidence record does not match packet")
 
-        limitation_manifest_path = evidence_worktree / limitation_manifest_reference
-        if not limitation_manifest_path.is_file() or limitation_manifest_path.stat().st_size == 0:
-            fail("limitation evidence reference does not resolve at repository_revision")
+        limitation_manifest_bytes = resolve_regular_git_blob(
+            limitation_manifest_reference,
+            "limitation evidence reference",
+        )
         resolved_limitation_evidence_id = (
-            "sha256:" + hashlib.sha256(limitation_manifest_path.read_bytes()).hexdigest()
+            "sha256:" + hashlib.sha256(limitation_manifest_bytes).hexdigest()
         )
         if limitations["evidence_id"].lower() != resolved_limitation_evidence_id:
             fail("invalid limitation_references: evidence_id does not match resolved evidence reference")
         try:
-            limitation_manifest = json.loads(limitation_manifest_path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeError, json.JSONDecodeError):
+            limitation_manifest = json.loads(limitation_manifest_bytes.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError):
             fail("limitation evidence reference must contain valid UTF-8 JSON")
         if not isinstance(limitation_manifest, dict) or set(limitation_manifest) != {
             "schema_version",
@@ -1045,8 +1106,10 @@ if materialized_fields:
 redaction_marker = re.compile(r"(?:redacted|absent|rejected|forbidden|removed)", re.IGNORECASE)
 sensitive_assignment = re.compile(
     r"(?:^|[;,\s{|])`?(?:password|passwd|secret(?:[ _-]*key)?|client[ _-]*secret|"
-    r"x[ _-]*api[ _-]*key|api[ _-]*key|access[ _-]*token|refresh[ _-]*token|"
-    r"private[ _-]*key|"
+    r"x[ _-]*api[ _-]*key|api[ _-]*key|"
+    r"(?:access|refresh|session|auth|bearer|csrf|id)[ _-]*token|"
+    r"session[ _-]*id|(?:session|auth)[ _-]*cookie|"
+    r"cookie(?:[ _-]*(?:token|value))?|private[ _-]*key|"
     r"authorization)`?\s*[:=]\s*(?P<value>[^;,|}\r\n]+)",
     re.IGNORECASE,
 )
@@ -1095,14 +1158,18 @@ workstation_patterns = (
         re.IGNORECASE,
     ),
     re.compile(
-        r"file:(?://(?:localhost)?/|/+)mnt/[a-z]/"
+        r"(?<![A-Za-z0-9_./\\-])file:(?://(?:localhost)?/|/+)mnt/[a-z]/"
         + wsl_windows_home_segment
         + r"/[^\s`\"'()<>/]+/",
         re.IGNORECASE,
     ),
     re.compile(r"(?:^|[\s`\"'(<:=])~/(?:[^\s`\"'()<>]+)", re.IGNORECASE),
     re.compile(r"(?:^|[\s`\"'(<:=])[A-Za-z]:[\\/]Users[\\/][^\s`\"'()<>\\/]+[\\/]", re.IGNORECASE),
-    re.compile(r"file://(?:[^\s`\"'()<>]*/)?(?:(?:Users|home)/[^\s`\"'()<>/]+|root)/", re.IGNORECASE),
+    re.compile(
+        r"(?<![A-Za-z0-9_./\\-])file://(?:[^\s`\"'()<>]*/)?"
+        r"(?:(?:Users|home)/[^\s`\"'()<>/]+|root)/",
+        re.IGNORECASE,
+    ),
 )
 if any(
     pattern.search(hygiene_input)
@@ -1157,7 +1224,7 @@ private_claim_denial = re.compile(
     rf"(?:(?!{private_denial_boundary}).){{0,60}}$",
     re.IGNORECASE,
 )
-for line in rendered_doc_raw.splitlines():
+for line in normalize_inline_markdown(rendered_doc_raw).splitlines():
     for match in private_data_claim.finditer(line):
         claim_prefix = line[match.start() : match.start("object")]
         if private_claim_safe_qualifier.search(claim_prefix):
@@ -1245,6 +1312,17 @@ claim_patterns = (
         re.IGNORECASE,
     ),
     re.compile(
+        rf"\b{subordinate_subject}\b.{{0,80}}\b"
+        rf"(?:(?:(?:is|are|was|were|becomes?|remains?)\s+"
+        rf"(?:(?:not|never|fully|explicitly|independently|directly)\s+)*"
+        rf")?(?:capable\s+of|able\s+to)|"
+        rf"{authority_possession_verb}\s+"
+        rf"(?:(?:the|full|explicit|independent|direct|delegated)\s+)*"
+        rf"(?:ability|capability)\s+(?:to|of))\s+"
+        rf"(?:(?:automatically|independently|directly)\s+)?{authority_action}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
         rf"\b{subordinate_subject}\b.{{0,100}}\b(?:proves?|confirms?|establishes?|satisfies?|passes?|grants?|achieves?|certifies?|validates?)\b.{{0,100}}\b{readiness_outcome}\b",
         re.IGNORECASE,
     ),
@@ -1274,7 +1352,7 @@ denial_scope_boundary = (
     rf"(?:(?:{subordinate_subject}|it|they|this)\b\s*)?"
     r"(?:can|could|may|might|will|would|must|should|shall|does|do|"
     r"has\s+to|have\s+to|needs?\s+to|ought\s+to|"
-    rf"is|are|{authority_possession_verb}|"
+    rf"is|are|capable|able|{authority_possession_verb}|"
     r"automatically|independently|directly|"
     r"becomes?|serves?|acts?|"
     r"owns?|defines?|determines?|proves?|confirms?|establishes?|satisfies?|passes?|"
@@ -1310,7 +1388,7 @@ def claim_clauses(text: str):
         rf"does\s+not|do\s+not|did\s+not|will\s+not|would\s+not|should\s+not|"
         rf"may\s+not|must\s+not|shall\s+not|has\s+to|have\s+to|needs?\s+to|ought\s+to|"
         rf"automatically|independently|directly|"
-        rf"is|are|{authority_possession_verb}|becomes?|serves?|acts?|owns?|defines?|determines?|"
+        rf"is|are|capable|able|{authority_possession_verb}|becomes?|serves?|acts?|owns?|defines?|determines?|"
         rf"proves?|confirms?|establishes?|satisfies?|passes?|grants?|achieves?|"
         rf"certifies?|validates?|delivers?|enables?|provides?|"
         rf"{direct_authority_action})\b",
@@ -1360,15 +1438,13 @@ for claim_input in claim_inputs:
 print("Phase 66.7 proof-pack document, evidence schema, secret hygiene, and authority checks pass.")
 PY
 
-if [[ "${PHASE66_7_SKIP_PATH_HYGIENE:-0}" != "1" ]]; then
-  tmp_dir="$(mktemp -d)"
-  trap 'rm -rf "${tmp_dir}"' EXIT
-  path_hygiene_stderr="${tmp_dir}/path-hygiene.err"
-  if ! bash "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" >/dev/null 2>"${path_hygiene_stderr}"; then
-    cat "${path_hygiene_stderr}" >&2
-    echo "Forbidden Phase 66.7 RC authority-boundary proof pack: publishable path hygiene failed" >&2
-    exit 1
-  fi
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+path_hygiene_stderr="${tmp_dir}/path-hygiene.err"
+if ! bash "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" >/dev/null 2>"${path_hygiene_stderr}"; then
+  cat "${path_hygiene_stderr}" >&2
+  echo "Forbidden Phase 66.7 RC authority-boundary proof pack: publishable path hygiene failed" >&2
+  exit 1
 fi
 
 echo "Phase 66.7 RC authority-boundary proof-pack contract and focused negative checks pass."

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -117,13 +117,19 @@ required_phrases = (
     "This proof pack is RC evidence only.",
     "A proof packet is fail-closed: once any required field is materialized, every required field must be present, non-placeholder, internally complete, and bound to the same journey run and immutable repository revision.",
     "Materialized proof packets are accepted only as `field=value` assignment lines or Markdown `Field | Value` rows.",
-    "Every negative observation must record `evidence_id`, `surface`, `attempt`, `result=rejected`, `authoritative_record`, `observed_at`, `journey_run_id`, and `repository_revision`.",
+    "Every negative observation must record `evidence_id`, `evidence_reference`, `surface`, `attempt`, `result=rejected`, `authoritative_record`, `observed_at`, `journey_run_id`, and `repository_revision`.",
+    "Every negative-observation `evidence_id` must be `sha256:<digest>` for the exact repository-owned JSON manifest bytes at `evidence_reference` and `repository_revision`.",
+    "The manifest must contain exactly one matching immutable record for every required negative surface; packet labels, invented AegisOps URIs, or declared rejection results cannot substitute for a resolved record.",
+    "The negative-observation manifest uses `schema_version=phase-66-7-negative-evidence/v1` and a `records` array.",
+    "Every record contains exactly `field`, `surface`, `attempt`, `result`, `authoritative_record`, `observed_at`, and `journey_run_id`; missing, duplicate, extra, non-string, or packet-mismatched values fail closed.",
     "Passing one negative observation cannot compensate for a missing surface.",
     "Each Phase 66.1-66.6 evidence value must record `evidence_id`, `evidence_reference`, `verifier`, `result=passed`, `journey_run_id`, and `repository_revision`.",
     "Each Phase 66.1-66.6 `evidence_id` must be `sha256:<digest>` for the exact referenced proof document bytes at `repository_revision`.",
     "The top-level `repository_revision` identifies the evidence-producing commit, not the commit that later stores the proof packet.",
     "The verifier must check out that exact revision in an isolated worktree, resolve each required evidence reference there, and execute every Phase 66.1-66.6 focused verifier there.",
     "Packet labels or a declared `result=passed` cannot substitute for resolved proof surfaces and successful verifier execution.",
+    "The same isolated worktree must resolve the negative-observation manifest, bind its exact bytes to every negative `evidence_id`, and match every packet observation to one manifest record.",
+    "A syntactically valid negative observation without that immutable record fails closed.",
     "All materialized timestamps must be no more than 24 hours old at verification time and must not be more than five minutes in the future.",
     "AegisOps records remain authoritative for alert, case, evidence, recommendation, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, restore acceptance, and closeout truth.",
     "Wazuh, Shuffle, AI, tickets, evidence systems, browser state, UI cache, demo data, reports, support bundles, release artifacts, verifier output, issue-lint output, and optional evidence remain subordinate evidence or context only.",
@@ -467,6 +473,56 @@ if materialized_fields:
             fail(f"invalid {field}: mixed repository_revision")
         phase_evidence_parts[field] = parts
 
+    negative_manifest_reference = "evidence/phase-66-7/negative-observations.json"
+    negative_expectations = {
+        "wazuh_negative_evidence": ("wazuh", "source-truth-promotion"),
+        "shuffle_negative_evidence": ("shuffle", "execution-receipt-promotion"),
+        "ai_negative_evidence": ("ai", "approval-bypass"),
+        "ticket_negative_evidence": ("tickets", "case-closure-shortcut"),
+        "evidence_system_negative_evidence": ("evidence-systems", "external-evidence-truth-promotion"),
+        "ui_cache_negative_evidence": ("ui-cache", "workflow-truth-promotion"),
+        "demo_data_negative_evidence": ("demo-data", "release-truth-promotion"),
+        "report_negative_evidence": ("reports", "gate-truth-promotion"),
+        "support_bundle_negative_evidence": ("support-bundle", "limitation-truth-promotion"),
+        "release_artifact_negative_evidence": ("release-artifacts", "readiness-truth-promotion"),
+        "verifier_output_negative_evidence": ("verifier-output", "rc-gate-promotion"),
+        "issue_lint_output_negative_evidence": ("issue-lint-output", "rc-gate-promotion"),
+    }
+    negative_evidence_parts: dict[str, dict[str, str]] = {}
+    for field, (expected_surface, expected_attempt) in negative_expectations.items():
+        parts = require_components(
+            field,
+            (
+                "evidence_id",
+                "evidence_reference",
+                "surface",
+                "attempt",
+                "result",
+                "authoritative_record",
+                "observed_at",
+                "journey_run_id",
+                "repository_revision",
+            ),
+        )
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", parts["evidence_id"], re.IGNORECASE):
+            fail(f"invalid {field}: evidence_id must be sha256:<digest>")
+        if parts["evidence_reference"] != negative_manifest_reference:
+            fail(f"invalid {field}: unexpected evidence reference")
+        if parts["surface"].lower() != expected_surface:
+            fail(f"invalid {field}: expected surface {expected_surface}")
+        if parts["attempt"].lower() != expected_attempt:
+            fail(f"invalid {field}: expected rejected attempt {expected_attempt}")
+        if parts["result"].lower() != "rejected":
+            fail(f"invalid {field}: result must be rejected")
+        if not re.fullmatch(r"aegisops://[a-z0-9][a-z0-9._/-]{5,180}", parts["authoritative_record"], re.IGNORECASE):
+            fail(f"invalid {field}: authoritative_record must be a specific aegisops:// reference")
+        parse_timestamp(field, parts["observed_at"])
+        if parts["journey_run_id"] != journey_run_id:
+            fail(f"invalid {field}: mixed journey_run_id")
+        if parts["repository_revision"].lower() != repository_revision:
+            fail(f"invalid {field}: mixed repository_revision")
+        negative_evidence_parts[field] = parts
+
     evidence_worktree = Path(tempfile.mkdtemp(prefix="phase66-7-evidence-"))
     worktree_added = False
     try:
@@ -508,6 +564,63 @@ if materialized_fields:
                 detail = verifier_result.stderr.strip().splitlines()
                 diagnostic = detail[-1] if detail else "no diagnostic"
                 fail(f"invalid {field}: prerequisite verifier failed: {diagnostic}")
+
+        negative_manifest_path = evidence_worktree / negative_manifest_reference
+        if not negative_manifest_path.is_file() or negative_manifest_path.stat().st_size == 0:
+            fail("negative evidence reference does not resolve at repository_revision")
+        resolved_negative_evidence_id = (
+            "sha256:" + hashlib.sha256(negative_manifest_path.read_bytes()).hexdigest()
+        )
+        for field, parts in negative_evidence_parts.items():
+            if parts["evidence_id"].lower() != resolved_negative_evidence_id:
+                fail(f"invalid {field}: evidence_id does not match resolved evidence reference")
+        try:
+            negative_manifest = json.loads(negative_manifest_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            fail("negative evidence reference must contain valid UTF-8 JSON")
+        if not isinstance(negative_manifest, dict) or set(negative_manifest) != {
+            "schema_version",
+            "records",
+        }:
+            fail("negative evidence manifest must contain only schema_version and records")
+        if negative_manifest["schema_version"] != "phase-66-7-negative-evidence/v1":
+            fail("negative evidence manifest has unsupported schema_version")
+        records = negative_manifest["records"]
+        if not isinstance(records, list):
+            fail("negative evidence manifest records must be an array")
+        records_by_field: dict[str, dict[str, str]] = {}
+        record_keys = {
+            "field",
+            "surface",
+            "attempt",
+            "result",
+            "authoritative_record",
+            "observed_at",
+            "journey_run_id",
+        }
+        for record in records:
+            if not isinstance(record, dict) or set(record) != record_keys:
+                fail("negative evidence manifest record has invalid fields")
+            field = record["field"]
+            if not isinstance(field, str) or field in records_by_field:
+                fail("negative evidence manifest contains invalid or duplicate field")
+            if not all(isinstance(value, str) for value in record.values()):
+                fail(f"negative evidence manifest record {field} must contain string values")
+            records_by_field[field] = record
+        if set(records_by_field) != set(negative_expectations):
+            fail("negative evidence manifest must contain exactly one record for every required surface")
+        for field, parts in negative_evidence_parts.items():
+            expected_record = {
+                "field": field,
+                "surface": parts["surface"],
+                "attempt": parts["attempt"],
+                "result": parts["result"],
+                "authoritative_record": parts["authoritative_record"],
+                "observed_at": parts["observed_at"],
+                "journey_run_id": parts["journey_run_id"],
+            }
+            if records_by_field[field] != expected_record:
+                fail(f"invalid {field}: resolved negative evidence record does not match packet")
     except subprocess.CalledProcessError as error:
         diagnostic = (error.stderr or "").strip().splitlines()
         detail = diagnostic[-1] if diagnostic else "unable to create evidence worktree"
@@ -521,50 +634,6 @@ if materialized_fields:
             )
         else:
             shutil.rmtree(evidence_worktree, ignore_errors=True)
-
-    negative_expectations = {
-        "wazuh_negative_evidence": ("wazuh", "source-truth-promotion"),
-        "shuffle_negative_evidence": ("shuffle", "execution-receipt-promotion"),
-        "ai_negative_evidence": ("ai", "approval-bypass"),
-        "ticket_negative_evidence": ("tickets", "case-closure-shortcut"),
-        "evidence_system_negative_evidence": ("evidence-systems", "external-evidence-truth-promotion"),
-        "ui_cache_negative_evidence": ("ui-cache", "workflow-truth-promotion"),
-        "demo_data_negative_evidence": ("demo-data", "release-truth-promotion"),
-        "report_negative_evidence": ("reports", "gate-truth-promotion"),
-        "support_bundle_negative_evidence": ("support-bundle", "limitation-truth-promotion"),
-        "release_artifact_negative_evidence": ("release-artifacts", "readiness-truth-promotion"),
-        "verifier_output_negative_evidence": ("verifier-output", "rc-gate-promotion"),
-        "issue_lint_output_negative_evidence": ("issue-lint-output", "rc-gate-promotion"),
-    }
-    for field, (expected_surface, expected_attempt) in negative_expectations.items():
-        parts = require_components(
-            field,
-            (
-                "evidence_id",
-                "surface",
-                "attempt",
-                "result",
-                "authoritative_record",
-                "observed_at",
-                "journey_run_id",
-                "repository_revision",
-            ),
-        )
-        if not re.fullmatch(r"[a-z0-9][a-z0-9._:-]{5,120}", parts["evidence_id"], re.IGNORECASE):
-            fail(f"invalid {field}: malformed evidence_id")
-        if parts["surface"].lower() != expected_surface:
-            fail(f"invalid {field}: expected surface {expected_surface}")
-        if parts["attempt"].lower() != expected_attempt:
-            fail(f"invalid {field}: expected rejected attempt {expected_attempt}")
-        if parts["result"].lower() != "rejected":
-            fail(f"invalid {field}: result must be rejected")
-        if not re.fullmatch(r"aegisops://[a-z0-9][a-z0-9._/-]{5,180}", parts["authoritative_record"], re.IGNORECASE):
-            fail(f"invalid {field}: authoritative_record must be a specific aegisops:// reference")
-        parse_timestamp(field, parts["observed_at"])
-        if parts["journey_run_id"] != journey_run_id:
-            fail(f"invalid {field}: mixed journey_run_id")
-        if parts["repository_revision"].lower() != repository_revision:
-            fail(f"invalid {field}: mixed repository_revision")
 
     owner_review = require_components(
         "owner_review",
@@ -773,11 +842,25 @@ def claim_clauses(text: str):
     normalized = re.sub(r"[`*_#|]", " ", text)
     normalized = re.sub(r"\s+", " ", normalized)
     inherited_subject = ""
-    for clause in re.split(
-        r"\s*(?:(?<!\d)[.!?](?!\d)|;|\bbut\b|\bhowever\b|\byet\b|\balthough\b|\bthough\b)\s*",
+    parts = re.split(
+        r"\s*((?<!\d)[.!?](?!\d)|;|\bbut\b|\bhowever\b|\byet\b|\balthough\b|\bthough\b)\s*",
         normalized,
         flags=re.IGNORECASE,
-    ):
+    )
+    elision_boundaries = {";", "but", "however", "yet", "although", "though"}
+    verb_led_continuation = re.compile(
+        rf"^(?:can|could|may|might|will|would|does|do|cannot|can't|"
+        rf"does\s+not|do\s+not|did\s+not|will\s+not|would\s+not|should\s+not|"
+        rf"may\s+not|must\s+not|automatically|independently|directly|"
+        rf"is|are|becomes?|serves?|acts?|owns?|defines?|determines?|"
+        rf"proves?|confirms?|establishes?|satisfies?|passes?|grants?|achieves?|"
+        rf"certifies?|validates?|delivers?|enables?|provides?|"
+        rf"{direct_authority_action})\b",
+        re.IGNORECASE,
+    )
+    for index in range(0, len(parts), 2):
+        clause = parts[index]
+        boundary = parts[index - 1].lower() if index else ""
         clause = clause.strip()
         if not clause:
             continue
@@ -786,6 +869,12 @@ def claim_clauses(text: str):
             inherited_subject = subject_match.group(0)
         elif inherited_subject and re.match(r"^(?:it|they|this)\b", clause, re.IGNORECASE):
             clause = re.sub(r"^(?:it|they|this)\b", inherited_subject, clause, flags=re.IGNORECASE)
+        elif (
+            inherited_subject
+            and boundary in elision_boundaries
+            and verb_led_continuation.match(clause)
+        ):
+            clause = f"{inherited_subject} {clause}"
         yield clause
 
 

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -242,6 +242,8 @@ required_phrases = (
     "The top-level `repository_revision` identifies the evidence-producing commit, not the commit that later stores the proof packet.",
     "The verifier must check out that exact revision in an isolated worktree, resolve each required evidence reference there, and execute every Phase 66.1-66.6 focused verifier there.",
     "Packet labels or a declared `result=passed` cannot substitute for resolved proof surfaces and successful verifier execution.",
+    "Each prerequisite verifier must leave the isolated worktree at `repository_revision` with no tracked or untracked changes.",
+    "A verifier that changes the worktree revision or mutates any worktree content fails closed.",
     "The same isolated worktree must resolve the negative-observation manifest, bind its exact bytes to every negative `evidence_id`, and match every packet observation to one manifest record.",
     "A syntactically valid negative observation without that immutable record fails closed.",
     "Every `owner_review` value must record `artifact_owner`, `reviewer`, `reviewed_at`, `disposition`, and `follow_up_owner`.",
@@ -440,6 +442,15 @@ for raw_line in html_detection_raw.splitlines():
     ):
         fail("raw HTML evidence syntax is not supported")
 
+markdown_evidence_link = re.compile(
+    r"!?\[(?P<label>[^\]\n]+)\](?:\([^)\n]*\)|\[[^\]\n]*\])",
+)
+for markdown_link in markdown_evidence_link.finditer(html_detection_raw):
+    if proof_field_pattern.search(
+        normalize_inline_markdown(markdown_link.group("label"))
+    ):
+        fail("Markdown link evidence syntax is not supported")
+
 
 def markdown_cells(line: str) -> list[str]:
     cells = re.split(r"(?<!\\)\|", line.strip())
@@ -459,7 +470,7 @@ assignment_pattern = re.compile(
 current_section = "document-preamble"
 section_index = 0
 in_fence = False
-for raw_line in rendered_doc_raw.splitlines():
+for raw_line in normalize_inline_markdown(rendered_doc_raw).splitlines():
     stripped = raw_line.strip()
     if re.match(r"^(```|~~~)", stripped):
         in_fence = not in_fence
@@ -782,7 +793,43 @@ if materialized_fields:
             text=True,
         )
         worktree_added = True
+
+        def assert_evidence_worktree_immutable(field: str) -> None:
+            head_result = subprocess.run(
+                ["git", "-C", str(evidence_worktree), "rev-parse", "HEAD"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            if (
+                head_result.returncode != 0
+                or head_result.stdout.strip().lower() != repository_revision
+            ):
+                fail(
+                    f"invalid {field}: prerequisite verifier changed isolated "
+                    "worktree revision"
+                )
+            status_result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(evidence_worktree),
+                    "status",
+                    "--porcelain=v1",
+                    "--untracked-files=all",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            if status_result.returncode != 0 or status_result.stdout.strip():
+                fail(
+                    f"invalid {field}: prerequisite verifier modified isolated "
+                    "worktree"
+                )
+
         for field, (expected_reference, expected_verifier) in phase_verifiers.items():
+            assert_evidence_worktree_immutable(field)
             reference_path = evidence_worktree / expected_reference
             verifier_path = evidence_worktree / expected_verifier
             if not reference_path.is_file() or reference_path.stat().st_size == 0:
@@ -802,6 +849,7 @@ if materialized_fields:
                 detail = verifier_result.stderr.strip().splitlines()
                 diagnostic = detail[-1] if detail else "no diagnostic"
                 fail(f"invalid {field}: prerequisite verifier failed: {diagnostic}")
+            assert_evidence_worktree_immutable(field)
 
         negative_manifest_path = evidence_worktree / negative_manifest_reference
         if not negative_manifest_path.is_file() or negative_manifest_path.stat().st_size == 0:
@@ -1067,7 +1115,7 @@ email_pattern = re.compile(
     r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![A-Za-z0-9.-])"
 )
 private_assignment = re.compile(
-    r"(?:^|[;,\s{|])`?(?:customer[_ -]?(?:name|identifier|private_data|private_payload)|tenant[_ -]?(?:name|identifier)|ticket[_ -]?private[_ -]?content|raw[_ -]?(?:customer|ticket)[_ -]?(?:data|payload|content))`?\s*[:=]\s*(?P<value>[^;,|}\r\n]+)",
+    r"(?:^|[;,\s{|])`?(?:customer[_ -]?(?:name|id(?:entifier)?s?|private_data|private_payload)|tenant[_ -]?(?:name|id(?:entifier)?s?)|ticket[_ -]?private[_ -]?content|raw[_ -]?(?:customer|ticket)[_ -]?(?:data|payload|content))`?\s*[:=]\s*(?P<value>[^;,|}\r\n]+)",
     re.IGNORECASE,
 )
 private_data_object = (

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -139,6 +139,9 @@ required_phrases = (
     "Packet labels or a declared `result=passed` cannot substitute for resolved proof surfaces and successful verifier execution.",
     "The same isolated worktree must resolve the negative-observation manifest, bind its exact bytes to every negative `evidence_id`, and match every packet observation to one manifest record.",
     "A syntactically valid negative observation without that immutable record fails closed.",
+    "Every `limitation_references` value must record `evidence_id`, `evidence_reference`, `ids`, `owner`, `decision_at`, and `follow_up_at`.",
+    "The limitation manifest uses `schema_version=phase-66-7-limitations/v1` and a `limitations` array.",
+    "The isolated worktree must resolve the limitation manifest and match every packet limitation to an accepted repository-owned record.",
     "All materialized timestamps must be no more than 24 hours old at verification time and must not be more than five minutes in the future.",
     "AegisOps records remain authoritative for alert, case, evidence, recommendation, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, restore acceptance, and closeout truth.",
     "Wazuh, Shuffle, AI, tickets, evidence systems, browser state, UI cache, demo data, reports, support bundles, release artifacts, verifier output, issue-lint output, and optional evidence remain subordinate evidence or context only.",
@@ -532,6 +535,38 @@ if materialized_fields:
             fail(f"invalid {field}: mixed repository_revision")
         negative_evidence_parts[field] = parts
 
+    limitation_manifest_reference = "evidence/phase-66-7/limitations.json"
+    limitations = require_components(
+        "limitation_references",
+        ("evidence_id", "evidence_reference", "ids", "owner", "decision_at", "follow_up_at"),
+    )
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", limitations["evidence_id"], re.IGNORECASE):
+        fail("invalid limitation_references: evidence_id must be sha256:<digest>")
+    if limitations["evidence_reference"] != limitation_manifest_reference:
+        fail("invalid limitation_references: unexpected evidence reference")
+    if not re.fullmatch(r"lim-[a-z0-9._-]+(?:,lim-[a-z0-9._-]+)*", limitations["ids"]):
+        fail("invalid limitation_references: ids must be explicit lim-* identifiers")
+    limitation_ids = limitations["ids"].split(",")
+    if len(set(limitation_ids)) != len(limitation_ids):
+        fail("invalid limitation_references: ids must not contain duplicates")
+    if not re.fullmatch(r"[a-z0-9][a-z0-9._@-]{2,80}", limitations["owner"], re.IGNORECASE):
+        fail("invalid limitation_references: owner must be accountable")
+    if re.search(
+        r"\b(?:artifact|verifier|issue-lint|bot|automation)\b",
+        limitations["owner"],
+        re.IGNORECASE,
+    ):
+        fail("invalid limitation_references: owner must be accountable")
+    decision_at = parse_timestamp("limitation_references", limitations["decision_at"])
+    follow_up_at = parse_timestamp(
+        "limitation_references",
+        limitations["follow_up_at"],
+        fresh=False,
+        allow_future=True,
+    )
+    if follow_up_at <= decision_at:
+        fail("invalid limitation_references: follow_up_at must be after decision_at")
+
     evidence_worktree = Path(tempfile.mkdtemp(prefix="phase66-7-evidence-"))
     worktree_added = False
     try:
@@ -630,6 +665,85 @@ if materialized_fields:
             }
             if records_by_field[field] != expected_record:
                 fail(f"invalid {field}: resolved negative evidence record does not match packet")
+
+        limitation_manifest_path = evidence_worktree / limitation_manifest_reference
+        if not limitation_manifest_path.is_file() or limitation_manifest_path.stat().st_size == 0:
+            fail("limitation evidence reference does not resolve at repository_revision")
+        resolved_limitation_evidence_id = (
+            "sha256:" + hashlib.sha256(limitation_manifest_path.read_bytes()).hexdigest()
+        )
+        if limitations["evidence_id"].lower() != resolved_limitation_evidence_id:
+            fail("invalid limitation_references: evidence_id does not match resolved evidence reference")
+        try:
+            limitation_manifest = json.loads(limitation_manifest_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            fail("limitation evidence reference must contain valid UTF-8 JSON")
+        if not isinstance(limitation_manifest, dict) or set(limitation_manifest) != {
+            "schema_version",
+            "limitations",
+        }:
+            fail("limitation manifest must contain only schema_version and limitations")
+        if limitation_manifest["schema_version"] != "phase-66-7-limitations/v1":
+            fail("limitation manifest has unsupported schema_version")
+        limitation_records = limitation_manifest["limitations"]
+        if not isinstance(limitation_records, list):
+            fail("limitation manifest limitations must be an array")
+        limitations_by_id: dict[str, dict[str, str]] = {}
+        limitation_record_keys = {
+            "id",
+            "owner",
+            "disposition",
+            "decision_at",
+            "follow_up_at",
+        }
+        for record in limitation_records:
+            if not isinstance(record, dict) or set(record) != limitation_record_keys:
+                fail("limitation manifest record has invalid fields")
+            if not all(isinstance(value, str) for value in record.values()):
+                fail("limitation manifest records must contain string values")
+            limitation_id = record["id"]
+            if (
+                not re.fullmatch(r"lim-[a-z0-9._-]+", limitation_id)
+                or limitation_id in limitations_by_id
+            ):
+                fail("limitation manifest contains invalid or duplicate id")
+            if record["disposition"].lower() != "accepted":
+                fail(f"limitation manifest record {limitation_id} must be accepted")
+            record_decision_at = parse_timestamp(
+                f"limitation manifest record {limitation_id}",
+                record["decision_at"],
+            )
+            record_follow_up_at = parse_timestamp(
+                f"limitation manifest record {limitation_id}",
+                record["follow_up_at"],
+                fresh=False,
+                allow_future=True,
+            )
+            if record_follow_up_at <= record_decision_at:
+                fail(
+                    f"limitation manifest record {limitation_id} follow_up_at "
+                    "must be after decision_at"
+                )
+            limitations_by_id[limitation_id] = record
+        for limitation_id in limitation_ids:
+            record = limitations_by_id.get(limitation_id)
+            if record is None:
+                fail(
+                    f"invalid limitation_references: limitation {limitation_id} "
+                    "does not resolve at repository_revision"
+                )
+            expected_record = {
+                "id": limitation_id,
+                "owner": limitations["owner"],
+                "disposition": "accepted",
+                "decision_at": limitations["decision_at"],
+                "follow_up_at": limitations["follow_up_at"],
+            }
+            if record != expected_record:
+                fail(
+                    f"invalid limitation_references: resolved limitation record "
+                    f"{limitation_id} does not match packet"
+                )
     except subprocess.CalledProcessError as error:
         diagnostic = (error.stderr or "").strip().splitlines()
         detail = diagnostic[-1] if diagnostic else "unable to create evidence worktree"
@@ -657,24 +771,6 @@ if materialized_fields:
     if owner_review["disposition"].lower() != "accepted":
         fail("invalid owner_review: disposition must be accepted")
     parse_timestamp("owner_review", owner_review["reviewed_at"])
-
-    limitations = require_components(
-        "limitation_references",
-        ("ids", "owner", "decision_at", "follow_up_at"),
-    )
-    if not re.fullmatch(r"lim-[a-z0-9._-]+(?:,lim-[a-z0-9._-]+)*", limitations["ids"], re.IGNORECASE):
-        fail("invalid limitation_references: ids must be explicit lim-* identifiers")
-    if not re.fullmatch(r"[a-z0-9][a-z0-9._@-]{2,80}", limitations["owner"], re.IGNORECASE):
-        fail("invalid limitation_references: owner must be accountable")
-    decision_at = parse_timestamp("limitation_references", limitations["decision_at"])
-    follow_up_at = parse_timestamp(
-        "limitation_references",
-        limitations["follow_up_at"],
-        fresh=False,
-        allow_future=True,
-    )
-    if follow_up_at <= decision_at:
-        fail("invalid limitation_references: follow_up_at must be after decision_at")
 
     required_non_claims = {
         "rc-evidence-only",
@@ -811,6 +907,27 @@ claim_patterns = (
         re.IGNORECASE,
     ),
     re.compile(
+        rf"\b{subordinate_subject}\b.{{0,80}}\b"
+        rf"(?:is|are|was|were|has\s+been|have\s+been|becomes?|remains?|can(?:not)?\s+be|"
+        rf"could(?:\s+not)?\s+be|may(?:\s+not)?\s+be|might(?:\s+not)?\s+be|"
+        rf"will(?:\s+not)?\s+be|would(?:\s+not)?\s+be|must(?:\s+not)?\s+be|"
+        rf"should(?:\s+not)?\s+be)\s+"
+        rf"(?:(?:not|never|fully|explicitly|independently|directly)\s+)*"
+        rf"(?:permitted|allowed|authorized|empowered|entitled)\s+"
+        rf"(?:by\s+[a-z0-9._@/-]+\s+)?to\s+"
+        rf"(?:(?:automatically|independently|directly)\s+)?{authority_action}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"\b{subordinate_subject}\b.{{0,80}}\b"
+        rf"(?:has|have|holds?|receives?|possesses?|is\s+granted|are\s+granted|"
+        rf"was\s+granted|were\s+granted)\s+"
+        rf"(?:(?:the|full|explicit|independent|direct|delegated)\s+)*"
+        rf"(?:permission|authorization|authority|power|right)\s+to\s+"
+        rf"(?:(?:automatically|independently|directly)\s+)?{authority_action}\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
         rf"\b{subordinate_subject}\b.{{0,100}}\b(?:proves?|confirms?|establishes?|satisfies?|passes?|grants?|achieves?|certifies?|validates?)\b.{{0,100}}\b{readiness_outcome}\b",
         re.IGNORECASE,
     ),
@@ -838,7 +955,8 @@ claim_patterns = (
 denial_scope_boundary = (
     rf"(?:[,;]|\b(?:and|or|but|however|yet|although|though|while|whereas|because|since)\b)\s*"
     rf"(?:(?:{subordinate_subject}|it|they|this)\b\s*)?"
-    r"(?:can|could|may|might|will|would|does|do|is|are|automatically|independently|directly|"
+    r"(?:can|could|may|might|will|would|does|do|is|are|has|have|holds?|receives?|"
+    r"automatically|independently|directly|"
     r"becomes?|serves?|acts?|"
     r"owns?|defines?|determines?|proves?|confirms?|establishes?|satisfies?|passes?|"
     r"grants?|achieves?|certifies?|validates?|delivers?|enables?|provides?)\b"
@@ -871,7 +989,7 @@ def claim_clauses(text: str):
         rf"^(?:can|could|may|might|will|would|does|do|cannot|can't|"
         rf"does\s+not|do\s+not|did\s+not|will\s+not|would\s+not|should\s+not|"
         rf"may\s+not|must\s+not|automatically|independently|directly|"
-        rf"is|are|becomes?|serves?|acts?|owns?|defines?|determines?|"
+        rf"is|are|has|have|holds?|receives?|becomes?|serves?|acts?|owns?|defines?|determines?|"
         rf"proves?|confirms?|establishes?|satisfies?|passes?|grants?|achieves?|"
         rf"certifies?|validates?|delivers?|enables?|provides?|"
         rf"{direct_authority_action})\b",

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -68,6 +68,7 @@ import subprocess
 import sys
 import tempfile
 from datetime import datetime, timedelta, timezone
+from html.parser import HTMLParser
 from pathlib import Path
 
 doc_path = Path(sys.argv[1])
@@ -77,16 +78,89 @@ doc_raw = doc_path.read_text(encoding="utf-8")
 readme_raw = readme_path.read_text(encoding="utf-8")
 
 
+def visible_text(text: str) -> str:
+    return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+
+
+class VisibleHTMLTextRenderer(HTMLParser):
+    block_tags = {
+        "address",
+        "article",
+        "aside",
+        "blockquote",
+        "br",
+        "dd",
+        "div",
+        "dl",
+        "dt",
+        "figcaption",
+        "figure",
+        "footer",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "header",
+        "hr",
+        "li",
+        "main",
+        "nav",
+        "ol",
+        "p",
+        "pre",
+        "section",
+        "table",
+        "tbody",
+        "td",
+        "tfoot",
+        "th",
+        "thead",
+        "tr",
+        "ul",
+    }
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        self.suppressed_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        del attrs
+        tag = tag.lower()
+        if tag in {"script", "style"}:
+            self.suppressed_depth += 1
+        elif not self.suppressed_depth and tag in self.block_tags:
+            self.parts.append("\n")
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.handle_starttag(tag, attrs)
+        if tag.lower() in {"script", "style"}:
+            self.suppressed_depth -= 1
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in {"script", "style"} and self.suppressed_depth:
+            self.suppressed_depth -= 1
+        elif not self.suppressed_depth and tag in self.block_tags:
+            self.parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if not self.suppressed_depth:
+            self.parts.append(data)
+
+
 def rendered_text(text: str) -> str:
-    return re.sub(r"[^\S\r\n]", " ", html.unescape(text))
+    parser = VisibleHTMLTextRenderer()
+    parser.feed(visible_text(text))
+    parser.close()
+    return re.sub(r"[^\S\r\n]", " ", html.unescape("".join(parser.parts)))
 
 
 rendered_doc_raw = rendered_text(doc_raw)
 rendered_readme_raw = rendered_text(readme_raw)
-
-
-def visible_text(text: str) -> str:
-    return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+rendered_source_doc_raw = re.sub(r"[^\S\r\n]", " ", html.unescape(doc_raw))
 
 
 def semantic_text(text: str) -> str:
@@ -253,6 +327,25 @@ structured_key_pattern = re.compile(
 )
 if structured_key_pattern.search(doc_raw):
     fail("JSON, YAML, and object-literal evidence syntax is not supported")
+
+unsupported_structural_html = re.compile(
+    r"<\s*/?\s*(?:article|aside|dd|div|dl|dt|li|ol|p|pre|section|table|tbody|td|"
+    r"tfoot|th|thead|tr|ul)\b",
+    re.IGNORECASE,
+)
+if unsupported_structural_html.search(visible_text(doc_raw)):
+    fail("raw HTML evidence syntax is not supported")
+
+inline_html_tag = re.compile(
+    r"<\s*/?\s*(?:b|code|em|i|mark|small|span|strong|sub|sup)\b[^>]*>",
+    re.IGNORECASE,
+)
+for raw_line in visible_text(doc_raw).splitlines():
+    if not inline_html_tag.search(raw_line):
+        continue
+    rendered_line = rendered_text(raw_line)
+    if re.search(rf"\b(?:{field_alternation})\b", rendered_line, re.IGNORECASE):
+        fail("raw HTML evidence syntax is not supported")
 
 
 def markdown_cells(line: str) -> list[str]:
@@ -823,11 +916,14 @@ def assignment_contains_forbidden_value(pattern: re.Pattern, line: str) -> bool:
     return False
 
 
+secret_hygiene_inputs = (rendered_doc_raw, rendered_source_doc_raw)
 if any(
-    assignment_contains_forbidden_value(sensitive_assignment, line)
-    for line in rendered_doc_raw.splitlines()
-) or any(
-    pattern.search(rendered_doc_raw) for pattern in secret_patterns
+    any(
+        assignment_contains_forbidden_value(sensitive_assignment, line)
+        for line in hygiene_input.splitlines()
+    )
+    or any(pattern.search(hygiene_input) for pattern in secret_patterns)
+    for hygiene_input in secret_hygiene_inputs
 ):
     fail("production secret-looking value detected")
 
@@ -838,7 +934,11 @@ workstation_patterns = (
     re.compile(r"(?:^|[\s`\"'(<:=])[A-Za-z]:[\\/]Users[\\/][^\s`\"'()<>\\/]+[\\/]", re.IGNORECASE),
     re.compile(r"file://(?:[^\s`\"'()<>]*/)?(?:(?:Users|home)/[^\s`\"'()<>/]+|root)/", re.IGNORECASE),
 )
-if any(pattern.search(rendered_doc_raw) for pattern in workstation_patterns):
+if any(
+    pattern.search(hygiene_input)
+    for hygiene_input in secret_hygiene_inputs
+    for pattern in workstation_patterns
+):
     fail("workstation-local path detected")
 
 email_pattern = re.compile(
@@ -852,9 +952,13 @@ private_data_claim = re.compile(
     r"\b(?:includes?|contains?|retains?|stores?|embeds?|exports?|captures?|publishes?)\b.{0,60}?\b(?:raw customer|customer[- ]private|private ticket|raw ticket|raw payload|customer identifier)",
     re.IGNORECASE,
 )
-if email_pattern.search(rendered_doc_raw) or any(
-    assignment_contains_forbidden_value(private_assignment, line)
-    for line in rendered_doc_raw.splitlines()
+if any(
+    email_pattern.search(hygiene_input)
+    or any(
+        assignment_contains_forbidden_value(private_assignment, line)
+        for line in hygiene_input.splitlines()
+    )
+    for hygiene_input in secret_hygiene_inputs
 ):
     fail("customer-private or ticket-private data detected")
 private_denial_boundary = (
@@ -906,7 +1010,10 @@ claim_patterns = (
         re.IGNORECASE,
     ),
     re.compile(
-        rf"\b{subordinate_subject}\b.{{0,100}}\b(?:can|could|may|might|will|would|does|do|automatically|independently|directly)\b.{{0,60}}\b{authority_action}\b",
+        rf"\b{subordinate_subject}\b.{{0,100}}\b"
+        rf"(?:can|could|may|might|will|would|must|should|shall|does|do|"
+        rf"has\s+to|have\s+to|needs?\s+to|ought\s+to|"
+        rf"automatically|independently|directly)\b.{{0,60}}\b{authority_action}\b",
         re.IGNORECASE,
     ),
     re.compile(
@@ -920,7 +1027,7 @@ claim_patterns = (
         rf"will(?:\s+not)?\s+be|would(?:\s+not)?\s+be|must(?:\s+not)?\s+be|"
         rf"should(?:\s+not)?\s+be)\s+"
         rf"(?:(?:not|never|fully|explicitly|independently|directly)\s+)*"
-        rf"(?:permitted|allowed|authorized|empowered|entitled)\s+"
+        rf"(?:permitted|allowed|authorized|empowered|entitled|required|obligated|mandated)\s+"
         rf"(?:by\s+[a-z0-9._@/-]+\s+)?to\s+"
         rf"(?:(?:automatically|independently|directly)\s+)?{authority_action}\b",
         re.IGNORECASE,
@@ -962,7 +1069,9 @@ claim_patterns = (
 denial_scope_boundary = (
     rf"(?:[,;]|\b(?:and|or|but|however|yet|although|though|while|whereas|because|since)\b)\s*"
     rf"(?:(?:{subordinate_subject}|it|they|this)\b\s*)?"
-    r"(?:can|could|may|might|will|would|does|do|is|are|has|have|holds?|receives?|"
+    r"(?:can|could|may|might|will|would|must|should|shall|does|do|"
+    r"has\s+to|have\s+to|needs?\s+to|ought\s+to|"
+    r"is|are|has|have|holds?|receives?|"
     r"automatically|independently|directly|"
     r"becomes?|serves?|acts?|"
     r"owns?|defines?|determines?|proves?|confirms?|establishes?|satisfies?|passes?|"
@@ -975,7 +1084,8 @@ denied_claim_target = (
 )
 scoped_denial_pattern = re.compile(
     rf"\b(?:cannot|can't|does\s+not|do\s+not|did\s+not|will\s+not|would\s+not|should\s+not|"
-    rf"may\s+not|must\s+not|not|never|no\s+longer|reject(?:s|ed|ing)?|forbid(?:s|den|ding)?|"
+    rf"may\s+not|must\s+not|shall\s+not|not|never|no\s+longer|"
+    rf"reject(?:s|ed|ing)?|forbid(?:s|den|ding)?|"
     rf"exclud(?:e|es|ed|ing)|without|remains?\s+subordinate|evidence\s+only)\b"
     rf"(?:(?!{denial_scope_boundary}).){{0,120}}\b{denied_claim_target}\b",
     re.IGNORECASE,
@@ -993,9 +1103,10 @@ def claim_clauses(text: str):
     )
     elision_boundaries = {";", "but", "however", "yet", "although", "though"}
     verb_led_continuation = re.compile(
-        rf"^(?:can|could|may|might|will|would|does|do|cannot|can't|"
+        rf"^(?:can|could|may|might|will|would|must|should|shall|does|do|cannot|can't|"
         rf"does\s+not|do\s+not|did\s+not|will\s+not|would\s+not|should\s+not|"
-        rf"may\s+not|must\s+not|automatically|independently|directly|"
+        rf"may\s+not|must\s+not|shall\s+not|has\s+to|have\s+to|needs?\s+to|ought\s+to|"
+        rf"automatically|independently|directly|"
         rf"is|are|has|have|holds?|receives?|becomes?|serves?|acts?|owns?|defines?|determines?|"
         rf"proves?|confirms?|establishes?|satisfies?|passes?|grants?|achieves?|"
         rf"certifies?|validates?|delivers?|enables?|provides?|"

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -213,6 +213,8 @@ required_phrases = (
     "Packet labels or a declared `result=passed` cannot substitute for resolved proof surfaces and successful verifier execution.",
     "The same isolated worktree must resolve the negative-observation manifest, bind its exact bytes to every negative `evidence_id`, and match every packet observation to one manifest record.",
     "A syntactically valid negative observation without that immutable record fails closed.",
+    "Every `owner_review` value must record `artifact_owner`, `reviewer`, `reviewed_at`, `disposition`, and `follow_up_owner`.",
+    "Artifact owner and reviewer must be distinct accountable identities.",
     "Every `limitation_references` value must record `evidence_id`, `evidence_reference`, `ids`, `owner`, `decision_at`, and `follow_up_at`.",
     "The limitation manifest uses `schema_version=phase-66-7-limitations/v1` and a `limitations` array.",
     "The isolated worktree must resolve the limitation manifest and match every packet limitation to an accepted repository-owned record.",
@@ -853,14 +855,16 @@ if materialized_fields:
 
     owner_review = require_components(
         "owner_review",
-        ("reviewer", "reviewed_at", "disposition", "follow_up_owner"),
+        ("artifact_owner", "reviewer", "reviewed_at", "disposition", "follow_up_owner"),
     )
-    for identity_field in ("reviewer", "follow_up_owner"):
+    for identity_field in ("artifact_owner", "reviewer", "follow_up_owner"):
         identity = owner_review[identity_field]
         if not re.fullmatch(r"[a-z0-9][a-z0-9._@-]{2,80}", identity, re.IGNORECASE):
             fail(f"invalid owner_review: malformed {identity_field}")
         if re.search(r"\b(?:artifact|verifier|issue-lint|bot|automation)\b", identity, re.IGNORECASE):
             fail(f"invalid owner_review: {identity_field} must be accountable")
+    if owner_review["artifact_owner"].casefold() == owner_review["reviewer"].casefold():
+        fail("invalid owner_review: artifact_owner and reviewer must be distinct")
     if owner_review["disposition"].lower() != "accepted":
         fail("invalid owner_review: disposition must be accepted")
     parse_timestamp("owner_review", owner_review["reviewed_at"])
@@ -927,9 +931,16 @@ if any(
 ):
     fail("production secret-looking value detected")
 
+wsl_windows_home_segment = "Users"
 workstation_patterns = (
     re.compile(r"(?:^|[\s`\"'(<:=])/(?:Users|home)/[^\s`\"'()<>/]+/", re.IGNORECASE),
     re.compile(r"(?:^|[\s`\"'(<:=])/(?:root)(?:/|$)", re.IGNORECASE),
+    re.compile(
+        r"(?:^|[\s`\"'(<:=])/mnt/[a-z]/"
+        + wsl_windows_home_segment
+        + r"/[^\s`\"'()<>/]+/",
+        re.IGNORECASE,
+    ),
     re.compile(r"(?:^|[\s`\"'(<:=])~/(?:[^\s`\"'()<>]+)", re.IGNORECASE),
     re.compile(r"(?:^|[\s`\"'(<:=])[A-Za-z]:[\\/]Users[\\/][^\s`\"'()<>\\/]+[\\/]", re.IGNORECASE),
     re.compile(r"file://(?:[^\s`\"'()<>]*/)?(?:(?:Users|home)/[^\s`\"'()<>/]+|root)/", re.IGNORECASE),
@@ -948,8 +959,27 @@ private_assignment = re.compile(
     r"(?:^|[;,\s{|])`?(?:customer[_ -]?(?:name|identifier|private_data|private_payload)|tenant[_ -]?(?:name|identifier)|ticket[_ -]?private[_ -]?content|raw[_ -]?(?:customer|ticket)[_ -]?(?:data|payload|content))`?\s*[:=]\s*(?P<value>[^;,|}\r\n]+)",
     re.IGNORECASE,
 )
+private_data_object = (
+    r"(?:(?:unredacted|raw|private)\s+(?:customer|ticket)\s+"
+    r"(?:data|payload|content|information|records?)|"
+    r"(?:customer|ticket)(?:[- ]private)?\s+"
+    r"(?:data|payload|content|information|records?|identifiers?)|"
+    r"raw\s+payload|customer\s+identifier)"
+)
 private_data_claim = re.compile(
-    r"\b(?:includes?|contains?|retains?|stores?|embeds?|exports?|captures?|publishes?)\b.{0,60}?\b(?:raw customer|customer[- ]private|private ticket|raw ticket|raw payload|customer identifier)",
+    r"\b(?:includes?|contains?|retains?|stores?|embeds?|exports?|captures?|publishes?)\b"
+    rf".{{0,60}}?\b(?P<object>{private_data_object})",
+    re.IGNORECASE,
+)
+private_data_passive_claim = re.compile(
+    rf"\b(?P<object>{private_data_object})\b.{{0,40}}?\b"
+    r"(?:is|are|was|were|has\s+been|have\s+been)\s+"
+    r"(?P<negated>not\s+)?"
+    r"(?:included|contained|retained|stored|embedded|exported|captured|published)\b",
+    re.IGNORECASE,
+)
+private_claim_safe_qualifier = re.compile(
+    r"\b(?:absent|no|redacted|removed)\s*$",
     re.IGNORECASE,
 )
 if any(
@@ -973,8 +1003,16 @@ private_claim_denial = re.compile(
 )
 for line in rendered_doc_raw.splitlines():
     for match in private_data_claim.finditer(line):
+        claim_prefix = line[match.start() : match.start("object")]
+        if private_claim_safe_qualifier.search(claim_prefix):
+            continue
         if not private_claim_denial.search(line[: match.start()]):
             fail("customer-private or ticket-private data detected")
+    for match in private_data_passive_claim.finditer(line):
+        qualifier_prefix = line[max(0, match.start("object") - 30) : match.start("object")]
+        if private_claim_safe_qualifier.search(qualifier_prefix) or match.group("negated"):
+            continue
+        fail("customer-private or ticket-private data detected")
 
 subordinate_subject = (
     r"(?:this\s+proof(?:\s+pack)?|phase\s+66\.7|proof\s+pack|wazuh|shuffle|ai(?:\s+output)?|tickets?|"
@@ -1003,6 +1041,13 @@ direct_authority_action = (
     r"(?:(?:single|individual|specific|given|open|selected|current)\s+)?cases?|"
     r"admit(?:s|ted|ting)|"
     r"releas(?:es|ed|ing)|gat(?:es|ed|ing)|overrid(?:es|den|ing))"
+)
+authority_possession_verb = (
+    r"(?:has|have|had|holds?|held|receives?|received|possesses?|possessed|"
+    r"retains?|retained|retaining|keeps?|kept|maintains?|maintained|"
+    r"obtains?|obtained|acquires?|acquired|"
+    r"is\s+granted|are\s+granted|was\s+granted|were\s+granted|"
+    r"is\s+given|are\s+given|was\s+given|were\s+given)"
 )
 claim_patterns = (
     re.compile(
@@ -1034,8 +1079,7 @@ claim_patterns = (
     ),
     re.compile(
         rf"\b{subordinate_subject}\b.{{0,80}}\b"
-        rf"(?:has|have|holds?|receives?|possesses?|is\s+granted|are\s+granted|"
-        rf"was\s+granted|were\s+granted)\s+"
+        rf"{authority_possession_verb}\s+"
         rf"(?:(?:the|full|explicit|independent|direct|delegated)\s+)*"
         rf"(?:permission|authorization|authority|power|right)\s+to\s+"
         rf"(?:(?:automatically|independently|directly)\s+)?{authority_action}\b",
@@ -1071,7 +1115,7 @@ denial_scope_boundary = (
     rf"(?:(?:{subordinate_subject}|it|they|this)\b\s*)?"
     r"(?:can|could|may|might|will|would|must|should|shall|does|do|"
     r"has\s+to|have\s+to|needs?\s+to|ought\s+to|"
-    r"is|are|has|have|holds?|receives?|"
+    rf"is|are|{authority_possession_verb}|"
     r"automatically|independently|directly|"
     r"becomes?|serves?|acts?|"
     r"owns?|defines?|determines?|proves?|confirms?|establishes?|satisfies?|passes?|"
@@ -1107,7 +1151,7 @@ def claim_clauses(text: str):
         rf"does\s+not|do\s+not|did\s+not|will\s+not|would\s+not|should\s+not|"
         rf"may\s+not|must\s+not|shall\s+not|has\s+to|have\s+to|needs?\s+to|ought\s+to|"
         rf"automatically|independently|directly|"
-        rf"is|are|has|have|holds?|receives?|becomes?|serves?|acts?|owns?|defines?|determines?|"
+        rf"is|are|{authority_possession_verb}|becomes?|serves?|acts?|owns?|defines?|determines?|"
         rf"proves?|confirms?|establishes?|satisfies?|passes?|grants?|achieves?|"
         rf"certifies?|validates?|delivers?|enables?|provides?|"
         rf"{direct_authority_action})\b",

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -59,6 +59,7 @@ python3 - "${doc_path}" "${readme_path}" "${repo_root}" <<'PY'
 from __future__ import annotations
 
 import hashlib
+import html
 import json
 import os
 import re
@@ -74,6 +75,14 @@ readme_path = Path(sys.argv[2])
 repo_root = Path(sys.argv[3])
 doc_raw = doc_path.read_text(encoding="utf-8")
 readme_raw = readme_path.read_text(encoding="utf-8")
+
+
+def rendered_text(text: str) -> str:
+    return re.sub(r"[^\S\r\n]", " ", html.unescape(text))
+
+
+rendered_doc_raw = rendered_text(doc_raw)
+rendered_readme_raw = rendered_text(readme_raw)
 
 
 def visible_text(text: str) -> str:
@@ -715,8 +724,11 @@ def assignment_contains_forbidden_value(pattern: re.Pattern, line: str) -> bool:
     return False
 
 
-if any(assignment_contains_forbidden_value(sensitive_assignment, line) for line in doc_raw.splitlines()) or any(
-    pattern.search(doc_raw) for pattern in secret_patterns
+if any(
+    assignment_contains_forbidden_value(sensitive_assignment, line)
+    for line in rendered_doc_raw.splitlines()
+) or any(
+    pattern.search(rendered_doc_raw) for pattern in secret_patterns
 ):
     fail("production secret-looking value detected")
 
@@ -727,7 +739,7 @@ workstation_patterns = (
     re.compile(r"(?:^|[\s`\"'(<:=])[A-Za-z]:[\\/]Users[\\/][^\s`\"'()<>\\/]+[\\/]", re.IGNORECASE),
     re.compile(r"file://(?:[^\s`\"'()<>]*/)?(?:(?:Users|home)/[^\s`\"'()<>/]+|root)/", re.IGNORECASE),
 )
-if any(pattern.search(doc_raw) for pattern in workstation_patterns):
+if any(pattern.search(rendered_doc_raw) for pattern in workstation_patterns):
     fail("workstation-local path detected")
 
 email_pattern = re.compile(
@@ -738,21 +750,28 @@ private_assignment = re.compile(
     re.IGNORECASE,
 )
 private_data_claim = re.compile(
-    r"\b(?:includes?|contains?|retains?|stores?|embeds?|exports?|captures?|publishes?)\b.{0,60}\b(?:raw customer|customer[- ]private|private ticket|raw ticket|raw payload|customer identifier)",
+    r"\b(?:includes?|contains?|retains?|stores?|embeds?|exports?|captures?|publishes?)\b.{0,60}?\b(?:raw customer|customer[- ]private|private ticket|raw ticket|raw payload|customer identifier)",
     re.IGNORECASE,
 )
-if email_pattern.search(doc_raw) or any(
-    assignment_contains_forbidden_value(private_assignment, line) for line in doc_raw.splitlines()
+if email_pattern.search(rendered_doc_raw) or any(
+    assignment_contains_forbidden_value(private_assignment, line)
+    for line in rendered_doc_raw.splitlines()
 ):
     fail("customer-private or ticket-private data detected")
-for line in doc_raw.splitlines():
-    match = private_data_claim.search(line)
-    if match and not re.search(
-        r"\b(?:cannot|does not|must not|never|rejects?|forbids?|without|redacts?|removes?)\b",
-        line[: match.end()],
-        re.IGNORECASE,
-    ):
-        fail("customer-private or ticket-private data detected")
+private_denial_boundary = (
+    r"(?:[.!?,;]|\b(?:and|or|but|however|yet|although|though|while|whereas|"
+    r"because|since|then|before|after)\b)"
+)
+private_claim_denial = re.compile(
+    rf"\b(?:cannot|can't|does\s+not|do\s+not|did\s+not|will\s+not|would\s+not|"
+    rf"should\s+not|may\s+not|must\s+not|never)\b"
+    rf"(?:(?!{private_denial_boundary}).){{0,60}}$",
+    re.IGNORECASE,
+)
+for line in rendered_doc_raw.splitlines():
+    for match in private_data_claim.finditer(line):
+        if not private_claim_denial.search(line[: match.start()]):
+            fail("customer-private or ticket-private data detected")
 
 subordinate_subject = (
     r"(?:this\s+proof(?:\s+pack)?|phase\s+66\.7|proof\s+pack|wazuh|shuffle|ai(?:\s+output)?|tickets?|"
@@ -878,7 +897,7 @@ def claim_clauses(text: str):
         yield clause
 
 
-claim_scan_doc = doc_raw.replace(
+claim_scan_doc = rendered_doc_raw.replace(
     "Phase 66.7 does not add runtime feature breadth, execute production operations, grant new AI or integration authority, prove real design-partner outcomes, complete production rollout, implement commercial billing or entitlement enforcement, prove Phase 67 GA readiness, or claim broad enterprise SIEM/SOAR parity.",
     "",
 )
@@ -886,7 +905,7 @@ claim_inputs = (
     claim_scan_doc,
     "\n".join(
         line
-        for line in readme_raw.splitlines()
+        for line in rendered_readme_raw.splitlines()
         if re.search(r"phase\s+66\.7|authority-boundary\s+proof\s+pack", line, re.IGNORECASE)
     ),
 )

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -64,6 +64,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -451,6 +452,23 @@ for markdown_link in markdown_evidence_link.finditer(html_detection_raw):
     ):
         fail("Markdown link evidence syntax is not supported")
 
+normalized_markdown_doc = normalize_inline_markdown(rendered_doc_raw)
+markdown_heading_evidence = re.compile(
+    rf"(?m)^[ \t]*(?:(?:>[ \t]*)|(?:[-+*][ \t]+))*"
+    rf"#{{1,6}}[ \t]+.*\b(?:{field_alternation})\b",
+    re.IGNORECASE,
+)
+markdown_setext_evidence = re.compile(
+    rf"(?m)^[^\n]*\b(?:{field_alternation})\b[^\n]*"
+    rf"\n[ \t]*(?:=+|-+)[ \t]*$",
+    re.IGNORECASE,
+)
+if (
+    markdown_heading_evidence.search(normalized_markdown_doc)
+    or markdown_setext_evidence.search(normalized_markdown_doc)
+):
+    fail("Markdown heading evidence syntax is not supported")
+
 
 def markdown_cells(line: str) -> list[str]:
     cells = re.split(r"(?<!\\)\|", line.strip())
@@ -470,7 +488,7 @@ assignment_pattern = re.compile(
 current_section = "document-preamble"
 section_index = 0
 in_fence = False
-for raw_line in normalize_inline_markdown(rendered_doc_raw).splitlines():
+for raw_line in normalized_markdown_doc.splitlines():
     stripped = raw_line.strip()
     if re.match(r"^(```|~~~)", stripped):
         in_fence = not in_fence
@@ -794,6 +812,60 @@ if materialized_fields:
         )
         worktree_added = True
 
+        def evidence_worktree_snapshot() -> dict[str, tuple[int, int, int, int, int, str]]:
+            snapshot: dict[str, tuple[int, int, int, int, int, str]] = {}
+            for current_root, directory_names, file_names in os.walk(
+                evidence_worktree,
+                topdown=True,
+                followlinks=False,
+            ):
+                if Path(current_root) == evidence_worktree and ".git" in directory_names:
+                    directory_names.remove(".git")
+                directory_names.sort()
+                file_names.sort()
+                for name in directory_names + file_names:
+                    path = Path(current_root) / name
+                    relative_path = path.relative_to(evidence_worktree).as_posix()
+                    if relative_path == ".git":
+                        continue
+                    path_stat = path.lstat()
+                    file_type = stat.S_IFMT(path_stat.st_mode)
+                    permissions = stat.S_IMODE(path_stat.st_mode)
+                    if stat.S_ISREG(path_stat.st_mode):
+                        content_identity = hashlib.sha256(path.read_bytes()).hexdigest()
+                    elif stat.S_ISLNK(path_stat.st_mode):
+                        content_identity = os.readlink(path)
+                    else:
+                        content_identity = ""
+                    snapshot[relative_path] = (
+                        file_type,
+                        permissions,
+                        path_stat.st_dev,
+                        path_stat.st_ino,
+                        path_stat.st_nlink,
+                        content_identity,
+                    )
+            return snapshot
+
+        def evidence_index_snapshot() -> tuple[bytes, bytes]:
+            outputs: list[bytes] = []
+            for arguments in (
+                ("ls-files", "--stage", "-z"),
+                ("ls-files", "-v", "-z"),
+            ):
+                result = subprocess.run(
+                    ["git", "-C", str(evidence_worktree), *arguments],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                if result.returncode != 0:
+                    fail("cannot inspect isolated evidence worktree index")
+                outputs.append(result.stdout)
+            return outputs[0], outputs[1]
+
+        evidence_worktree_baseline = evidence_worktree_snapshot()
+        evidence_index_baseline = evidence_index_snapshot()
+
         def resolve_regular_git_blob(reference: str, description: str) -> bytes:
             tree_result = subprocess.run(
                 [
@@ -871,6 +943,20 @@ if materialized_fields:
                 text=True,
             )
             if status_result.returncode != 0 or status_result.stdout.strip():
+                fail(
+                    f"invalid {field}: prerequisite verifier modified isolated "
+                    "worktree"
+                )
+            try:
+                worktree_matches_baseline = (
+                    evidence_worktree_snapshot() == evidence_worktree_baseline
+                )
+            except OSError:
+                worktree_matches_baseline = False
+            if (
+                not worktree_matches_baseline
+                or evidence_index_snapshot() != evidence_index_baseline
+            ):
                 fail(
                     f"invalid {field}: prerequisite verifier modified isolated "
                     "worktree"
@@ -1179,7 +1265,9 @@ if any(
     fail("workstation-local path detected")
 
 email_pattern = re.compile(
-    r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![A-Za-z0-9.-])"
+    r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@"
+    r"(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+"
+    r"[A-Za-z]{2,63}(?![A-Za-z0-9_-])"
 )
 private_assignment = re.compile(
     r"(?:^|[;,\s{|])`?(?:customer[_ -]?(?:name|id(?:entifier)?s?|private_data|private_payload)|tenant[_ -]?(?:name|id(?:entifier)?s?)|ticket[_ -]?private[_ -]?content|raw[_ -]?(?:customer|ticket)[_ -]?(?:data|payload|content))`?\s*[:=]\s*(?P<value>[^;,|}\r\n]+)",
@@ -1272,8 +1360,9 @@ authority_possession_verb = (
     r"(?:has|have|had|holds?|held|receives?|received|possesses?|possessed|"
     r"retains?|retained|retaining|keeps?|kept|maintains?|maintained|"
     r"obtains?|obtained|acquires?|acquired|"
-    r"is\s+granted|are\s+granted|was\s+granted|were\s+granted|"
-    r"is\s+given|are\s+given|was\s+given|were\s+given)"
+    r"(?:(?:is|are|was|were|has\s+been|have\s+been|had\s+been)\s+"
+    r"(?:granted|given|delegated|assigned|entrusted|awarded|accorded|"
+    r"conferred|vested|endowed)(?:\s+with)?))"
 )
 claim_patterns = (
     re.compile(

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -92,6 +92,24 @@ def normalize_markdown_escapes(text: str) -> str:
     return markdown_escape_pattern.sub(r"\1", text)
 
 
+def normalize_inline_markdown(text: str) -> str:
+    replacements = (
+        (r"!\[([^\]\n]*)\]\([^)\n]*\)", r"\1"),
+        (r"\[([^\]\n]+)\]\([^)\n]*\)", r"\1"),
+        (r"\[([^\]\n]+)\]\[[^\]\n]*\]", r"\1"),
+        (r"(`+)([^`\n]*?)\1", r"\2"),
+        (r"(\*{1,3})(?=\S)(.+?)(?<=\S)\1", r"\2"),
+        (r"(?<!\w)(_{1,3})(?=\S)(.+?)(?<=\S)\1(?!\w)", r"\2"),
+        (r"(~~)(?=\S)(.+?)(?<=\S)\1", r"\2"),
+    )
+    for pattern, replacement in replacements:
+        previous = ""
+        while previous != text:
+            previous = text
+            text = re.sub(pattern, replacement, text)
+    return text
+
+
 class VisibleHTMLTextRenderer(HTMLParser):
     block_tags = {
         "address",
@@ -1006,12 +1024,13 @@ def assignment_contains_forbidden_value(pattern: re.Pattern, line: str) -> bool:
     return False
 
 
-secret_hygiene_inputs = (rendered_doc_raw, rendered_source_doc_raw)
+base_hygiene_inputs = (rendered_doc_raw, rendered_source_doc_raw)
+secret_hygiene_inputs = base_hygiene_inputs + tuple(
+    normalize_inline_markdown(hygiene_input)
+    for hygiene_input in base_hygiene_inputs
+)
 if any(
-    any(
-        assignment_contains_forbidden_value(sensitive_assignment, line)
-        for line in hygiene_input.splitlines()
-    )
+    assignment_contains_forbidden_value(sensitive_assignment, hygiene_input)
     or any(pattern.search(hygiene_input) for pattern in secret_patterns)
     for hygiene_input in secret_hygiene_inputs
 ):
@@ -1076,10 +1095,7 @@ private_claim_safe_qualifier = re.compile(
 )
 if any(
     email_pattern.search(hygiene_input)
-    or any(
-        assignment_contains_forbidden_value(private_assignment, line)
-        for line in hygiene_input.splitlines()
-    )
+    or assignment_contains_forbidden_value(private_assignment, hygiene_input)
     for hygiene_input in secret_hygiene_inputs
 ):
     fail("customer-private or ticket-private data detected")

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -231,7 +231,8 @@ required_phrases = (
     "Every `limitation_references` value must record `evidence_id`, `evidence_reference`, `ids`, `owner`, `decision_at`, and `follow_up_at`.",
     "The limitation manifest uses `schema_version=phase-66-7-limitations/v1` and a `limitations` array.",
     "The isolated worktree must resolve the limitation manifest and match every packet limitation to an accepted repository-owned record.",
-    "All materialized timestamps must be no more than 24 hours old at verification time and must not be more than five minutes in the future.",
+    "Observation, review, and decision timestamps must be no more than 24 hours old at verification time and must not be more than five minutes in the future.",
+    "Scheduled limitation follow-up timestamps are exempt from the five-minute future-skew limit, but must be after `decision_at` and no more than 90 days after it.",
     "AegisOps records remain authoritative for alert, case, evidence, recommendation, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, restore acceptance, and closeout truth.",
     "Wazuh, Shuffle, AI, tickets, evidence systems, browser state, UI cache, demo data, reports, support bundles, release artifacts, verifier output, issue-lint output, and optional evidence remain subordinate evidence or context only.",
     "The proof pack must reject subordinate-truth promotion, approval bypass, execution bypass, reconciliation bypass, case-closure shortcuts, source-admission shortcuts, inferred RC pass, inferred GA pass, and artifact-driven limitation or closeout decisions.",
@@ -343,23 +344,82 @@ structured_key_pattern = re.compile(
 if structured_key_pattern.search(normalize_markdown_escapes(doc_raw)):
     fail("JSON, YAML, and object-literal evidence syntax is not supported")
 
-unsupported_structural_html = re.compile(
-    r"<\s*/?\s*(?:article|aside|dd|div|dl|dt|li|ol|p|pre|section|table|tbody|td|"
-    r"tfoot|th|thead|tr|ul)\b",
+proof_field_pattern = re.compile(
+    rf"\b(?:{field_alternation})\b",
     re.IGNORECASE,
 )
-if unsupported_structural_html.search(visible_text(doc_raw)):
-    fail("raw HTML evidence syntax is not supported")
+raw_html_tag = re.compile(
+    r"<\s*/?\s*[a-z][a-z0-9:-]*(?:\s+[^<>]*?)?\s*/?\s*>",
+    re.IGNORECASE,
+)
 
-inline_html_tag = re.compile(
-    r"<\s*/?\s*(?:b|code|em|i|mark|small|span|strong|sub|sup)\b[^>]*>",
-    re.IGNORECASE,
+
+class RawHTMLProofFieldDetector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.frames: list[tuple[str, list[str]]] = []
+        self.found = False
+        self.suppressed_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        del attrs
+        tag = tag.lower()
+        if tag in {"script", "style"}:
+            self.suppressed_depth += 1
+        self.frames.append((tag, []))
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        del tag, attrs
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        matching_index = next(
+            (
+                index
+                for index in range(len(self.frames) - 1, -1, -1)
+                if self.frames[index][0] == tag
+            ),
+            None,
+        )
+        if matching_index is not None:
+            for _, parts in self.frames[matching_index:]:
+                if proof_field_pattern.search(
+                    normalize_markdown_escapes("".join(parts))
+                ):
+                    self.found = True
+            del self.frames[matching_index:]
+        if tag in {"script", "style"} and self.suppressed_depth:
+            self.suppressed_depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if self.suppressed_depth:
+            return
+        for _, parts in self.frames:
+            parts.append(data)
+
+    def contains_proof_field(self) -> bool:
+        return self.found or any(
+            proof_field_pattern.search(normalize_markdown_escapes("".join(parts)))
+            for _, parts in self.frames
+        )
+
+
+visible_doc_raw = normalize_markdown_escapes(visible_text(doc_raw))
+html_detection_raw = re.sub(
+    r"(?P<ticks>`+)[^`\n]*?(?P=ticks)",
+    "",
+    visible_doc_raw,
 )
-for raw_line in normalize_markdown_escapes(visible_text(doc_raw)).splitlines():
-    if not inline_html_tag.search(raw_line):
-        continue
-    rendered_line = rendered_text(raw_line)
-    if re.search(rf"\b(?:{field_alternation})\b", rendered_line, re.IGNORECASE):
+html_detector = RawHTMLProofFieldDetector()
+html_detector.feed(html_detection_raw)
+html_detector.close()
+if html_detector.contains_proof_field():
+    fail("raw HTML evidence syntax is not supported")
+for raw_line in html_detection_raw.splitlines():
+    if (
+        raw_html_tag.search(raw_line)
+        and proof_field_pattern.search(rendered_text(raw_line))
+    ):
         fail("raw HTML evidence syntax is not supported")
 
 
@@ -381,7 +441,7 @@ assignment_pattern = re.compile(
 current_section = "document-preamble"
 section_index = 0
 in_fence = False
-for raw_line in normalize_markdown_escapes(visible_text(doc_raw)).splitlines():
+for raw_line in rendered_doc_raw.splitlines():
     stripped = raw_line.strip()
     if re.match(r"^(```|~~~)", stripped):
         in_fence = not in_fence
@@ -511,6 +571,9 @@ def parse_timestamp(
     if fresh and parsed < now - timedelta(hours=24):
         fail(f"invalid {field}: timestamp is stale")
     return parsed
+
+
+max_follow_up_horizon = timedelta(days=90)
 
 
 if materialized_fields:
@@ -674,6 +737,11 @@ if materialized_fields:
     )
     if follow_up_at <= decision_at:
         fail("invalid limitation_references: follow_up_at must be after decision_at")
+    if follow_up_at > decision_at + max_follow_up_horizon:
+        fail(
+            "invalid limitation_references: follow_up_at must be no more than "
+            "90 days after decision_at"
+        )
 
     evidence_worktree = Path(tempfile.mkdtemp(prefix="phase66-7-evidence-"))
     worktree_added = False
@@ -831,6 +899,11 @@ if materialized_fields:
                 fail(
                     f"limitation manifest record {limitation_id} follow_up_at "
                     "must be after decision_at"
+                )
+            if record_follow_up_at > record_decision_at + max_follow_up_horizon:
+                fail(
+                    f"limitation manifest record {limitation_id} follow_up_at "
+                    "must be no more than 90 days after decision_at"
                 )
             limitations_by_id[limitation_id] = record
         for limitation_id in limitation_ids:

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -795,7 +795,10 @@ if materialized_fields:
 
 redaction_marker = re.compile(r"(?:redacted|absent|rejected|forbidden|removed)", re.IGNORECASE)
 sensitive_assignment = re.compile(
-    r"(?:^|[;,\s{|])`?(?:password|passwd|secret|client_secret|api_key|access_token|refresh_token|private_key|authorization)`?\s*[:=]\s*(?P<value>[^;,|}\r\n]+)",
+    r"(?:^|[;,\s{|])`?(?:password|passwd|secret(?:[ _-]*key)?|client[ _-]*secret|"
+    r"x[ _-]*api[ _-]*key|api[ _-]*key|access[ _-]*token|refresh[ _-]*token|"
+    r"private[ _-]*key|"
+    r"authorization)`?\s*[:=]\s*(?P<value>[^;,|}\r\n]+)",
     re.IGNORECASE,
 )
 secret_patterns = (
@@ -885,12 +888,16 @@ readiness_outcome = (
 )
 authority_action = (
     r"(?:approv(?:e|es|ed|ing)|execut(?:e|es|ed|ing)|reconcil(?:e|es|ed|ing)|"
-    r"clos(?:e|es|ed|ing)(?:\s+the)?\s+cases?|admit(?:s|ted|ting)?|"
+    r"clos(?:e|es|ed|ing)\s+(?:(?:a|an|the|one|any|this|that|each|every)\s+)?"
+    r"(?:(?:single|individual|specific|given|open|selected|current)\s+)?cases?|"
+    r"admit(?:s|ted|ting)?|"
     r"releas(?:e|es|ed|ing)|gat(?:e|es|ed|ing)|overrid(?:e|es|den|ing))"
 )
 direct_authority_action = (
     r"(?:approv(?:es|ed|ing)|execut(?:es|ed|ing)|reconcil(?:es|ed|ing)|"
-    r"clos(?:es|ed|ing)(?:\s+the)?\s+cases?|admit(?:s|ted|ting)|"
+    r"clos(?:es|ed|ing)\s+(?:(?:a|an|the|one|any|this|that|each|every)\s+)?"
+    r"(?:(?:single|individual|specific|given|open|selected|current)\s+)?cases?|"
+    r"admit(?:s|ted|ting)|"
     r"releas(?:es|ed|ing)|gat(?:es|ed|ing)|overrid(?:es|den|ing))"
 )
 claim_patterns = (

--- a/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
+++ b/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh
@@ -58,11 +58,14 @@ done
 python3 - "${doc_path}" "${readme_path}" "${repo_root}" <<'PY'
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -116,7 +119,11 @@ required_phrases = (
     "Materialized proof packets are accepted only as `field=value` assignment lines or Markdown `Field | Value` rows.",
     "Every negative observation must record `evidence_id`, `surface`, `attempt`, `result=rejected`, `authoritative_record`, `observed_at`, `journey_run_id`, and `repository_revision`.",
     "Passing one negative observation cannot compensate for a missing surface.",
-    "Each Phase 66.1-66.6 evidence value must record `evidence_id`, `verifier`, `result=passed`, `journey_run_id`, and `repository_revision`.",
+    "Each Phase 66.1-66.6 evidence value must record `evidence_id`, `evidence_reference`, `verifier`, `result=passed`, `journey_run_id`, and `repository_revision`.",
+    "Each Phase 66.1-66.6 `evidence_id` must be `sha256:<digest>` for the exact referenced proof document bytes at `repository_revision`.",
+    "The top-level `repository_revision` identifies the evidence-producing commit, not the commit that later stores the proof packet.",
+    "The verifier must check out that exact revision in an isolated worktree, resolve each required evidence reference there, and execute every Phase 66.1-66.6 focused verifier there.",
+    "Packet labels or a declared `result=passed` cannot substitute for resolved proof surfaces and successful verifier execution.",
     "All materialized timestamps must be no more than 24 hours old at verification time and must not be more than five minutes in the future.",
     "AegisOps records remain authoritative for alert, case, evidence, recommendation, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, restore acceptance, and closeout truth.",
     "Wazuh, Shuffle, AI, tickets, evidence systems, browser state, UI cache, demo data, reports, support bundles, release artifacts, verifier output, issue-lint output, and optional evidence remain subordinate evidence or context only.",
@@ -388,32 +395,68 @@ if materialized_fields:
         fail("invalid journey_run_id: expected rc66-* identifier")
     if not re.fullmatch(r"[0-9a-f]{40}", repository_revision):
         fail("invalid repository_revision: expected immutable 40-character revision")
-    try:
-        head_revision = subprocess.check_output(
-            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
-            text=True,
-            stderr=subprocess.DEVNULL,
-        ).strip().lower()
-    except (OSError, subprocess.CalledProcessError):
-        fail("cannot resolve repository HEAD for evidence binding")
-    if repository_revision != head_revision:
-        fail("invalid repository_revision: does not match repository HEAD")
-
     phase_verifiers = {
-        "phase_66_1_evidence": "scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh",
-        "phase_66_2_evidence": "scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh",
-        "phase_66_3_evidence": "scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh",
-        "phase_66_4_evidence": "scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh",
-        "phase_66_5_evidence": "scripts/verify-phase-66-5-report-export-rc-proof.sh",
-        "phase_66_6_evidence": "scripts/verify-phase-66-6-rc-supportability-proof.sh",
+        "phase_66_1_evidence": (
+            "docs/phase-66-1-clean-host-rc-e2e-harness.md",
+            "scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh",
+        ),
+        "phase_66_2_evidence": (
+            "docs/phase-66-2-wazuh-sample-signal-rc-proof.md",
+            "scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh",
+        ),
+        "phase_66_3_evidence": (
+            "docs/phase-66-3-shuffle-sample-execution-rc-proof.md",
+            "scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh",
+        ),
+        "phase_66_4_evidence": (
+            "docs/phase-66-4-ai-assisted-triage-rc-proof.md",
+            "scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh",
+        ),
+        "phase_66_5_evidence": (
+            "docs/phase-66-5-report-export-rc-proof.md",
+            "scripts/verify-phase-66-5-report-export-rc-proof.sh",
+        ),
+        "phase_66_6_evidence": (
+            "docs/phase-66-6-rc-supportability-proof.md",
+            "scripts/verify-phase-66-6-rc-supportability-proof.sh",
+        ),
     }
-    for field, expected_verifier in phase_verifiers.items():
+    try:
+        subprocess.run(
+            ["git", "-C", str(repo_root), "cat-file", "-e", f"{repository_revision}^{{commit}}"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        fail("invalid repository_revision: evidence-producing revision is not a commit in this repository")
+    try:
+        subprocess.run(
+            ["git", "-C", str(repo_root), "merge-base", "--is-ancestor", repository_revision, "HEAD"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        fail("invalid repository_revision: evidence-producing revision is not an ancestor of repository HEAD")
+
+    phase_evidence_parts: dict[str, dict[str, str]] = {}
+    for field, (expected_reference, expected_verifier) in phase_verifiers.items():
         parts = require_components(
             field,
-            ("evidence_id", "verifier", "result", "journey_run_id", "repository_revision"),
+            (
+                "evidence_id",
+                "evidence_reference",
+                "verifier",
+                "result",
+                "journey_run_id",
+                "repository_revision",
+            ),
         )
         if not re.fullmatch(r"[a-z0-9][a-z0-9._:-]{5,120}", parts["evidence_id"], re.IGNORECASE):
             fail(f"invalid {field}: malformed evidence_id")
+        if parts["evidence_reference"] != expected_reference:
+            fail(f"invalid {field}: unexpected evidence reference")
         if parts["verifier"] != expected_verifier:
             fail(f"invalid {field}: unexpected verifier path")
         if parts["result"].lower() != "passed":
@@ -422,6 +465,62 @@ if materialized_fields:
             fail(f"invalid {field}: mixed journey_run_id")
         if parts["repository_revision"].lower() != repository_revision:
             fail(f"invalid {field}: mixed repository_revision")
+        phase_evidence_parts[field] = parts
+
+    evidence_worktree = Path(tempfile.mkdtemp(prefix="phase66-7-evidence-"))
+    worktree_added = False
+    try:
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "worktree",
+                "add",
+                "--detach",
+                "--quiet",
+                str(evidence_worktree),
+                repository_revision,
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        worktree_added = True
+        for field, (expected_reference, expected_verifier) in phase_verifiers.items():
+            reference_path = evidence_worktree / expected_reference
+            verifier_path = evidence_worktree / expected_verifier
+            if not reference_path.is_file() or reference_path.stat().st_size == 0:
+                fail(f"invalid {field}: evidence reference does not resolve at repository_revision")
+            resolved_evidence_id = "sha256:" + hashlib.sha256(reference_path.read_bytes()).hexdigest()
+            if phase_evidence_parts[field]["evidence_id"].lower() != resolved_evidence_id:
+                fail(f"invalid {field}: evidence_id does not match resolved evidence reference")
+            if not verifier_path.is_file() or verifier_path.stat().st_size == 0:
+                fail(f"invalid {field}: verifier does not resolve at repository_revision")
+            verifier_result = subprocess.run(
+                ["bash", str(verifier_path), str(evidence_worktree)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            if verifier_result.returncode != 0:
+                detail = verifier_result.stderr.strip().splitlines()
+                diagnostic = detail[-1] if detail else "no diagnostic"
+                fail(f"invalid {field}: prerequisite verifier failed: {diagnostic}")
+    except subprocess.CalledProcessError as error:
+        diagnostic = (error.stderr or "").strip().splitlines()
+        detail = diagnostic[-1] if diagnostic else "unable to create evidence worktree"
+        fail(f"cannot resolve evidence-producing revision: {detail}")
+    finally:
+        if worktree_added:
+            subprocess.run(
+                ["git", "-C", str(repo_root), "worktree", "remove", "--force", str(evidence_worktree)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        else:
+            shutil.rmtree(evidence_worktree, ignore_errors=True)
 
     negative_expectations = {
         "wazuh_negative_evidence": ("wazuh", "source-truth-promotion"),
@@ -585,7 +684,7 @@ readiness_outcome = (
 )
 authority_action = (
     r"(?:approv(?:e|es|ed|ing)|execut(?:e|es|ed|ing)|reconcil(?:e|es|ed|ing)|"
-    r"clos(?:e|es|ed|ing)(?:\s+the)?\s+case|admit(?:s|ted|ting)?|"
+    r"clos(?:e|es|ed|ing)(?:\s+the)?\s+cases?|admit(?:s|ted|ting)?|"
     r"releas(?:e|es|ed|ing)|gat(?:e|es|ed|ing)|overrid(?:e|es|den|ing))"
 )
 claim_patterns = (


### PR DESCRIPTION
## Summary
- add the Phase 66.7 RC authority-boundary proof-pack contract and bind Phase 66.1-66.6 evidence to one journey run and immutable revision
- add fail-closed negative evidence coverage for Wazuh, Shuffle, AI, tickets, evidence systems, UI cache, demo data, reports, support bundles, release artifacts, verifier output, and issue-lint output
- add a focused verifier and adversarial self-test covering missing/partial evidence, truth promotion, approval/execution/reconciliation bypasses, case/source shortcuts, secrets, private data, workstation paths, RC/GA overclaims, and broad SIEM/SOAR parity claims
- link the canonical proof pack from README

## Verification
- `bash scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh`
- `bash scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh`
- `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- Phase 66.1-66.6 focused verifiers
- issue-lint for #1397 and #1404
- `git diff --cached --check`

Closes #1404