### PR TITLE
[codex] Add Phase 66.8 RC closeout evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Canonical cross-phase boundary reference:
 - [Phase 66.5 report export RC proof](docs/phase-66-5-report-export-rc-proof.md) defines the reviewed report export proof surface for RC evidence while preserving AegisOps records as workflow authority and excluding compliance certification, production SLA reporting, customer portal readiness, GA, and commercial replacement claims.
 - [Phase 66.6 RC supportability proof](docs/phase-66-6-rc-supportability-proof.md) defines the reviewed backup, restore dry-run, upgrade, rollback, support-bundle, redaction, owner-review, limitation, and non-claim evidence surface while preserving AegisOps records as workflow, release, gate, limitation, and closeout truth and excluding GA, production support, customer portal, and commercial replacement claims.
 - [Phase 66.7 RC authority-boundary proof pack](docs/phase-66-7-rc-authority-boundary-proof-pack.md) collects Phase 66.1-66.6 evidence and negative observations across Wazuh, Shuffle, AI, tickets, evidence systems, UI cache, demo data, reports, support bundles, release artifacts, verifier output, and issue-lint output while preserving AegisOps records as authority and excluding RC or GA gate, production, commercial replacement, and broad SIEM/SOAR parity claims.
+- [Phase 66.8 RC closeout evaluation](docs/phase-66-closeout-evaluation.md) records the bounded Phase 66 RC verdict, child outcomes, focused verifier and issue-lint evidence, accepted limitations, subordinate authority posture, and Phase 67 handoff without GA, production rollout, self-service commercial, or broad SIEM/SOAR parity claims.
 - [Phase 58.5 upgrade and rollback plan contract](docs/phase-58-5-upgrade-rollback-plan-contract.md) defines reviewed upgrade-plan and rollback-plan evidence fields, failure states, and authority boundaries without implementing live upgrade or rollback execution.
 - [Phase 53.2 Wazuh certificate and credential contract](docs/deployment/wazuh-certificate-credential-contract.md) defines certificate generation-wrapper posture, credential custody, default-credential rejection, rotation guidance, and no-live-secret validation for the Wazuh profile.
 - [Phase 53.3 Wazuh intake binding contract](docs/deployment/wazuh-manager-intake-binding-contract.md) defines the manager-to-AegisOps intake URL, reviewed proxy route, shared-secret custody reference, provenance fields, and analytic-signal admission boundary for Wazuh-origin events.
