### PR TITLE
[codex] Preserve Shuffle worker spec during Phase 67 ownership claims

### DIFF
--- a/control-plane/deployment/phase-67-integration-lab/README.md
+++ b/control-plane/deployment/phase-67-integration-lab/README.md
@@ -53,6 +53,10 @@ and runtime image ID before and after the reviewed execution. The runner first
 proves that no `shuffle-workers` service exists, then binds the created service
 ID to the trial with ownership labels as soon as it appears; cleanup refuses to
 remove a service unless its ID, labels, and reviewed image still match.
+Because Shuffle 2.2.1 creates that service through Docker API v1.40 with both
+legacy service-level and task-level network fields, the ownership update
+round-trips the complete v1.40 spec and proves that every non-label field is
+unchanged. This avoids an implicit network migration or worker task restart.
 If startup fails before the first capture completes, cleanup may claim the new
 service only after the preflight absence and reviewed Orborus image both match.
 Component observation times separately retain the early Wazuh negative probes

--- a/control-plane/deployment/phase-67-integration-lab/RUNBOOK.md
+++ b/control-plane/deployment/phase-67-integration-lab/RUNBOOK.md
@@ -128,6 +128,11 @@ Before startup, the runner fails closed if a `shuffle-workers` service already
 exists. It separately inspects the service created after that preflight, binds
 its service ID immediately to the current trial with Phase, component, and
 trial-run labels, and verifies its sole running task container and image ID.
+Shuffle 2.2.1 creates a hybrid v1.40 Swarm spec containing both legacy
+service-level networks and task-level networks. The label claim therefore uses
+the selected context's verified local Unix socket to round-trip the complete
+v1.40 spec, and fails unless service ID, version, image, and every non-label
+field remain unchanged.
 If startup fails before this initial capture completes, cleanup claims the
 newly appeared service only when the preflight absence and reviewed Orborus
 image both match, then applies the same ID and ownership checks before removal.