@@ -122,6 +123,8 @@ The Phase 66.5 report export RC proof is defined by the [Phase 66.5 report expor
 The Phase 66.6 RC supportability proof is defined by the [Phase 66.6 RC supportability proof](docs/phase-66-6-rc-supportability-proof.md).
 
 The Phase 66.7 RC authority-boundary proof pack is defined by the [Phase 66.7 RC authority-boundary proof pack](docs/phase-66-7-rc-authority-boundary-proof-pack.md).
+
+The Phase 66.8 RC closeout evaluation is defined by the [Phase 66.8 RC closeout evaluation](docs/phase-66-closeout-evaluation.md).
 
 The Phase 52.1 first-user CLI command contract is defined by the [Phase 52.1 CLI command contract](docs/phase-52-1-cli-command-contract.md).
 

--- a/docs/phase-66-closeout-evaluation.md
+++ b/docs/phase-66-closeout-evaluation.md
@@ -1,0 +1,121 @@
+# Phase 66 RC Closeout Evaluation
+
+- **Status**: Accepted at the bounded Phase 66 release-candidate evidence boundary; Phase 67 GA, production rollout, self-service commercial readiness, and broad SIEM/SOAR parity remain unproven.
+- **Date**: 2026-07-24 Asia/Tokyo closeout date
+- **Owner**: AegisOps maintainers
+- **Related Issues**: #1397, #1398, #1399, #1400, #1401, #1402, #1403, #1404, #1405
+
+## Verdict
+
+Phase 66 RC Replacement Readiness is accepted for the repository-owned, bounded release-candidate evidence chain covering clean-host setup, Wazuh sample-signal intake, Shuffle sample execution, AI-assisted triage, report export, backup and restore dry-run, upgrade and rollback planning, support-bundle handling, and authority-boundary negative evidence.
+
+The accepted verdict is an RC evidence verdict only. It records that the Phase 66 proof surfaces and focused checks are present and internally consistent; it does not approve a release, accept a GA gate, authorize production rollout, establish real design-partner success, or establish commercial replacement readiness.
+
+AegisOps records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth.
+
+Phase 66 closeout text, release artifacts, Wazuh signals, Shuffle receipts, AI traces, reports, support bundles, tickets, optional evidence, UI cache, demo data, verifier output, and issue-lint output remain subordinate evidence only. They cannot approve, execute, reconcile, close, accept a gate, resolve a limitation, or establish readiness by themselves.
+
+Phase 66 must reject missing child outcomes, missing verifier or test evidence, missing issue-lint evidence, missing accepted limitations, missing Phase 67 handoff, workstation-local paths, production secrets, customer-private data, inferred GA acceptance, production rollout claims, self-service commercial readiness claims, broad SIEM/SOAR parity claims, verifier-as-truth, and issue-lint-as-truth.
+
+## Child Issue Outcomes
+
+| Issue | Scope | Outcome |
+| --- | --- | --- |
+| #1397 | Epic: Phase 66 RC Replacement Readiness | Open until #1405 lands; accepted at the bounded RC evidence boundary when this closeout, focused Phase 66 checks, inherited boundary checks, maintainability, path hygiene, and issue-lint pass. |
+| #1398 | Phase 66.1 clean-host RC E2E harness | Closed. `docs/phase-66-1-clean-host-rc-e2e-harness.md` and its focused verifier and self-test define the clean-host journey from setup through report export without GA, production rollout, self-service commercial, or broad SIEM/SOAR parity claims. |
+| #1399 | Phase 66.2 Wazuh sample signal RC proof | Closed. `docs/phase-66-2-wazuh-sample-signal-rc-proof.md` and its focused verifier and self-test record reviewed Wazuh-origin signal evidence while preserving Wazuh as subordinate analytic context. |
+| #1400 | Phase 66.3 Shuffle sample execution RC proof | Closed. `docs/phase-66-3-shuffle-sample-execution-rc-proof.md` and its focused verifier and self-test record reviewed Shuffle execution evidence while preserving AegisOps delegation and reconciliation authority. |
+| #1401 | Phase 66.4 AI-assisted triage RC proof | Closed. `docs/phase-66-4-ai-assisted-triage-rc-proof.md` and its focused verifier and self-test record cited, reviewable AI triage evidence without granting AI approval, execution, reconciliation, or case-closure authority. |
+| #1402 | Phase 66.5 report export RC proof | Closed. `docs/phase-66-5-report-export-rc-proof.md` and its focused verifier and self-test record reviewed export evidence while preserving AegisOps records as workflow authority. |
+| #1403 | Phase 66.6 RC supportability proof | Closed. `docs/phase-66-6-rc-supportability-proof.md` and its focused verifier and self-test record backup, restore dry-run, upgrade, rollback, support-bundle, redaction, owner-review, and limitation evidence without production-support or GA claims. |
+| #1404 | Phase 66.7 RC authority-boundary proof pack | Closed. `docs/phase-66-7-rc-authority-boundary-proof-pack.md` and its focused verifier and self-test collect negative observations across the Phase 66 journey without treating subordinate evidence as authority or accepting an RC or GA gate. |
+| #1405 | Phase 66.8 RC closeout evaluation | Open until this document, its focused verifier and self-test, inherited checks, and issue-lint evidence land. |
+
+## Changed RC Proof Surfaces
+
+Phase 66 introduced or finalized these canonical proof surfaces:
+
+- `docs/phase-66-1-clean-host-rc-e2e-harness.md`
+- `docs/phase-66-2-wazuh-sample-signal-rc-proof.md`
+- `docs/phase-66-3-shuffle-sample-execution-rc-proof.md`
+- `docs/phase-66-4-ai-assisted-triage-rc-proof.md`
+- `docs/phase-66-5-report-export-rc-proof.md`
+- `docs/phase-66-6-rc-supportability-proof.md`
+- `docs/phase-66-7-rc-authority-boundary-proof-pack.md`
+- `docs/phase-66-closeout-evaluation.md`
+- `scripts/verify-phase-66-8-rc-closeout-evaluation.sh`
+- `scripts/test-verify-phase-66-8-rc-closeout-evaluation.sh`
+- `README.md`
+
+These files document and validate the bounded RC evidence surface. They do not add runtime feature breadth or production authority.
+
+## Verifier and Test Evidence
+
+Focused Phase 66 and inherited checks that must pass:
+
+- `bash scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh`
+- `bash scripts/test-verify-phase-66-1-clean-host-rc-e2e-harness.sh`
+- `bash scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh`
+- `bash scripts/test-verify-phase-66-2-wazuh-sample-signal-rc-proof.sh`
+- `bash scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh`
+- `bash scripts/test-verify-phase-66-3-shuffle-sample-execution-rc-proof.sh`
+- `bash scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh`
+- `bash scripts/test-verify-phase-66-4-ai-assisted-triage-rc-proof.sh`
+- `bash scripts/verify-phase-66-5-report-export-rc-proof.sh`
+- `bash scripts/test-verify-phase-66-5-report-export-rc-proof.sh`
+- `bash scripts/verify-phase-66-6-rc-supportability-proof.sh`
+- `bash scripts/test-verify-phase-66-6-rc-supportability-proof.sh`
+- `bash scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh`
+- `bash scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh`
+- `bash scripts/verify-phase-66-8-rc-closeout-evaluation.sh`
+- `bash scripts/test-verify-phase-66-8-rc-closeout-evaluation.sh`
+- `bash scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh`
+- `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`
+- `bash scripts/verify-maintainability-hotspots.sh`
+- `bash scripts/verify-publishable-path-hygiene.sh`
+
+Recorded result on 2026-07-24: every listed Phase 66 verifier and self-test, both inherited Phase 51 boundary verifiers, the maintainability baseline check, and publishable path hygiene passed.
+
+Verifier and self-test output is validation evidence only. A passing command does not become workflow, release, gate, limitation, closeout, or readiness truth.
+
+## Issue-Lint Summary
+
+Issue-lint evidence:
+
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1397 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1398 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1399 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1400 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1401 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1402 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1403 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1404 --config <supervisor-config-path>`
+- `node <codex-supervisor-root>/dist/index.js issue-lint 1405 --config <supervisor-config-path>`
+
+Recorded result on 2026-07-24: issues #1397 through #1405 each reported `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, and `high_risk_blocking_ambiguity=none`.
+
+Each command should report `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, and `high_risk_blocking_ambiguity=none` before Phase 66 is considered fully closed.
+
+Issue-lint output is planning and metadata evidence only. It does not become workflow, release, gate, limitation, closeout, or readiness truth.
+
+## Accepted Limitations
+
+Phase 66 does not collect real beta or design-partner evidence, prove real design-partner success, accept a Phase 67 GA gate, collect production launch evidence, approve production rollout, or establish self-service commercial readiness.
+
+Phase 66 does not provide broad enterprise SIEM/SOAR parity, commercial billing, entitlement enforcement, a customer portal, HA/SLA proof, MSSP operations, compliance certification, production support operations, or new runtime feature breadth.
+
+Phase 66 does not promote Wazuh signals, Shuffle receipts, AI output, reports, support bundles, tickets, optional evidence, UI cache, demo data, release artifacts, verifier output, issue-lint output, or closeout wording into AegisOps workflow, release, gate, limitation, closeout, RC, GA, or commercial replacement truth.
+
+## Phase 67 Handoff
+
+Phase 67 may consume Phase 66 as subordinate GA-planning input for the clean-host journey, Wazuh signal evidence, Shuffle execution evidence, AI triage evidence, report export evidence, supportability evidence, authority-boundary observations, verifier coverage, issue-lint coverage, and accepted limitations.
+
+Phase 67 must prove GA gates independently under `docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md`, using repo-owned evidence and explicit maintainer review.
+
+Phase 67 must not infer GA gate acceptance from Phase 66 issue closure, proof-file presence, owner assignment, timestamps, reports, receipts, traces, support bundles, negative observations, verifier success, issue-lint success, or this closeout verdict.
+
+## Explicit Non-Claims
+
+This closeout does not claim Phase 67 GA readiness, a passed GA gate, real design-partner success, production rollout readiness, self-service commercial readiness, broad enterprise SIEM/SOAR parity, commercial replacement readiness beyond the bounded RC evidence verdict, autonomous remediation, production support readiness, customer portal readiness, HA/SLA readiness, MSSP readiness, or compliance certification.
+
+The Phase 66 verdict does not authorize release, deployment, case closure, action execution, reconciliation, limitation resolution, or gate acceptance. Those decisions remain in the authoritative AegisOps record chain and require the responsible human owner.

--- a/scripts/test-verify-phase-66-8-rc-closeout-evaluation.sh
+++ b/scripts/test-verify-phase-66-8-rc-closeout-evaluation.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="${repo_root}/scripts/verify-phase-66-8-rc-closeout-evaluation.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+pass_stdout="${workdir}/pass.out"
+pass_stderr="${workdir}/pass.err"
+fail_stdout="${workdir}/fail.out"
+fail_stderr="${workdir}/fail.err"
+
+assert_passes() {
+  local target="$1"
+
+  if ! bash "${verifier}" "${target}" >"${pass_stdout}" 2>"${pass_stderr}"; then
+    echo "Expected verifier to pass for ${target}" >&2
+    cat "${pass_stdout}" >&2
+    cat "${pass_stderr}" >&2
+    exit 1
+  fi
+}
+
+assert_fails_with() {
+  local target="$1"
+  local expected="$2"
+
+  if bash "${verifier}" "${target}" >"${fail_stdout}" 2>"${fail_stderr}"; then
+    echo "Expected verifier to fail for ${target}" >&2
+    cat "${fail_stdout}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fiq -- "${expected}" "${fail_stderr}"; then
+    echo "Expected failure output to contain: ${expected}" >&2
+    cat "${fail_stdout}" >&2
+    cat "${fail_stderr}" >&2
+    exit 1
+  fi
+}
+
+copy_repo_path() {
+  local target="$1"
+  local relative_path="$2"
+
+  mkdir -p "${target}/$(dirname "${relative_path}")"
+  cp -p "${repo_root}/${relative_path}" "${target}/${relative_path}"
+}
+
+copy_valid_repo() {
+  local target="$1"
+  local path
+
+  mkdir -p "${target}"
+  copy_repo_path "${target}" "README.md"
+  copy_repo_path "${target}" "docs/phase-66-closeout-evaluation.md"
+  copy_repo_path "${target}" "control-plane/aegisops/control_plane/publishable_paths.py"
+  : >"${target}/control-plane/aegisops/__init__.py"
+  : >"${target}/control-plane/aegisops/control_plane/__init__.py"
+
+  for path in \
+    "docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md" \
+    "docs/phase-51-6-authority-boundary-negative-test-policy.md" \
+    "docs/phase-65-closeout-evaluation.md" \
+    "docs/phase-66-1-clean-host-rc-e2e-harness.md" \
+    "docs/phase-66-2-wazuh-sample-signal-rc-proof.md" \
+    "docs/phase-66-3-shuffle-sample-execution-rc-proof.md" \
+    "docs/phase-66-4-ai-assisted-triage-rc-proof.md" \
+    "docs/phase-66-5-report-export-rc-proof.md" \
+    "docs/phase-66-6-rc-supportability-proof.md" \
+    "docs/phase-66-7-rc-authority-boundary-proof-pack.md"; do
+    copy_repo_path "${target}" "${path}"
+  done
+
+  for path in \
+    "scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh" \
+    "scripts/test-verify-phase-66-1-clean-host-rc-e2e-harness.sh" \
+    "scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh" \
+    "scripts/test-verify-phase-66-2-wazuh-sample-signal-rc-proof.sh" \
+    "scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh" \
+    "scripts/test-verify-phase-66-3-shuffle-sample-execution-rc-proof.sh" \
+    "scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh" \
+    "scripts/test-verify-phase-66-4-ai-assisted-triage-rc-proof.sh" \
+    "scripts/verify-phase-66-5-report-export-rc-proof.sh" \
+    "scripts/test-verify-phase-66-5-report-export-rc-proof.sh" \
+    "scripts/verify-phase-66-6-rc-supportability-proof.sh" \
+    "scripts/test-verify-phase-66-6-rc-supportability-proof.sh" \
+    "scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh" \
+    "scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh" \
+    "scripts/verify-phase-66-8-rc-closeout-evaluation.sh" \
+    "scripts/test-verify-phase-66-8-rc-closeout-evaluation.sh" \
+    "scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh" \
+    "scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh" \
+    "scripts/verify-maintainability-hotspots.sh" \
+    "scripts/verify-publishable-path-hygiene.sh"; do
+    copy_repo_path "${target}" "${path}"
+  done
+
+  git -C "${target}" init -q
+  git -C "${target}" config user.email "aegisops@example.invalid"
+  git -C "${target}" config user.name "AegisOps Test"
+  git -C "${target}" add README.md docs scripts control-plane/aegisops
+  git -C "${target}" commit -q -m "fixture"
+}
+
+new_fixture() {
+  local name="$1"
+  local target="${workdir}/${name}"
+
+  cp -R "${workdir}/valid" "${target}"
+  printf '%s\n' "${target}"
+}
+
+remove_doc_text() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E//g' \
+    "${target}/docs/phase-66-closeout-evaluation.md"
+}
+
+comment_doc_text() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E/<!-- $ENV{TEXT} -->/g' \
+    "${target}/docs/phase-66-closeout-evaluation.md"
+}
+
+fence_doc_text() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e \
+    's/\Q$ENV{TEXT}\E/```\n$ENV{TEXT}\n```/g' \
+    "${target}/docs/phase-66-closeout-evaluation.md"
+}
+
+blockquote_doc_text() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e 's/\Q$ENV{TEXT}\E/> $ENV{TEXT}/g' \
+    "${target}/docs/phase-66-closeout-evaluation.md"
+}
+
+duplicate_doc_text() {
+  local target="$1"
+  local text="$2"
+
+  TEXT="${text}" perl -0pi -e \
+    's/\Q$ENV{TEXT}\E/$ENV{TEXT}\n$ENV{TEXT}/g' \
+    "${target}/docs/phase-66-closeout-evaluation.md"
+}
+
+valid_repo="${workdir}/valid"
+copy_valid_repo "${valid_repo}"
+assert_passes "${valid_repo}"
+
+missing_doc_repo="$(new_fixture "missing-doc")"
+rm "${missing_doc_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${missing_doc_repo}" "Missing Phase 66 RC closeout evaluation"
+
+missing_reference_repo="$(new_fixture "missing-reference")"
+rm "${missing_reference_repo}/docs/phase-66-7-rc-authority-boundary-proof-pack.md"
+assert_fails_with "${missing_reference_repo}" \
+  "Missing Phase 66 closeout reference docs/phase-66-7-rc-authority-boundary-proof-pack.md"
+
+missing_readme_repo="$(new_fixture "missing-readme")"
+perl -0pi -e \
+  's/- \[Phase 66\.8 RC closeout evaluation\]\(docs\/phase-66-closeout-evaluation\.md\)[^\n]*\n//' \
+  "${missing_readme_repo}/README.md"
+assert_fails_with "${missing_readme_repo}" "Missing README Phase 66.8 closeout reference"
+
+missing_heading_repo="$(new_fixture "missing-heading")"
+perl -0pi -e 's/^## Accepted Limitations$/## Deferred Items/m' \
+  "${missing_heading_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${missing_heading_repo}" \
+  "Expected exactly one Phase 66 closeout section: ## Accepted Limitations"
+
+missing_child_repo="$(new_fixture "missing-child")"
+remove_doc_text "${missing_child_repo}" \
+  "| #1404 | Phase 66.7 RC authority-boundary proof pack | Closed. \`docs/phase-66-7-rc-authority-boundary-proof-pack.md\` and its focused verifier and self-test collect negative observations across the Phase 66 journey without treating subordinate evidence as authority or accepting an RC or GA gate. |"
+assert_fails_with "${missing_child_repo}" \
+  "Expected exactly one Phase 66 child issue outcome row"
+
+commented_child_repo="$(new_fixture "commented-child")"
+comment_doc_text "${commented_child_repo}" \
+  "| #1404 | Phase 66.7 RC authority-boundary proof pack | Closed. \`docs/phase-66-7-rc-authority-boundary-proof-pack.md\` and its focused verifier and self-test collect negative observations across the Phase 66 journey without treating subordinate evidence as authority or accepting an RC or GA gate. |"
+assert_fails_with "${commented_child_repo}" \
+  "Expected exactly one Phase 66 child issue outcome row"
+
+fenced_child_repo="$(new_fixture "fenced-child")"
+fence_doc_text "${fenced_child_repo}" \
+  "| #1404 | Phase 66.7 RC authority-boundary proof pack | Closed. \`docs/phase-66-7-rc-authority-boundary-proof-pack.md\` and its focused verifier and self-test collect negative observations across the Phase 66 journey without treating subordinate evidence as authority or accepting an RC or GA gate. |"
+assert_fails_with "${fenced_child_repo}" \
+  "Expected exactly one Phase 66 child issue outcome row"
+
+blockquote_child_repo="$(new_fixture "blockquote-child")"
+blockquote_doc_text "${blockquote_child_repo}" \
+  "| #1404 | Phase 66.7 RC authority-boundary proof pack | Closed. \`docs/phase-66-7-rc-authority-boundary-proof-pack.md\` and its focused verifier and self-test collect negative observations across the Phase 66 journey without treating subordinate evidence as authority or accepting an RC or GA gate. |"
+assert_fails_with "${blockquote_child_repo}" \
+  "Expected exactly one Phase 66 child issue outcome row"
+
+duplicate_child_repo="$(new_fixture "duplicate-child")"
+duplicate_doc_text "${duplicate_child_repo}" \
+  "| #1404 | Phase 66.7 RC authority-boundary proof pack | Closed. \`docs/phase-66-7-rc-authority-boundary-proof-pack.md\` and its focused verifier and self-test collect negative observations across the Phase 66 journey without treating subordinate evidence as authority or accepting an RC or GA gate. |"
+assert_fails_with "${duplicate_child_repo}" \
+  "Expected exactly one Phase 66 child issue outcome row"
+
+missing_surface_repo="$(new_fixture "missing-surface")"
+remove_doc_text "${missing_surface_repo}" \
+  "- \`docs/phase-66-6-rc-supportability-proof.md\`"
+assert_fails_with "${missing_surface_repo}" \
+  "Expected exactly one Phase 66 changed proof surface"
+
+missing_verifier_repo="$(new_fixture "missing-verifier")"
+remove_doc_text "${missing_verifier_repo}" \
+  "- \`bash scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh\`"
+assert_fails_with "${missing_verifier_repo}" \
+  "Expected exactly one Phase 66 verifier evidence line"
+
+missing_verifier_script_repo="$(new_fixture "missing-verifier-script")"
+rm "${missing_verifier_script_repo}/scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh"
+assert_fails_with "${missing_verifier_script_repo}" \
+  "Missing Phase 66 verifier script scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh"
+
+missing_issue_lint_repo="$(new_fixture "missing-issue-lint")"
+remove_doc_text "${missing_issue_lint_repo}" \
+  "- \`node <codex-supervisor-root>/dist/index.js issue-lint 1405 --config <supervisor-config-path>\`"
+assert_fails_with "${missing_issue_lint_repo}" \
+  "Expected exactly one Phase 66 issue-lint evidence line"
+
+missing_limitation_repo="$(new_fixture "missing-limitation")"
+remove_doc_text "${missing_limitation_repo}" \
+  "Phase 66 does not collect real beta or design-partner evidence, prove real design-partner success, accept a Phase 67 GA gate, collect production launch evidence, approve production rollout, or establish self-service commercial readiness."
+assert_fails_with "${missing_limitation_repo}" "Missing Phase 66 accepted limitation"
+
+missing_handoff_repo="$(new_fixture "missing-handoff")"
+remove_doc_text "${missing_handoff_repo}" \
+  "Phase 67 must prove GA gates independently under \`docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md\`, using repo-owned evidence and explicit maintainer review."
+assert_fails_with "${missing_handoff_repo}" "Missing Phase 67 handoff boundary"
+
+missing_recorded_result_repo="$(new_fixture "missing-recorded-result")"
+remove_doc_text "${missing_recorded_result_repo}" \
+  "Recorded result on 2026-07-24: issues #1397 through #1405 each reported \`execution_ready=yes\`, \`missing_required=none\`, \`missing_recommended=none\`, \`metadata_errors=none\`, and \`high_risk_blocking_ambiguity=none\`."
+assert_fails_with "${missing_recorded_result_repo}" \
+  "Missing required Phase 66 closeout term"
+
+ga_ready_repo="$(new_fixture "ga-ready")"
+printf '%s\n' "Phase 66 is GA ready." \
+  >>"${ga_ready_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${ga_ready_repo}" "readiness or authority claim"
+
+ready_for_ga_repo="$(new_fixture "ready-for-ga")"
+printf '%s\n' "Phase 66 is ready for GA." \
+  >>"${ready_for_ga_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${ready_for_ga_repo}" "readiness or authority claim"
+
+generally_available_repo="$(new_fixture "generally-available")"
+printf '%s\n' "AegisOps is generally available." \
+  >>"${generally_available_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${generally_available_repo}" "readiness or authority claim"
+
+ga_achieved_repo="$(new_fixture "ga-achieved")"
+printf '%s\n' "GA readiness has been achieved." \
+  >>"${ga_achieved_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${ga_achieved_repo}" "readiness or authority claim"
+
+ga_table_repo="$(new_fixture "ga-table")"
+printf '%s\n' "| GA gate | accepted |" \
+  >>"${ga_table_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${ga_table_repo}" "readiness or authority claim"
+
+production_ready_repo="$(new_fixture "production-ready")"
+printf '%s\n' "AegisOps production rollout is ready." \
+  >>"${production_ready_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${production_ready_repo}" "readiness or authority claim"
+
+production_complete_repo="$(new_fixture "production-complete")"
+printf '%s\n' "Production rollout readiness is complete." \
+  >>"${production_complete_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${production_complete_repo}" "readiness or authority claim"
+
+self_service_repo="$(new_fixture "self-service")"
+printf '%s\n' "Self-service commercial readiness is achieved." \
+  >>"${self_service_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${self_service_repo}" "readiness or authority claim"
+
+parity_repo="$(new_fixture "broad-parity")"
+printf '%s\n' "Broad enterprise SIEM/SOAR parity is achieved." \
+  >>"${parity_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${parity_repo}" "readiness or authority claim"
+
+verifier_truth_repo="$(new_fixture "verifier-truth")"
+printf '%s\n' "Verifier output is readiness truth." \
+  >>"${verifier_truth_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${verifier_truth_repo}" "readiness or authority claim"
+
+issue_lint_truth_repo="$(new_fixture "issue-lint-truth")"
+printf '%s\n' "Issue-lint output becomes closeout truth." \
+  >>"${issue_lint_truth_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${issue_lint_truth_repo}" "readiness or authority claim"
+
+wazuh_truth_repo="$(new_fixture "wazuh-truth")"
+printf '%s\n' "Wazuh signals are workflow truth." \
+  >>"${wazuh_truth_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${wazuh_truth_repo}" "readiness or authority claim"
+
+closure_truth_repo="$(new_fixture "closure-truth")"
+printf '%s\n' "Issue closure proves GA readiness." \
+  >>"${closure_truth_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${closure_truth_repo}" "readiness or authority claim"
+
+achieved_ga_repo="$(new_fixture "achieved-ga")"
+printf '%s\n' "Phase 66 has achieved GA readiness." \
+  >>"${achieved_ga_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${achieved_ga_repo}" "readiness or authority claim"
+
+ready_for_production_repo="$(new_fixture "ready-for-production")"
+printf '%s\n' "AegisOps is ready for production rollout." \
+  >>"${ready_for_production_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${ready_for_production_repo}" "readiness or authority claim"
+
+has_parity_repo="$(new_fixture "has-parity")"
+printf '%s\n' "AegisOps has established broad enterprise SIEM/SOAR parity." \
+  >>"${has_parity_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${has_parity_repo}" "readiness or authority claim"
+
+denial_then_claim_repo="$(new_fixture "denial-then-claim")"
+printf '%s\n' "Without external evidence, Phase 66 is GA ready." \
+  >>"${denial_then_claim_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${denial_then_claim_repo}" \
+  "Forbidden Phase 66 closeout evaluation"
+
+elided_subject_repo="$(new_fixture "elided-subject")"
+printf '%s\n' "Phase 66 does not claim GA readiness and it is GA ready." \
+  >>"${elided_subject_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${elided_subject_repo}" \
+  "Forbidden Phase 66 closeout evaluation"
+
+issue_lint_gate_repo="$(new_fixture "issue-lint-gate")"
+printf '%s\n' "Issue-lint output passes the GA gate." \
+  >>"${issue_lint_gate_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${issue_lint_gate_repo}" "readiness or authority claim"
+
+issue_lint_authoritative_repo="$(new_fixture "issue-lint-authoritative")"
+printf '%s\n' "Issue-lint output is authoritative." \
+  >>"${issue_lint_authoritative_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${issue_lint_authoritative_repo}" "readiness or authority claim"
+
+wazuh_authority_repo="$(new_fixture "wazuh-authority")"
+printf '%s\n' "Wazuh signals can close cases." \
+  >>"${wazuh_authority_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${wazuh_authority_repo}" "readiness or authority claim"
+
+commented_overclaim_repo="$(new_fixture "commented-overclaim")"
+printf '%s\n' "<!-- Phase 66 is GA ready. -->" \
+  >>"${commented_overclaim_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${commented_overclaim_repo}" "readiness or authority claim"
+
+fenced_overclaim_repo="$(new_fixture "fenced-overclaim")"
+printf '%s\n' '```text' "Phase 66 is GA ready." '```' \
+  >>"${fenced_overclaim_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${fenced_overclaim_repo}" "readiness or authority claim"
+
+secret_repo="$(new_fixture "secret")"
+printf '%s\n' "api_key=actual-production-secret-value" \
+  >>"${secret_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${secret_repo}" "production secret-looking value detected"
+
+formatted_secret_repo="$(new_fixture "formatted-secret")"
+printf '%s\n' 'api**_key**: actual-production-secret-value' \
+  >>"${formatted_secret_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${formatted_secret_repo}" "production secret-looking value detected"
+
+entity_secret_repo="$(new_fixture "entity-secret")"
+printf '%s\n' 'api&#95;key&#61;actual-production-secret-value' \
+  >>"${entity_secret_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${entity_secret_repo}" "production secret-looking value detected"
+
+prose_secret_repo="$(new_fixture "prose-secret")"
+printf '%s\n' "API key is actual-production-secret-value" \
+  >>"${prose_secret_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${prose_secret_repo}" "production secret-looking value detected"
+
+commented_secret_repo="$(new_fixture "commented-secret")"
+printf '%s\n' "<!-- token=actual-production-secret-value -->" \
+  >>"${commented_secret_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${commented_secret_repo}" "production secret-looking value detected"
+
+customer_private_repo="$(new_fixture "customer-private")"
+printf '%s\n' "This closeout includes unredacted customer ticket data." \
+  >>"${customer_private_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${customer_private_repo}" "customer-private data detected"
+
+customer_id_repo="$(new_fixture "customer-id")"
+printf '%s\n' "customer_id=customer-0042" \
+  >>"${customer_id_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${customer_id_repo}" "customer-private data detected"
+
+customer_email_repo="$(new_fixture "customer-email")"
+printf '%s\n' "Evidence owner: alice@example.com" \
+  >>"${customer_email_repo}/docs/phase-66-closeout-evaluation.md"
+assert_fails_with "${customer_email_repo}" "customer-private data detected"
+
+path_repo="$(new_fixture "path")"
+users_segment="Users"
+printf '%s\n' "Operator note references /${users_segment}/local/aegisops." \
+  >>"${path_repo}/docs/phase-66-closeout-evaluation.md"
+git -C "${path_repo}" add docs/phase-66-closeout-evaluation.md
+git -C "${path_repo}" commit -q -m "path"
+assert_fails_with "${path_repo}" \
+  "Forbidden Phase 66 closeout evaluation absolute path usage detected"
+
+echo "Phase 66.8 RC closeout verifier self-test passes."

--- a/scripts/verify-phase-66-8-rc-closeout-evaluation.sh
+++ b/scripts/verify-phase-66-8-rc-closeout-evaluation.sh
@@ -1,0 +1,534 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+repo_root="$(cd "${repo_root}" && pwd -P)"
+
+doc_path="docs/phase-66-closeout-evaluation.md"
+absolute_doc_path="${repo_root}/${doc_path}"
+readme_path="${repo_root}/README.md"
+
+required_reference_paths=(
+  "docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md"
+  "docs/phase-51-6-authority-boundary-negative-test-policy.md"
+  "docs/phase-65-closeout-evaluation.md"
+  "docs/phase-66-1-clean-host-rc-e2e-harness.md"
+  "docs/phase-66-2-wazuh-sample-signal-rc-proof.md"
+  "docs/phase-66-3-shuffle-sample-execution-rc-proof.md"
+  "docs/phase-66-4-ai-assisted-triage-rc-proof.md"
+  "docs/phase-66-5-report-export-rc-proof.md"
+  "docs/phase-66-6-rc-supportability-proof.md"
+  "docs/phase-66-7-rc-authority-boundary-proof-pack.md"
+)
+
+required_verifier_scripts=(
+  "scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+  "scripts/test-verify-phase-66-1-clean-host-rc-e2e-harness.sh"
+  "scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh"
+  "scripts/test-verify-phase-66-2-wazuh-sample-signal-rc-proof.sh"
+  "scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh"
+  "scripts/test-verify-phase-66-3-shuffle-sample-execution-rc-proof.sh"
+  "scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh"
+  "scripts/test-verify-phase-66-4-ai-assisted-triage-rc-proof.sh"
+  "scripts/verify-phase-66-5-report-export-rc-proof.sh"
+  "scripts/test-verify-phase-66-5-report-export-rc-proof.sh"
+  "scripts/verify-phase-66-6-rc-supportability-proof.sh"
+  "scripts/test-verify-phase-66-6-rc-supportability-proof.sh"
+  "scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh"
+  "scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh"
+  "scripts/verify-phase-66-8-rc-closeout-evaluation.sh"
+  "scripts/test-verify-phase-66-8-rc-closeout-evaluation.sh"
+  "scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh"
+  "scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh"
+  "scripts/verify-maintainability-hotspots.sh"
+  "scripts/verify-publishable-path-hygiene.sh"
+)
+
+require_file() {
+  local path="$1"
+  local description="$2"
+
+  if [[ ! -s "${path}" ]]; then
+    echo "Missing ${description}: ${path#"${repo_root}/"}" >&2
+    exit 1
+  fi
+}
+
+require_file "${absolute_doc_path}" "Phase 66 RC closeout evaluation"
+require_file "${readme_path}" "README for Phase 66 closeout link check"
+
+for reference_path in "${required_reference_paths[@]}"; do
+  require_file "${repo_root}/${reference_path}" "Phase 66 closeout reference ${reference_path}"
+done
+
+for verifier_script in "${required_verifier_scripts[@]}"; do
+  require_file "${repo_root}/${verifier_script}" "Phase 66 verifier script ${verifier_script}"
+done
+
+python3 - "${absolute_doc_path}" "${readme_path}" <<'PY'
+from __future__ import annotations
+
+import html
+import re
+import sys
+from pathlib import Path
+
+
+doc_path = Path(sys.argv[1])
+readme_path = Path(sys.argv[2])
+doc_raw = doc_path.read_text(encoding="utf-8")
+readme_raw = readme_path.read_text(encoding="utf-8")
+
+
+def visible_markdown(value: str) -> str:
+    return re.sub(r"<!--.*?-->", "", value, flags=re.DOTALL)
+
+
+def without_fenced_blocks(value: str) -> str:
+    visible_lines: list[str] = []
+    fence: str | None = None
+    for line in value.splitlines():
+        marker = re.match(r"^\s*(```+|~~~+)", line)
+        if marker:
+            current = marker.group(1)[0]
+            if fence is None:
+                fence = current
+            elif fence == current:
+                fence = None
+            continue
+        if fence is None:
+            visible_lines.append(line)
+    return "\n".join(visible_lines)
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+doc_visible = visible_markdown(doc_raw)
+readme_visible = visible_markdown(readme_raw)
+doc = without_fenced_blocks(doc_visible)
+readme = without_fenced_blocks(readme_visible)
+
+readme_phrases = (
+    "- [Phase 66.8 RC closeout evaluation](docs/phase-66-closeout-evaluation.md) records the bounded Phase 66 RC verdict, child outcomes, focused verifier and issue-lint evidence, accepted limitations, subordinate authority posture, and Phase 67 handoff without GA, production rollout, self-service commercial, or broad SIEM/SOAR parity claims.",
+    "The Phase 66.8 RC closeout evaluation is defined by the [Phase 66.8 RC closeout evaluation](docs/phase-66-closeout-evaluation.md).",
+)
+for phrase in readme_phrases:
+    if phrase not in readme:
+        fail(f"Missing README Phase 66.8 closeout reference: {phrase}")
+
+required_phrases = (
+    "# Phase 66 RC Closeout Evaluation",
+    "**Status**: Accepted at the bounded Phase 66 release-candidate evidence boundary; Phase 67 GA, production rollout, self-service commercial readiness, and broad SIEM/SOAR parity remain unproven.",
+    "**Related Issues**: #1397, #1398, #1399, #1400, #1401, #1402, #1403, #1404, #1405",
+    "Phase 66 RC Replacement Readiness is accepted for the repository-owned, bounded release-candidate evidence chain",
+    "The accepted verdict is an RC evidence verdict only.",
+    "AegisOps records remain authoritative for alert, case, evidence, approval, action request, execution receipt, reconciliation, audit, release, gate, limitation, and closeout truth.",
+    "Phase 66 closeout text, release artifacts, Wazuh signals, Shuffle receipts, AI traces, reports, support bundles, tickets, optional evidence, UI cache, demo data, verifier output, and issue-lint output remain subordinate evidence only.",
+    "Phase 66 must reject missing child outcomes, missing verifier or test evidence, missing issue-lint evidence, missing accepted limitations, missing Phase 67 handoff, workstation-local paths, production secrets, customer-private data, inferred GA acceptance, production rollout claims, self-service commercial readiness claims, broad SIEM/SOAR parity claims, verifier-as-truth, and issue-lint-as-truth.",
+    "Focused Phase 66 and inherited checks that must pass:",
+    "Recorded result on 2026-07-24: every listed Phase 66 verifier and self-test, both inherited Phase 51 boundary verifiers, the maintainability baseline check, and publishable path hygiene passed.",
+    "Recorded result on 2026-07-24: issues #1397 through #1405 each reported `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, and `high_risk_blocking_ambiguity=none`.",
+    "Each command should report `execution_ready=yes`, `missing_required=none`, `missing_recommended=none`, `metadata_errors=none`, and `high_risk_blocking_ambiguity=none` before Phase 66 is considered fully closed.",
+    "Issue-lint output is planning and metadata evidence only. It does not become workflow, release, gate, limitation, closeout, or readiness truth.",
+)
+for phrase in required_phrases:
+    if phrase not in doc:
+        fail(f"Missing required Phase 66 closeout term: {phrase}")
+
+required_headings = (
+    "## Verdict",
+    "## Child Issue Outcomes",
+    "## Changed RC Proof Surfaces",
+    "## Verifier and Test Evidence",
+    "## Issue-Lint Summary",
+    "## Accepted Limitations",
+    "## Phase 67 Handoff",
+    "## Explicit Non-Claims",
+)
+lines = doc.splitlines()
+heading_positions: dict[str, int] = {}
+for heading in required_headings:
+    matches = [index for index, line in enumerate(lines) if line.strip() == heading]
+    if len(matches) != 1:
+        fail(f"Expected exactly one Phase 66 closeout section: {heading}")
+    heading_positions[heading] = matches[0]
+if [heading_positions[heading] for heading in required_headings] != sorted(
+    heading_positions.values()
+):
+    fail("Phase 66 closeout sections are out of order")
+
+
+def section_text(heading: str, next_heading: str | None) -> str:
+    start = heading_positions[heading] + 1
+    end = heading_positions[next_heading] if next_heading else len(lines)
+    return "\n".join(lines[start:end])
+
+
+def require_exact_line(section: str, expected: str, description: str) -> None:
+    matches = sum(line.strip() == expected for line in section.splitlines())
+    if matches != 1:
+        fail(f"Expected exactly one {description}: {expected}")
+
+
+child_outcomes = section_text("## Child Issue Outcomes", "## Changed RC Proof Surfaces")
+required_child_rows = (
+    "| #1397 | Epic: Phase 66 RC Replacement Readiness | Open until #1405 lands; accepted at the bounded RC evidence boundary when this closeout, focused Phase 66 checks, inherited boundary checks, maintainability, path hygiene, and issue-lint pass. |",
+    "| #1398 | Phase 66.1 clean-host RC E2E harness | Closed. `docs/phase-66-1-clean-host-rc-e2e-harness.md` and its focused verifier and self-test define the clean-host journey from setup through report export without GA, production rollout, self-service commercial, or broad SIEM/SOAR parity claims. |",
+    "| #1399 | Phase 66.2 Wazuh sample signal RC proof | Closed. `docs/phase-66-2-wazuh-sample-signal-rc-proof.md` and its focused verifier and self-test record reviewed Wazuh-origin signal evidence while preserving Wazuh as subordinate analytic context. |",
+    "| #1400 | Phase 66.3 Shuffle sample execution RC proof | Closed. `docs/phase-66-3-shuffle-sample-execution-rc-proof.md` and its focused verifier and self-test record reviewed Shuffle execution evidence while preserving AegisOps delegation and reconciliation authority. |",
+    "| #1401 | Phase 66.4 AI-assisted triage RC proof | Closed. `docs/phase-66-4-ai-assisted-triage-rc-proof.md` and its focused verifier and self-test record cited, reviewable AI triage evidence without granting AI approval, execution, reconciliation, or case-closure authority. |",
+    "| #1402 | Phase 66.5 report export RC proof | Closed. `docs/phase-66-5-report-export-rc-proof.md` and its focused verifier and self-test record reviewed export evidence while preserving AegisOps records as workflow authority. |",
+    "| #1403 | Phase 66.6 RC supportability proof | Closed. `docs/phase-66-6-rc-supportability-proof.md` and its focused verifier and self-test record backup, restore dry-run, upgrade, rollback, support-bundle, redaction, owner-review, and limitation evidence without production-support or GA claims. |",
+    "| #1404 | Phase 66.7 RC authority-boundary proof pack | Closed. `docs/phase-66-7-rc-authority-boundary-proof-pack.md` and its focused verifier and self-test collect negative observations across the Phase 66 journey without treating subordinate evidence as authority or accepting an RC or GA gate. |",
+    "| #1405 | Phase 66.8 RC closeout evaluation | Open until this document, its focused verifier and self-test, inherited checks, and issue-lint evidence land. |",
+)
+for row in required_child_rows:
+    require_exact_line(child_outcomes, row, "Phase 66 child issue outcome row")
+
+changed_surfaces = section_text(
+    "## Changed RC Proof Surfaces", "## Verifier and Test Evidence"
+)
+required_changed_surfaces = (
+    "- `docs/phase-66-1-clean-host-rc-e2e-harness.md`",
+    "- `docs/phase-66-2-wazuh-sample-signal-rc-proof.md`",
+    "- `docs/phase-66-3-shuffle-sample-execution-rc-proof.md`",
+    "- `docs/phase-66-4-ai-assisted-triage-rc-proof.md`",
+    "- `docs/phase-66-5-report-export-rc-proof.md`",
+    "- `docs/phase-66-6-rc-supportability-proof.md`",
+    "- `docs/phase-66-7-rc-authority-boundary-proof-pack.md`",
+    "- `docs/phase-66-closeout-evaluation.md`",
+    "- `scripts/verify-phase-66-8-rc-closeout-evaluation.sh`",
+    "- `scripts/test-verify-phase-66-8-rc-closeout-evaluation.sh`",
+    "- `README.md`",
+)
+for line in required_changed_surfaces:
+    require_exact_line(changed_surfaces, line, "Phase 66 changed proof surface")
+
+verifier_evidence = section_text(
+    "## Verifier and Test Evidence", "## Issue-Lint Summary"
+)
+required_verifier_lines = (
+    "- `bash scripts/verify-phase-66-1-clean-host-rc-e2e-harness.sh`",
+    "- `bash scripts/test-verify-phase-66-1-clean-host-rc-e2e-harness.sh`",
+    "- `bash scripts/verify-phase-66-2-wazuh-sample-signal-rc-proof.sh`",
+    "- `bash scripts/test-verify-phase-66-2-wazuh-sample-signal-rc-proof.sh`",
+    "- `bash scripts/verify-phase-66-3-shuffle-sample-execution-rc-proof.sh`",
+    "- `bash scripts/test-verify-phase-66-3-shuffle-sample-execution-rc-proof.sh`",
+    "- `bash scripts/verify-phase-66-4-ai-assisted-triage-rc-proof.sh`",
+    "- `bash scripts/test-verify-phase-66-4-ai-assisted-triage-rc-proof.sh`",
+    "- `bash scripts/verify-phase-66-5-report-export-rc-proof.sh`",
+    "- `bash scripts/test-verify-phase-66-5-report-export-rc-proof.sh`",
+    "- `bash scripts/verify-phase-66-6-rc-supportability-proof.sh`",
+    "- `bash scripts/test-verify-phase-66-6-rc-supportability-proof.sh`",
+    "- `bash scripts/verify-phase-66-7-rc-authority-boundary-proof-pack.sh`",
+    "- `bash scripts/test-verify-phase-66-7-rc-authority-boundary-proof-pack.sh`",
+    "- `bash scripts/verify-phase-66-8-rc-closeout-evaluation.sh`",
+    "- `bash scripts/test-verify-phase-66-8-rc-closeout-evaluation.sh`",
+    "- `bash scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh`",
+    "- `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`",
+    "- `bash scripts/verify-maintainability-hotspots.sh`",
+    "- `bash scripts/verify-publishable-path-hygiene.sh`",
+)
+for line in required_verifier_lines:
+    require_exact_line(verifier_evidence, line, "Phase 66 verifier evidence line")
+
+issue_lint = section_text("## Issue-Lint Summary", "## Accepted Limitations")
+for issue_number in range(1397, 1406):
+    line = (
+        f"- `node <codex-supervisor-root>/dist/index.js issue-lint {issue_number} "
+        "--config <supervisor-config-path>`"
+    )
+    require_exact_line(issue_lint, line, "Phase 66 issue-lint evidence line")
+
+accepted_limitations = section_text("## Accepted Limitations", "## Phase 67 Handoff")
+required_limitations = (
+    "Phase 66 does not collect real beta or design-partner evidence, prove real design-partner success, accept a Phase 67 GA gate, collect production launch evidence, approve production rollout, or establish self-service commercial readiness.",
+    "Phase 66 does not provide broad enterprise SIEM/SOAR parity, commercial billing, entitlement enforcement, a customer portal, HA/SLA proof, MSSP operations, compliance certification, production support operations, or new runtime feature breadth.",
+    "Phase 66 does not promote Wazuh signals, Shuffle receipts, AI output, reports, support bundles, tickets, optional evidence, UI cache, demo data, release artifacts, verifier output, issue-lint output, or closeout wording into AegisOps workflow, release, gate, limitation, closeout, RC, GA, or commercial replacement truth.",
+)
+for phrase in required_limitations:
+    if phrase not in accepted_limitations:
+        fail(f"Missing Phase 66 accepted limitation: {phrase}")
+
+phase67_handoff = section_text("## Phase 67 Handoff", "## Explicit Non-Claims")
+required_handoff = (
+    "Phase 67 may consume Phase 66 as subordinate GA-planning input for the clean-host journey, Wazuh signal evidence, Shuffle execution evidence, AI triage evidence, report export evidence, supportability evidence, authority-boundary observations, verifier coverage, issue-lint coverage, and accepted limitations.",
+    "Phase 67 must prove GA gates independently under `docs/phase-51-3-pilot-beta-rc-ga-gate-contract.md`, using repo-owned evidence and explicit maintainer review.",
+    "Phase 67 must not infer GA gate acceptance from Phase 66 issue closure, proof-file presence, owner assignment, timestamps, reports, receipts, traces, support bundles, negative observations, verifier success, issue-lint success, or this closeout verdict.",
+)
+for phrase in required_handoff:
+    if phrase not in phase67_handoff:
+        fail(f"Missing Phase 67 handoff boundary: {phrase}")
+
+explicit_non_claims = section_text("## Explicit Non-Claims", None)
+required_non_claims = (
+    "This closeout does not claim Phase 67 GA readiness, a passed GA gate, real design-partner success, production rollout readiness, self-service commercial readiness, broad enterprise SIEM/SOAR parity, commercial replacement readiness beyond the bounded RC evidence verdict, autonomous remediation, production support readiness, customer portal readiness, HA/SLA readiness, MSSP readiness, or compliance certification.",
+    "The Phase 66 verdict does not authorize release, deployment, case closure, action execution, reconciliation, limitation resolution, or gate acceptance. Those decisions remain in the authoritative AegisOps record chain and require the responsible human owner.",
+)
+for phrase in required_non_claims:
+    if phrase not in explicit_non_claims:
+        fail(f"Missing Phase 66 explicit non-claim: {phrase}")
+
+
+def rendered_text(value: str, *, remove_comments: bool = True) -> str:
+    if remove_comments:
+        value = visible_markdown(value)
+    value = html.unescape(value)
+    value = re.sub(r"\\([\\`*_{}\[\]()#+.!|<>=~-])", r"\1", value)
+    value = re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"\1", value)
+    value = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", value)
+    value = re.sub(r"<[^>\n]+>", " ", value)
+    value = re.sub(r"[`*_~]", "", value)
+    return value
+
+
+security_source = re.sub(r"<!--(.*?)-->", r"\1", doc_raw, flags=re.DOTALL)
+rendered = rendered_text(security_source, remove_comments=False)
+normalized = re.sub(r"[ \t]+", " ", rendered)
+
+secret_patterns = (
+    re.compile(
+        r"(?i)\bauthorization\s*(?::|=)?\s*bearer\s+([A-Za-z0-9._~+/=-]{12,})"
+    ),
+    re.compile(
+        r"(?i)\b(?:api[\s_-]*key|access[\s_-]*token|refresh[\s_-]*token|"
+        r"session[\s_-]*token|client[\s_-]*secret|password|passwd|secret|token)"
+        r"\s*(?::|=|->|\bis\b|\bequals\b)\s*([^\s,;|]+)"
+    ),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+)
+
+
+def safe_secret_value(value: str) -> bool:
+    candidate = value.strip("`'\".,()[]{}")
+    lowered = candidate.lower()
+    return (
+        not candidate
+        or candidate.startswith("<")
+        or candidate.startswith("${")
+        or candidate.startswith("$")
+        or lowered in {"redacted", "masked", "placeholder", "example", "none", "unset"}
+        or lowered.startswith(("redacted-", "example-", "placeholder-"))
+    )
+
+
+for pattern in secret_patterns:
+    for match in pattern.finditer(normalized):
+        if match.lastindex and safe_secret_value(match.group(1)):
+            continue
+        fail("Forbidden Phase 66 closeout evaluation: production secret-looking value detected")
+
+paragraphs = [
+    re.sub(r"\s+", " ", paragraph).strip()
+    for paragraph in re.split(r"\n\s*\n", rendered)
+    if paragraph.strip()
+]
+table_cells = [
+    cell.strip()
+    for line in rendered.splitlines()
+    if "|" in line
+    for cell in line.split("|")
+    if cell.strip()
+]
+sentences = [
+    sentence.strip()
+    for sentence in re.split(r"(?<=[.!?])\s+|[;\n]+", rendered)
+    if sentence.strip()
+]
+clauses: list[str] = []
+subject_boundary = (
+    r"(?:phase\s+66|aegisops|this\s+closeout|the\s+verdict|it\b|they\b|"
+    r"verifier|issue-lint|wazuh|shuffle|ai\s+output|reports?|support\s+bundles?)"
+)
+for segment in paragraphs + table_cells + sentences:
+    clauses.extend(
+        clause.strip()
+        for clause in re.split(
+            rf"\b(?:but|however|although|yet|whereas)\b|"
+            rf"\band\b(?=\s+{subject_boundary})|"
+            rf",\s*(?={subject_boundary})|[.!?;]+",
+            segment,
+            flags=re.IGNORECASE,
+        )
+        if clause.strip()
+    )
+
+denial_pattern = re.compile(
+    r"(?i)\b(?:does?\s+not|do\s+not|must\s+not|cannot|can['’]?t|"
+    r"without(?:\s+\w+){0,3}|not\s+(?:claim|prove|establish|accept|approve|"
+    r"authorize|grant|become|infer|promote|provide)|"
+    r"reject(?:s|ed|ing)?|exclud(?:e|es|ed|ing)|"
+    r"remain(?:s)?\s+(?:unproven|out\s+of\s+scope)|"
+    r"(?:is|are)\s+not|no\s+(?:ga|production|commercial|self-service|broad))\b"
+)
+
+for segment in paragraphs + table_cells + sentences:
+    lowered_segment = re.sub(r"\s+", " ", segment).lower()
+    if not denial_pattern.search(lowered_segment):
+        continue
+    if re.search(
+        r"(?i)(?:"
+        r"\b(?:but|yet|and|however)\b\s*"
+        r"(?:(?:phase\s+66|aegisops|this\s+closeout|the\s+verdict|it|they)\s+)?"
+        r"|(?:,|;)\s*"
+        r"(?:phase\s+66|aegisops|this\s+closeout|the\s+verdict|it|they)\s+"
+        r")"
+        r"(?:is|are|has\s+(?:achieved|established)|can|passes?|accepts?|approves?)"
+        r"\b.{0,80}\b(?:ga|general\s+availability|production\s+rollout|"
+        r"self-service\s+commercial|commercial\s+replacement|"
+        r"broad(?:\s+enterprise)?\s+(?:siem|soar))\b",
+        lowered_segment,
+    ):
+        fail(
+            "Forbidden Phase 66 closeout evaluation contradictory readiness "
+            f"claim: {segment.strip()}"
+        )
+
+for clause in clauses:
+    lowered = re.sub(r"\s+", " ", clause).lower()
+    if denial_pattern.search(lowered):
+        contradiction = re.search(
+            r"(?i)\b(?:but|yet|and)\s+(?:it\s+|they\s+)?"
+            r"(?:is|are|has\s+(?:achieved|established)|can)\b.{0,80}"
+            r"\b(?:ga|production\s+rollout|self-service\s+commercial|"
+            r"commercial\s+replacement|broad(?:\s+enterprise)?\s+(?:siem|soar))\b",
+            lowered,
+        )
+        if contradiction:
+            fail(
+                "Forbidden Phase 66 closeout evaluation contradictory readiness "
+                f"claim: {clause.strip()}"
+            )
+        continue
+
+    forbidden_claims = (
+        (
+            r"\b(?:phase\s+66|aegisops|this\s+closeout|the\s+verdict)\b"
+            r".{0,100}\b(?:ga|general\s+availability)\b.{0,80}"
+            r"\b(?:ready|readiness|accepted|passes?|passed|proves?|proven|"
+            r"satisfies?|approved|complete)\b"
+        ),
+        (
+            r"\b(?:phase\s+66|aegisops|this\s+closeout|the\s+verdict|it|they)\b"
+            r".{0,80}\b(?:is|are|becomes?|has\s+(?:achieved|established)|"
+            r"proves?|meets?|passes?|accepts?|approves?|qualifies?)\b.{0,80}"
+            r"\b(?:ga(?:\s+(?:ready|readiness|gate))?|general\s+availability|"
+            r"generally\s+available|ready\s+for\s+(?:ga|general\s+availability)|"
+            r"ready\s+for\s+production\s+rollout|production\s+rollout\s+readiness|"
+            r"self-service\s+commercial\s+readiness|commercial\s+replacement\s+readiness|"
+            r"broad(?:\s+enterprise)?\s+(?:siem|soar|siem/soar)\s+parity)\b"
+        ),
+        (
+            r"\b(?:ga|general\s+availability)\b.{0,80}"
+            r"\b(?:gate|readiness)\b.{0,50}"
+            r"\b(?:is|was|has\s+been)?\s*"
+            r"(?:accepted|passed|approved|proven|complete|achieved|established)\b"
+        ),
+        (
+            r"\b(?:ga\s+readiness|ga\s+gate|general\s+availability|"
+            r"production\s+rollout(?:\s+readiness)?|"
+            r"self-service\s+commercial\s+readiness|commercial\s+replacement\s+readiness|"
+            r"broad(?:\s+enterprise)?\s+(?:siem|soar|siem/soar)\s+parity)\b"
+            r".{0,50}\b(?:is|was|has\s+been)?\s*"
+            r"(?:ready|accepted|passed|approved|proven|complete|achieved|established)\b"
+        ),
+        (
+            r"\b(?:ready\s+for\s+(?:ga|general\s+availability|production\s+rollout)|"
+            r"generally\s+available)\b"
+        ),
+        (
+            r"\b(?:phase\s+66|aegisops|this\s+closeout|the\s+verdict)\b"
+            r".{0,100}\bproduction\b.{0,60}"
+            r"\b(?:rollout|deployment|support|launch)\b.{0,50}"
+            r"\b(?:ready|readiness|accepted|approved|proven|complete)\b"
+        ),
+        (
+            r"\b(?:self-service\s+commercial|commercial\s+replacement|"
+            r"broad(?:\s+enterprise)?\s+(?:siem|soar|siem/soar))\b.{0,80}"
+            r"\b(?:ready|readiness|parity|achieved|established|proven|complete)\b"
+        ),
+        (
+            r"\b(?:verifier|issue-lint)(?:\s+output|\s+success)?\b.{0,60}"
+            r"\b(?:is|becomes?|serves?\s+as|establishes?|proves?|passes?|accepts?)\b"
+            r".{0,60}"
+            r"\b(?:authoritative|truth|readiness|rc|ga|gate|release|closeout|"
+            r"workflow|limitation)\b"
+        ),
+        (
+            r"\b(?:wazuh(?:\s+signals?)?|shuffle(?:\s+receipts?)?|ai(?:\s+output|\s+traces?)?|"
+            r"reports?|support\s+bundles?|tickets?|ui\s+cache|demo\s+data|"
+            r"release\s+artifacts?)\b.{0,80}"
+            r"\b(?:is|are|becomes?|serve(?:s)?\s+as)\b.{0,60}"
+            r"\b(?:authoritative|truth|approval|execution|reconciliation|gate|readiness)\b"
+        ),
+        (
+            r"\b(?:closeout\s+text|release\s+artifacts?|wazuh(?:\s+signals?)?|"
+            r"shuffle(?:\s+receipts?)?|ai(?:\s+output|\s+traces?)?|reports?|"
+            r"support\s+bundles?|tickets?|optional\s+evidence|ui\s+cache|demo\s+data|"
+            r"verifier(?:\s+output)?|issue-lint(?:\s+output)?)\b.{0,80}"
+            r"\b(?:can|may|is\s+allowed\s+to|has\s+authority\s+to)\b.{0,60}"
+            r"\b(?:approve|execute|reconcile|close|accept|resolve|authorize|deploy|release)\b"
+        ),
+        (
+            r"\b(?:issue\s+closure|proof-file\s+presence|verifier\s+success|"
+            r"issue-lint\s+success)\b.{0,80}"
+            r"\b(?:proves?|accepts?|passes?|establishes?)\b.{0,60}"
+            r"\b(?:rc|ga|gate|readiness)\b"
+        ),
+    )
+    for pattern in forbidden_claims:
+        if re.search(pattern, lowered, flags=re.IGNORECASE):
+            fail(
+                "Forbidden Phase 66 closeout evaluation readiness or authority claim: "
+                f"{clause.strip()}"
+            )
+
+    if (
+        re.search(r"\b(?:raw|unredacted|customer[-\s]private)\b", lowered)
+        and re.search(
+            r"\b(?:customer|ticket|alert|log|chat|payload|export|record|data)\b",
+            lowered,
+        )
+        and re.search(
+            r"\b(?:includes?|contains?|embeds?|carries?|records?|publishes?|stores?)\b",
+            lowered,
+        )
+    ):
+        fail("Forbidden Phase 66 closeout evaluation: customer-private data detected")
+
+customer_identifier_pattern = re.compile(
+    r"(?i)\b(?:customer|tenant|account)[\s_-]*(?:id|identifier|email|phone)"
+    r"\s*(?::|=|->|\bis\b|\bequals\b)\s*([^\s,;|]+)"
+)
+for match in customer_identifier_pattern.finditer(normalized):
+    value = match.group(1).strip("`'\".,()[]{}")
+    if value.startswith(("<", "${", "$")) or value.lower().startswith(
+        ("redacted", "example", "placeholder")
+    ):
+        continue
+    fail("Forbidden Phase 66 closeout evaluation: customer-private data detected")
+
+for match in re.finditer(
+    r"(?i)\b[A-Z0-9._%+-]+@([A-Z0-9.-]+\.[A-Z]{2,})\b", normalized
+):
+    if match.group(1).lower().endswith(".invalid"):
+        continue
+    fail("Forbidden Phase 66 closeout evaluation: customer-private data detected")
+PY
+
+path_hygiene_stderr="${repo_root}/.tmp-phase66-8-path-hygiene.err"
+trap 'rm -f "${path_hygiene_stderr}"' EXIT
+if ! bash "${repo_root}/scripts/verify-publishable-path-hygiene.sh" "${repo_root}" \
+  >/dev/null 2>"${path_hygiene_stderr}"; then
+  cat "${path_hygiene_stderr}" >&2
+  echo "Forbidden Phase 66 closeout evaluation absolute path usage detected" >&2
+  exit 1
+fi
+
+echo "Phase 66.8 RC closeout evaluation contract and focused negative checks pass."


### PR DESCRIPTION
## Summary

- add the Phase 66.8 closeout evaluation with a bounded RC evidence verdict, child outcomes, recorded verifier and issue-lint results, accepted limitations, explicit non-claims, and Phase 67 handoff
- add a focused closeout verifier that requires the complete Phase 66 evidence chain and rejects GA/production/commercial overclaims, subordinate-evidence authority expansion, secrets, customer-private data, hidden evidence, and workstation-local paths
- add regression fixtures for missing, duplicated, commented, fenced, blockquoted, and semantically unsafe closeout content
- link the closeout from the canonical README surfaces

## Validation

- Phase 66.1-66.7 focused verifiers and self-tests
- `bash scripts/verify-phase-66-8-rc-closeout-evaluation.sh`
- `bash scripts/test-verify-phase-66-8-rc-closeout-evaluation.sh`
- `bash scripts/verify-phase-51-3-pilot-beta-rc-ga-gate-contract.sh`
- `bash scripts/verify-phase-51-6-authority-boundary-negative-test-policy.sh`
- `bash scripts/verify-maintainability-hotspots.sh`
- `bash scripts/verify-publishable-path-hygiene.sh`
- issue-lint for #1397 through #1405 (`execution_ready=yes`, no missing metadata or blocking ambiguity)
- `bash -n` for both new scripts and `git diff --check`

Closes #1405.