--- a/control-plane/deployment/phase-67-integration-lab/e2e/update_swarm_service_labels.py
+++ b/control-plane/deployment/phase-67-integration-lab/e2e/update_swarm_service_labels.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from copy import deepcopy
+import http.client
+import json
+import os
+from pathlib import Path
+import re
+import socket
+import stat
+import subprocess
+import sys
+from typing import Any, Mapping
+from urllib.parse import quote, urlencode
+
+
+API_VERSION = "1.40"
+MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+SERVICE_ID_PATTERN = re.compile(r"^[a-z0-9]{12,64}$")
+IMMUTABLE_IMAGE_PATTERN = re.compile(
+    r"^[^\s@]+@sha256:[0-9a-f]{64}$"
+)
+CONTEXT_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+class SwarmLabelUpdateError(RuntimeError):
+    pass
+
+
+class UnixSocketHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, socket_path: Path, timeout: float) -> None:
+        super().__init__("localhost", timeout=timeout)
+        self.socket_path = socket_path
+
+    def connect(self) -> None:
+        connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        connection.settimeout(self.timeout)
+        connection.connect(os.fspath(self.socket_path))
+        self.sock = connection
+
+
+class DockerEngineAPI:
+    def __init__(self, socket_path: Path, timeout: float = 30.0) -> None:
+        self.socket_path = socket_path
+        self.timeout = timeout
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        payload: Mapping[str, Any] | None = None,
+    ) -> Any:
+        body = None
+        headers: dict[str, str] = {}
+        if payload is not None:
+            body = json.dumps(
+                payload,
+                ensure_ascii=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        connection = UnixSocketHTTPConnection(self.socket_path, self.timeout)
+        try:
+            connection.request(method, path, body=body, headers=headers)
+            response = connection.getresponse()
+            response_body = response.read(MAX_RESPONSE_BYTES + 1)
+        except (OSError, TimeoutError, http.client.HTTPException) as exc:
+            raise SwarmLabelUpdateError(
+                f"Docker Engine {method} {path} failed: {exc}"
+            ) from exc
+        finally:
+            connection.close()
+
+        if len(response_body) > MAX_RESPONSE_BYTES:
+            raise SwarmLabelUpdateError(
+                f"Docker Engine {method} {path} exceeded the response limit"
+            )
+        decoded: Any = None
+        if response_body:
+            try:
+                decoded = json.loads(response_body)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise SwarmLabelUpdateError(
+                    f"Docker Engine {method} {path} returned invalid JSON"
+                ) from exc
+        if not 200 <= response.status < 300:
+            message = (
+                decoded.get("message")
+                if isinstance(decoded, dict)
+                else response_body.decode("utf-8", errors="replace")
+            )
+            raise SwarmLabelUpdateError(
+                f"Docker Engine {method} {path} returned HTTP "
+                f"{response.status}: {message or response.reason}"
+            )
+        return decoded
+
+    def assert_api_version_supported(self) -> None:
+        version = _require_mapping(self._request_json("GET", "/version"), "version")
+        daemon_max = _parse_api_version(version.get("ApiVersion"), "ApiVersion")
+        daemon_min = _parse_api_version(
+            version.get("MinAPIVersion"),
+            "MinAPIVersion",
+        )
+        required = _parse_api_version(API_VERSION, "required API version")
+        if not daemon_min <= required <= daemon_max:
+            raise SwarmLabelUpdateError(
+                f"Docker Engine API v{API_VERSION} is outside daemon range "
+                f"{daemon_min[0]}.{daemon_min[1]}-"
+                f"{daemon_max[0]}.{daemon_max[1]}"
+            )
+
+    def get_service(self, service_id: str) -> Mapping[str, Any]:
+        path = f"/v{API_VERSION}/services/{quote(service_id, safe='')}"
+        return _require_mapping(self._request_json("GET", path), "service")
+
+    def update_service(
+        self,
+        service_id: str,
+        version: int,
+        spec: Mapping[str, Any],
+    ) -> None:
+        query = urlencode({"version": version})
+        path = (
+            f"/v{API_VERSION}/services/{quote(service_id, safe='')}/update?"
+            f"{query}"
+        )
+        result = self._request_json("POST", path, spec)
+        if result is None:
+            return
+        response = _require_mapping(result, "service update response")
+        warnings = response.get("Warnings")
+        if warnings not in (None, []):
+            raise SwarmLabelUpdateError(
+                f"Docker Engine service update returned warnings: {warnings}"
+            )
+
+
+def _require_mapping(value: Any, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, dict):
+        raise SwarmLabelUpdateError(f"Docker Engine {field} must be an object")
+    return value
+
+
+def _parse_api_version(value: Any, field: str) -> tuple[int, int]:
+    if not isinstance(value, str) or not re.fullmatch(r"\d+\.\d+", value):
+        raise SwarmLabelUpdateError(f"Docker Engine {field} is invalid")
+    major, minor = value.split(".", 1)
+    return int(major), int(minor)
+
+
+def _service_state(
+    service: Mapping[str, Any],
+    *,
+    expected_id: str,
+    expected_name: str,
+    expected_image: str,
+) -> tuple[int, dict[str, Any], dict[str, str]]:
+    if service.get("ID") != expected_id:
+        raise SwarmLabelUpdateError("Shuffle worker service ID changed")
+    version = _require_mapping(service.get("Version"), "service Version").get(
+        "Index"
+    )
+    if isinstance(version, bool) or not isinstance(version, int) or version < 1:
+        raise SwarmLabelUpdateError("Shuffle worker service version is invalid")
+    spec = deepcopy(dict(_require_mapping(service.get("Spec"), "service Spec")))
+    if spec.get("Name") != expected_name:
+        raise SwarmLabelUpdateError("Shuffle worker service name changed")
+    task_template = _require_mapping(
+        spec.get("TaskTemplate"),
+        "service TaskTemplate",
+    )
+    container_spec = _require_mapping(
+        task_template.get("ContainerSpec"),
+        "service ContainerSpec",
+    )
+    if container_spec.get("Image") != expected_image:
+        raise SwarmLabelUpdateError(
+            "Shuffle worker service is not pinned to the reviewed digest"
+        )
+    raw_labels = spec.get("Labels", {})
+    if not isinstance(raw_labels, dict) or not all(
+        isinstance(key, str) and isinstance(value, str)
+        for key, value in raw_labels.items()
+    ):
+        raise SwarmLabelUpdateError("Shuffle worker service labels are invalid")
+    return version, spec, dict(raw_labels)
+
+
+def claim_service_labels(
+    api: DockerEngineAPI,
+    *,
+    service_id: str,
+    expected_version: int,
+    expected_name: str,
+    expected_image: str,
+    labels: Mapping[str, str],
+) -> Mapping[str, Any]:
+    if not labels or not all(
+        isinstance(key, str)
+        and bool(key)
+        and isinstance(value, str)
+        and not any(ord(character) < 32 for character in key + value)
+        for key, value in labels.items()
+    ):
+        raise SwarmLabelUpdateError("ownership labels are invalid")
+    api.assert_api_version_supported()
+    before = api.get_service(service_id)
+    version, before_spec, before_labels = _service_state(
+        before,
+        expected_id=service_id,
+        expected_name=expected_name,
+        expected_image=expected_image,
+    )
+    if version != expected_version:
+        raise SwarmLabelUpdateError(
+            "Shuffle worker service changed before ownership could be claimed"
+        )
+    conflicting_keys = sorted(set(before_labels).intersection(labels))
+    if conflicting_keys:
+        raise SwarmLabelUpdateError(
+            "Shuffle worker service already carries ownership labels: "
+            + ", ".join(conflicting_keys)
+        )
+
+    expected_labels = {**before_labels, **labels}
+    updated_spec = deepcopy(before_spec)
+    updated_spec["Labels"] = expected_labels
+    before_nonlabel_spec = deepcopy(before_spec)
+    before_nonlabel_spec.pop("Labels", None)
+    updated_nonlabel_spec = deepcopy(updated_spec)
+    updated_nonlabel_spec.pop("Labels", None)
+    if updated_nonlabel_spec != before_nonlabel_spec:
+        raise SwarmLabelUpdateError(
+            "ownership update attempted to change the service specification"
+        )
+
+    api.update_service(service_id, version, updated_spec)
+    after = api.get_service(service_id)
+    after_version, after_spec, after_labels = _service_state(
+        after,
+        expected_id=service_id,
+        expected_name=expected_name,
+        expected_image=expected_image,
+    )
+    if after_version <= version:
+        raise SwarmLabelUpdateError(
+            "Shuffle worker service version did not advance after ownership update"
+        )
+    if after_labels != expected_labels:
+        raise SwarmLabelUpdateError(
+            "Shuffle worker service did not retain the exact ownership labels"
+        )
+    after_nonlabel_spec = deepcopy(after_spec)
+    after_nonlabel_spec.pop("Labels", None)
+    if after_nonlabel_spec != before_nonlabel_spec:
+        raise SwarmLabelUpdateError(
+            "Shuffle worker service changed outside ownership labels"
+        )
+    return {
+        "service_id": service_id,
+        "version_before": version,
+        "version_after": after_version,
+        "labels": expected_labels,
+    }
+
+
+def resolve_docker_socket(context: str) -> Path:
+    if not CONTEXT_NAME_PATTERN.fullmatch(context):
+        raise SwarmLabelUpdateError("Docker context name is invalid")
+    try:
+        completed = subprocess.run(
+            ["docker", "context", "inspect", context],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise SwarmLabelUpdateError(
+            f"cannot inspect Docker context {context}: {exc}"
+        ) from exc
+    if completed.returncode != 0:
+        diagnostic = completed.stderr.strip() or completed.stdout.strip()
+        raise SwarmLabelUpdateError(
+            f"cannot inspect Docker context {context}: {diagnostic}"
+        )
+    try:
+        contexts = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise SwarmLabelUpdateError(
+            f"Docker context {context} returned invalid JSON"
+        ) from exc
+    if not isinstance(contexts, list) or len(contexts) != 1:
+        raise SwarmLabelUpdateError(
+            f"Docker context {context} did not resolve uniquely"
+        )
+    metadata = _require_mapping(contexts[0], "context metadata")
+    if metadata.get("Name") != context:
+        raise SwarmLabelUpdateError("Docker context identity changed")
+    endpoints = _require_mapping(metadata.get("Endpoints"), "context Endpoints")
+    docker_endpoint = _require_mapping(
+        endpoints.get("docker"),
+        "context Docker endpoint",
+    )
+    host = docker_endpoint.get("Host")
+    if not isinstance(host, str) or not host.startswith("unix:///"):
+        raise SwarmLabelUpdateError(
+            "Phase 67.4 requires a local Unix-socket Docker context"
+        )
+    socket_path = Path(host.removeprefix("unix://")).resolve(strict=True)
+    if not socket_path.is_absolute() or not stat.S_ISSOCK(socket_path.stat().st_mode):
+        raise SwarmLabelUpdateError(
+            f"Docker context endpoint is not a Unix socket: {socket_path}"
+        )
+    return socket_path
+
+
+def _parse_label(raw: str) -> tuple[str, str]:
+    key, separator, value = raw.partition("=")
+    if not separator or not key or any(ord(character) < 32 for character in raw):
+        raise argparse.ArgumentTypeError("labels must use non-empty key=value form")
+    return key, value
+
+
+def _positive_timeout(raw: str) -> float:
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("timeout must be numeric") from exc
+    if not 0 < value <= 120:
+        raise argparse.ArgumentTypeError("timeout must be between 0 and 120 seconds")
+    return value
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Claim a Shuffle worker service without migrating its legacy "
+            "Swarm network specification."
+        )
+    )
+    parser.add_argument("--docker-context", required=True)
+    parser.add_argument("--service-id", required=True)
+    parser.add_argument("--expected-version", required=True, type=int)
+    parser.add_argument("--expected-name", required=True)
+    parser.add_argument("--expected-image", required=True)
+    parser.add_argument(
+        "--label",
+        action="append",
+        required=True,
+        type=_parse_label,
+        metavar="KEY=VALUE",
+    )
+    parser.add_argument("--timeout", type=_positive_timeout, default=30.0)
+    args = parser.parse_args(argv)
+    if not SERVICE_ID_PATTERN.fullmatch(args.service_id):
+        parser.error("--service-id is not a Swarm service ID")
+    if args.expected_version < 1:
+        parser.error("--expected-version must be positive")
+    if not IMMUTABLE_IMAGE_PATTERN.fullmatch(args.expected_image):
+        parser.error("--expected-image must be a digest-pinned image reference")
+    label_keys = [key for key, _ in args.label]
+    if len(label_keys) != len(set(label_keys)):
+        parser.error("--label keys must be unique")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        socket_path = resolve_docker_socket(args.docker_context)
+        result = claim_service_labels(
+            DockerEngineAPI(socket_path, timeout=args.timeout),
+            service_id=args.service_id,
+            expected_version=args.expected_version,
+            expected_name=args.expected_name,
+            expected_image=args.expected_image,
+            labels=dict(args.label),
+        )
+    except (OSError, ValueError, SwarmLabelUpdateError) as exc:
+        print(f"Swarm ownership update failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/control-plane/deployment/phase-67-integration-lab/run-e2e-trial.sh
+++ b/control-plane/deployment/phase-67-integration-lab/run-e2e-trial.sh
@@ -46,6 +46,7 @@ shuffle_action_publish_spec="$(
 schema="${LAB_DIR}/e2e/evidence-manifest.schema.json"
 validator="${LAB_DIR}/e2e/validate_evidence_manifest.py"
 builder="${LAB_DIR}/e2e/build_evidence.py"
+swarm_service_labeler="${LAB_DIR}/e2e/update_swarm_service_labels.py"
 evaluation="${REPO_ROOT}/docs/phase-67-prerequisite-evaluation.md"
 reviewed_workflow="${LAB_DIR}/shuffle/harmless-local-log-workflow.json"
 workflow_validator="${LAB_DIR}/shuffle/validate_preserved_workflow.py"
@@ -345,8 +346,12 @@ shuffle_worker_service_is_trial_owned() {
   [[ -n "${shuffle_worker_service_id}" ]] \
     && jq -e \
       --arg service_id "${shuffle_worker_service_id}" \
+      --arg service_name "${shuffle_worker_service}" \
+      --arg service_image "${shuffle_worker_immutable_ref}" \
       --arg trial_run_id "${trial_run_id}" '
         .[0].ID == $service_id
+        and .[0].Spec.Name == $service_name
+        and .[0].Spec.TaskTemplate.ContainerSpec.Image == $service_image
         and .[0].Spec.Labels["com.aegisops.lab.phase"] == "67.4"
         and .[0].Spec.Labels["com.aegisops.lab.component"]
           == "shuffle-worker-image"
@@ -355,10 +360,48 @@ shuffle_worker_service_is_trial_owned() {
       ' <<<"${service_metadata}" >/dev/null
 }
 
+shuffle_worker_service_matches_attempted_claim() {
+  local before_metadata="$1"
+  local after_metadata="$2"
+
+  jq -e -s \
+    --arg service_id "${shuffle_worker_service_id}" \
+    --arg service_name "${shuffle_worker_service}" \
+    --arg service_image "${shuffle_worker_immutable_ref}" \
+    --arg trial_run_id "${trial_run_id}" '
+      .[0][0] as $before
+      | .[1][0] as $after
+      | $before.ID == $service_id
+        and $after.ID == $service_id
+        and $after.Version.Index > $before.Version.Index
+        and $after.Spec.Name == $service_name
+        and $after.Spec.TaskTemplate.ContainerSpec.Image == $service_image
+        and (
+          ($after.Spec.Labels // {})
+          == (
+            ($before.Spec.Labels // {})
+            + {
+                "com.aegisops.lab.phase": "67.4",
+                "com.aegisops.lab.component": "shuffle-worker-image",
+                "com.aegisops.lab.trial-run-id": $trial_run_id
+              }
+          )
+        )
+        and (
+          ($after.Spec | del(.Labels))
+          == ($before.Spec | del(.Labels))
+        )
+    ' \
+    <(printf '%s\n' "${before_metadata}") \
+    <(printf '%s\n' "${after_metadata}") \
+    >/dev/null
+}
+
 claim_reviewed_shuffle_worker_service() {
   local service_metadata="$1"
   local service_id
   local service_image
+  local service_version
   local owned_metadata
 
   if [[ "${shuffle_worker_owned}" == true ]]; then
@@ -373,8 +416,9 @@ claim_reviewed_shuffle_worker_service() {
     return 1
   fi
   if ! jq -e '
-    (.[0].Spec.Labels["com.aegisops.lab.trial-run-id"] // "") == ""
+    (.[0].Spec.Labels["com.aegisops.lab.phase"] // "") == ""
     and (.[0].Spec.Labels["com.aegisops.lab.component"] // "") == ""
+    and (.[0].Spec.Labels["com.aegisops.lab.trial-run-id"] // "") == ""
   ' <<<"${service_metadata}" >/dev/null; then
     echo "BLOCKED: new Shuffle worker service already carries ownership labels" >&2
     return 1
@@ -394,13 +438,32 @@ claim_reviewed_shuffle_worker_service() {
     echo "BLOCKED: Shuffle worker service is not pinned to the reviewed digest" >&2
     return 1
   fi
+  if ! service_version="$(
+    jq -er '
+      .[0].Version.Index
+      | select(type == "number" and . >= 1 and floor == .)
+    ' <<<"${service_metadata}"
+  )"; then
+    echo "BLOCKED: new Shuffle worker service has no stable service version" >&2
+    return 1
+  fi
   shuffle_worker_service_id="${service_id}"
-  if ! docker_lab service update \
-    --detach=true \
-    --label-add "com.aegisops.lab.phase=67.4" \
-    --label-add "com.aegisops.lab.component=shuffle-worker-image" \
-    --label-add "com.aegisops.lab.trial-run-id=${trial_run_id}" \
-    "${service_id}" >/dev/null; then
+  if ! python3 "${swarm_service_labeler}" \
+    --docker-context "${AEGISOPS_LAB_DOCKER_CONTEXT}" \
+    --service-id "${service_id}" \
+    --expected-version "${service_version}" \
+    --expected-name "${shuffle_worker_service}" \
+    --expected-image "${shuffle_worker_immutable_ref}" \
+    --label "com.aegisops.lab.phase=67.4" \
+    --label "com.aegisops.lab.component=shuffle-worker-image" \
+    --label "com.aegisops.lab.trial-run-id=${trial_run_id}" \
+    >/dev/null; then
+    if owned_metadata="$(
+      docker_lab service inspect "${shuffle_worker_service_id}" 2>/dev/null
+    )" && shuffle_worker_service_matches_attempted_claim \
+      "${service_metadata}" "${owned_metadata}"; then
+      shuffle_worker_owned=true
+    fi
     echo "BLOCKED: failed to label the new Shuffle worker service" >&2
     return 1
   fi

--- a/control-plane/tests/test_phase67_4_real_service_e2e.py
+++ b/control-plane/tests/test_phase67_4_real_service_e2e.py
@@ -44,7 +44,78 @@ builder = _load_module(
     "phase67_4_evidence_builder",
     E2E_ROOT / "build_evidence.py",
 )
+swarm_labeler = _load_module(
+    "phase67_4_swarm_service_labeler",
+    E2E_ROOT / "update_swarm_service_labels.py",
+)
 SCHEMA = validator.load_json(E2E_ROOT / "evidence-manifest.schema.json")
+
+
+class _FakeDockerEngine:
+    def __init__(self, service: dict, after_update=None) -> None:
+        self.service = deepcopy(service)
+        self.after_update = after_update
+        self.api_checked = False
+        self.updated_spec: dict | None = None
+
+    def assert_api_version_supported(self) -> None:
+        self.api_checked = True
+
+    def get_service(self, service_id: str) -> dict:
+        if self.service["ID"] != service_id:
+            raise AssertionError("unexpected service ID")
+        return deepcopy(self.service)
+
+    def update_service(
+        self,
+        service_id: str,
+        version: int,
+        spec: dict,
+    ) -> None:
+        if self.service["ID"] != service_id:
+            raise AssertionError("unexpected service ID")
+        if self.service["Version"]["Index"] != version:
+            raise AssertionError("unexpected service version")
+        self.updated_spec = deepcopy(spec)
+        self.service["Spec"] = deepcopy(spec)
+        self.service["Version"]["Index"] += 1
+        if self.after_update is not None:
+            self.after_update(self.service)
+
+
+def _hybrid_network_worker_service() -> dict:
+    return {
+        "ID": "wo7au34eetl5tc0id1jzxxu9e",
+        "Version": {"Index": 2342226},
+        "Spec": {
+            "Name": "shuffle-workers",
+            "Labels": {"shuffle-existing": "retained"},
+            "TaskTemplate": {
+                "ContainerSpec": {
+                    "Image": (
+                        "ghcr.io/shuffle/shuffle-worker:2.2.1@sha256:"
+                        + "9" * 64
+                    )
+                },
+                "Networks": [{"Target": "shuffle-overlay"}],
+            },
+            "Networks": [
+                {"Target": "shuffle-overlay"},
+                {"Target": "ingress"},
+            ],
+            "EndpointSpec": {
+                "Mode": "vip",
+                "Ports": [
+                    {
+                        "Protocol": "tcp",
+                        "TargetPort": 33333,
+                        "PublishedPort": 33333,
+                        "PublishMode": "ingress",
+                    }
+                ],
+            },
+        },
+    }
 
 
 def _manifest() -> dict[str, object]:
@@ -3456,6 +3527,190 @@ class Phase674RealServiceE2ETests(unittest.TestCase):
                     identifiers,
                 )
 
+    def test_swarm_label_claim_preserves_hybrid_network_spec(self) -> None:
+        service = _hybrid_network_worker_service()
+        api = _FakeDockerEngine(service)
+        labels = {
+            "com.aegisops.lab.phase": "67.4",
+            "com.aegisops.lab.component": "shuffle-worker-image",
+            "com.aegisops.lab.trial-run-id": "phase67-e2e-test",
+        }
+
+        result = swarm_labeler.claim_service_labels(
+            api,
+            service_id=service["ID"],
+            expected_version=service["Version"]["Index"],
+            expected_name=service["Spec"]["Name"],
+            expected_image=service["Spec"]["TaskTemplate"]["ContainerSpec"][
+                "Image"
+            ],
+            labels=labels,
+        )
+
+        self.assertTrue(api.api_checked)
+        self.assertIsNotNone(api.updated_spec)
+        assert api.updated_spec is not None
+        self.assertEqual(
+            api.updated_spec["TaskTemplate"]["Networks"],
+            service["Spec"]["TaskTemplate"]["Networks"],
+        )
+        self.assertEqual(
+            api.updated_spec["Networks"],
+            service["Spec"]["Networks"],
+        )
+        expected_spec = deepcopy(service["Spec"])
+        expected_spec["Labels"].update(labels)
+        self.assertEqual(api.updated_spec, expected_spec)
+        self.assertEqual(result["version_before"], 2342226)
+        self.assertEqual(result["version_after"], 2342227)
+
+    def test_swarm_label_claim_rejects_stale_or_preowned_service(self) -> None:
+        service = _hybrid_network_worker_service()
+        arguments = {
+            "service_id": service["ID"],
+            "expected_name": service["Spec"]["Name"],
+            "expected_image": service["Spec"]["TaskTemplate"]["ContainerSpec"][
+                "Image"
+            ],
+            "labels": {"com.aegisops.lab.phase": "67.4"},
+        }
+        with self.assertRaisesRegex(
+            swarm_labeler.SwarmLabelUpdateError,
+            "changed before ownership",
+        ):
+            swarm_labeler.claim_service_labels(
+                _FakeDockerEngine(service),
+                expected_version=service["Version"]["Index"] - 1,
+                **arguments,
+            )
+
+        service["Spec"]["Labels"]["com.aegisops.lab.phase"] = "unknown"
+        with self.assertRaisesRegex(
+            swarm_labeler.SwarmLabelUpdateError,
+            "already carries ownership labels",
+        ):
+            swarm_labeler.claim_service_labels(
+                _FakeDockerEngine(service),
+                expected_version=service["Version"]["Index"],
+                **arguments,
+            )
+
+    def test_swarm_label_claim_rejects_nonlabel_daemon_mutation(self) -> None:
+        service = _hybrid_network_worker_service()
+
+        def mutate_network(updated_service: dict) -> None:
+            updated_service["Spec"]["TaskTemplate"]["Networks"].append(
+                {"Target": "unexpected-overlay"}
+            )
+
+        with self.assertRaisesRegex(
+            swarm_labeler.SwarmLabelUpdateError,
+            "changed outside ownership labels",
+        ):
+            swarm_labeler.claim_service_labels(
+                _FakeDockerEngine(service, after_update=mutate_network),
+                service_id=service["ID"],
+                expected_version=service["Version"]["Index"],
+                expected_name=service["Spec"]["Name"],
+                expected_image=service["Spec"]["TaskTemplate"][
+                    "ContainerSpec"
+                ]["Image"],
+                labels={"com.aegisops.lab.phase": "67.4"},
+            )
+
+    def test_swarm_labeler_uses_the_v140_engine_update_endpoint(self) -> None:
+        requests: list[tuple[str, str, object, dict[str, str]]] = []
+        response_payloads = [
+            {"ApiVersion": "1.51", "MinAPIVersion": "1.24"},
+            {"ID": "wo7au34eetl5tc0id1jzxxu9e"},
+            {"Warnings": None},
+            {"Warnings": ["unexpected daemon warning"]},
+        ]
+
+        class FakeConnection:
+            def __init__(self, _socket_path: Path, _timeout: float) -> None:
+                pass
+
+            def request(
+                self,
+                method: str,
+                path: str,
+                body=None,
+                headers=None,
+            ) -> None:
+                requests.append((method, path, body, headers or {}))
+
+            def getresponse(self):
+                payload = json.dumps(response_payloads.pop(0)).encode("utf-8")
+                return SimpleNamespace(
+                    status=200,
+                    reason="OK",
+                    read=lambda _limit: payload,
+                )
+
+            def close(self) -> None:
+                pass
+
+        original_connection = swarm_labeler.UnixSocketHTTPConnection
+        swarm_labeler.UnixSocketHTTPConnection = FakeConnection
+        try:
+            api = swarm_labeler.DockerEngineAPI(Path("/unused/docker.sock"))
+            api.assert_api_version_supported()
+            self.assertEqual(
+                api.get_service("wo7au34eetl5tc0id1jzxxu9e"),
+                {"ID": "wo7au34eetl5tc0id1jzxxu9e"},
+            )
+            spec = {"Name": "shuffle-workers", "Labels": {"owner": "trial"}}
+            api.update_service("wo7au34eetl5tc0id1jzxxu9e", 42, spec)
+            with self.assertRaisesRegex(
+                swarm_labeler.SwarmLabelUpdateError,
+                "returned warnings",
+            ):
+                api.update_service("wo7au34eetl5tc0id1jzxxu9e", 43, spec)
+        finally:
+            swarm_labeler.UnixSocketHTTPConnection = original_connection
+
+        self.assertEqual(requests[0][0:2], ("GET", "/version"))
+        self.assertEqual(
+            requests[1][0:2],
+            (
+                "GET",
+                "/v1.40/services/wo7au34eetl5tc0id1jzxxu9e",
+            ),
+        )
+        self.assertEqual(
+            requests[2][0:2],
+            (
+                "POST",
+                "/v1.40/services/wo7au34eetl5tc0id1jzxxu9e/update?version=42",
+            ),
+        )
+        self.assertEqual(json.loads(requests[2][2]), spec)
+        self.assertEqual(
+            requests[2][3],
+            {"Content-Type": "application/json"},
+        )
+
+    def test_swarm_labeler_rejects_non_unix_docker_context(self) -> None:
+        context = {
+            "Name": "remote-context",
+            "Endpoints": {"docker": {"Host": "tcp://docker.example:2376"}},
+        }
+        original_run = swarm_labeler.subprocess.run
+        swarm_labeler.subprocess.run = lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps([context]),
+            stderr="",
+        )
+        try:
+            with self.assertRaisesRegex(
+                swarm_labeler.SwarmLabelUpdateError,
+                "local Unix-socket Docker context",
+            ):
+                swarm_labeler.resolve_docker_socket("remote-context")
+        finally:
+            swarm_labeler.subprocess.run = original_run
+
     def test_operator_runner_binds_full_scope_restart_and_cleanup(self) -> None:
         runner = (LAB_ROOT / "run-e2e-trial.sh").read_text(encoding="utf-8")
         compose = (LAB_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
@@ -3607,6 +3862,10 @@ class Phase674RealServiceE2ETests(unittest.TestCase):
         self.assertIn("claim_reviewed_shuffle_worker_service()", runner)
         self.assertIn("shuffle_worker_service_is_trial_owned()", runner)
         self.assertIn(
+            "shuffle_worker_service_matches_attempted_claim()",
+            runner,
+        )
+        self.assertIn(
             "com.aegisops.lab.trial-run-id=${trial_run_id}",
             runner,
         )
@@ -3656,7 +3915,20 @@ class Phase674RealServiceE2ETests(unittest.TestCase):
             worker_claim.index(
                 '[[ "${service_image}" != "${shuffle_worker_immutable_ref}" ]]'
             ),
-            worker_claim.index("docker_lab service update"),
+            worker_claim.index('python3 "${swarm_service_labeler}"'),
+        )
+        self.assertIn(
+            '--expected-version "${service_version}"',
+            worker_claim,
+        )
+        self.assertIn(
+            '--docker-context "${AEGISOPS_LAB_DOCKER_CONTEXT}"',
+            worker_claim,
+        )
+        self.assertNotIn("docker_lab service update", worker_claim)
+        self.assertIn(
+            "shuffle_worker_service_matches_attempted_claim",
+            worker_claim,
         )
         self.assertLess(
             worker_claim.index('shuffle_worker_service_id="${service_id}"'),

--- a/scripts/verify-phase-67-4-real-service-e2e.sh
+++ b/scripts/verify-phase-67-4-real-service-e2e.sh
@@ -8,6 +8,7 @@ e2e_root="${lab_root}/e2e"
 schema="${e2e_root}/evidence-manifest.schema.json"
 sample="${e2e_root}/sample-evidence.json"
 validator="${e2e_root}/validate_evidence_manifest.py"
+swarm_service_labeler="${e2e_root}/update_swarm_service_labels.py"
 evaluation="${repo_root}/docs/phase-67-prerequisite-evaluation.md"
 
 fail() {
@@ -43,6 +44,7 @@ for path in \
   "${validator}" \
   "${e2e_root}/build_evidence.py" \
   "${e2e_root}/run_real_journey.py" \
+  "${swarm_service_labeler}" \
   "${lab_root}/run-e2e-trial.sh" \
   "${evaluation}" \
   "${repo_root}/control-plane/tests/test_phase67_4_real_service_e2e.py"; do
@@ -53,6 +55,7 @@ for path in \
   "${validator}" \
   "${e2e_root}/build_evidence.py" \
   "${e2e_root}/run_real_journey.py" \
+  "${swarm_service_labeler}" \
   "${lab_root}/run-e2e-trial.sh"; do
   require_executable "${path}"
 done
@@ -314,6 +317,10 @@ require_fixed "${lab_root}/run-e2e-trial.sh" 'configured_shuffle_worker_immutabl
 require_fixed "${lab_root}/run-e2e-trial.sh" 'assert_shuffle_worker_service_absent'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'claim_reviewed_shuffle_worker_service'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'shuffle_worker_service_is_trial_owned'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'shuffle_worker_service_matches_attempted_claim'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'python3 "${swarm_service_labeler}"'
+require_fixed "${lab_root}/run-e2e-trial.sh" '--expected-version "${service_version}"'
+reject_fixed "${lab_root}/run-e2e-trial.sh" 'docker_lab service update'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'com.aegisops.lab.trial-run-id=${trial_run_id}'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'without current-trial ownership'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'remove_reviewed_shuffle_worker_service'
@@ -321,6 +328,12 @@ require_fixed "${lab_root}/run-e2e-trial.sh" 'docker_lab service rm "${shuffle_w
 require_fixed "${lab_root}/run-e2e-trial.sh" 'initial Shuffle worker cleanup claim did not complete'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'refusing to claim an unverified Shuffle worker service during cleanup'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'label=com.docker.swarm.service.name=${shuffle_worker_service}'
+require_fixed "${swarm_service_labeler}" 'API_VERSION = "1.40"'
+require_fixed "${swarm_service_labeler}" 'docker", "context", "inspect", context'
+require_fixed "${swarm_service_labeler}" 'host.startswith("unix:///")'
+require_fixed "${swarm_service_labeler}" 'updated_nonlabel_spec != before_nonlabel_spec'
+require_fixed "${swarm_service_labeler}" 'after_nonlabel_spec != before_nonlabel_spec'
+require_fixed "${swarm_service_labeler}" 'after_labels != expected_labels'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'run_reviewed_journey'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'Shuffle action image identity changed after the trial snapshot'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'compose_scope full ps -aq'


### PR DESCRIPTION
## Summary

- replace the Phase 67.4 Shuffle worker label claim with a Docker Engine API v1.40 update that round-trips the complete current service spec
- verify the selected Docker context resolves to a local Unix socket, reject version/image/ownership drift, and prove every non-label field is unchanged after the update
- add hybrid `Spec.Networks` / `TaskTemplate.Networks` regression coverage, verifier assertions, and operator documentation

## Why

The real-service trial exposed a Shuffle 2.2.1 / modern Docker CLI compatibility failure. Orborus creates `shuffle-workers` through API v1.40 with both legacy service-level networks and task-level networks. A label-only `docker service update` drops the legacy field and Docker rejects the update with:

```
networks must be migrated to TaskSpec before being changed
```

The new helper submits the complete v1.40 spec with only ownership labels changed, avoiding an implicit network migration.

## Validation

- `python3 -m unittest discover -s control-plane/tests -p 'test_*.py'` (1596 tests)
- Phase 67.1-67.4 verifiers and adversarial self-tests
- Phase 67.4 verifier and self-test rerun after final changes
- shell/Python syntax checks and `git diff --check`
- live Colima proof against the failed-trial `shuffle-workers` service:
  - update HTTP 200, version advanced
  - non-label spec remained equal
  - legacy networks remained 2 and task networks remained 1
  - running task and container IDs remained unchanged
- removed the five failed-trial orphan Swarm services after verification

## Issue relationship

Unblocks #1418.

This PR intentionally does not close #1418. A passing evidence packet still requires rerunning the complete trial from merged `main` and the distinct local operator must approve the macOS approval dialog.