### PR TITLE
Harden Phase 67 Shuffle service lifecycle

### DIFF
--- a/control-plane/deployment/phase-67-integration-lab/README.md
+++ b/control-plane/deployment/phase-67-integration-lab/README.md
@@ -200,12 +200,17 @@ the snapshot. The inventory includes the configured dynamic Shuffle worker
 image and the action tag's observed repository digest and runtime image ID
 because neither dynamic image is guaranteed to appear in the pre-dispatch
 Compose container enumeration. Before startup, the runner proves that no
-`shuffle-tools_1-2-0` service exists, then creates the reviewed Shuffle Tools
-Swarm service directly from the immutable digest rather than leaving Orborus to
-resolve a mutable tag. It binds the returned service ID to the current trial
-with ownership labels and removes only that ID after revalidating its labels and
-image. It verifies the service task's
-actual image ID before and after approved execution. After approval, the runner
+`shuffle-tools_1-2-0` service exists, then waits for the Shuffle 2.2.1 worker to
+auto-create it. The runner derives the actual `shuffle_swarm_executions` overlay
+ID from the worker service, validates the exact callback, dynamically allocated
+`app-port`, and running task image ID, and observes an unchanged service ID,
+version, and non-label specification twice. It then claims ownership labels by
+round-tripping the complete service specification and revalidates the runtime
+image ID. Cleanup records the exact worker and action IDs and specifications,
+stops Compose and Orborus, then removes only those unchanged IDs after rejecting
+disappearance or replacement. The restart check removes both stopped services,
+re-proves their absence, and separately claims the newly auto-created worker and
+action services before continuing. After approval, the runner
 also rechecks that action identity and the complete repository snapshot
 immediately before dispatch.
 Startup, initial health,
@@ -237,13 +242,12 @@ The Wazuh intake harness is retained as a prerequisite subtrial whose trigger,
 admission, replay, and boundary-probe timestamps remain verbatim in
 `wazuh-output.txt`. Ordered steps 12 and 13 use only the later Shuffle receipt
 replay and receipt negative probes, so earlier Wazuh operations are not
-relabeled as later journey events. Publication prepares permissions and moves
-the report and raw artifact directory first; the passing manifest is moved last
-and partial publication is rolled back when that final commit cannot complete.
-The final manifest path is validated again after the move, and the separately
-published report plus the complete artifact file set are rehashed against that
-manifest. Success therefore refers to the exact published bytes rather than an
-earlier staging-path read.
+relabeled as later journey events. Publication stages the manifest under a
+hidden candidate path, then moves the report and raw artifact directory. The
+candidate manifest, published report, and complete published artifact set are
+validated and rehashed before an atomic no-clobber link exposes the passing
+manifest at its canonical path as the last commit point. Failure before that
+commit leaves no discoverable passing manifest.
 
 Use `status.sh [scope] [--write-evidence]`, `logs.sh [service ...]`, and the bounded tail controlled by `AEGISOPS_LAB_LOG_TAIL` for inspection. Log tails must be integers from 1 through 10000. See [RUNBOOK.md](RUNBOOK.md) for startup, evidence, troubleshooting, and teardown details.
 

--- a/control-plane/deployment/phase-67-integration-lab/RUNBOOK.md
+++ b/control-plane/deployment/phase-67-integration-lab/RUNBOOK.md
@@ -117,13 +117,18 @@ Immediately before dispatch, the runner reloads the denied request and decision
 from PostgreSQL and recounts its executions; any lifecycle change or execution
 blocks the trial.
 Before startup, the runner fails closed if a `shuffle-tools_1-2-0` Swarm
-service already exists. It creates that service from the reviewed repository
-digest, records the returned service ID, and labels it with the current trial
-identity. The service and its running task must retain that ID, all ownership
-labels, the reviewed digest, and image ID before approval and again after
-execution; the mutable compatibility tag is not the execution reference.
-Cleanup removes only that recorded service ID after revalidating its labels and
-image, so a pre-existing or replacement service cannot be adopted or removed.
+service already exists. It waits for the Shuffle 2.2.1 worker to auto-create
+that service, derives the actual `shuffle_swarm_executions` overlay ID from the
+worker service, and verifies its exact callback, one dynamically allocated
+`app-port`, and running task image ID against the reviewed digest. Only after
+two identical observations of the service ID, version, and non-label spec does
+the runner claim trial ownership by round-tripping the complete v1.40 spec.
+It revalidates the runtime image ID after the claim and before cleanup. Cleanup
+captures the exact service ID and specification, stops Compose and Orborus, and
+only then removes that unchanged ID. The restart check removes both stopped
+services, re-proves their absence, and separately claims the newly auto-created
+worker and action services. Disappearance or name-to-ID replacement is rejected
+so a pre-existing or replacement service cannot be adopted or removed.
 Before startup, the runner fails closed if a `shuffle-workers` service already
 exists. It separately inspects the service created after that preflight, binds
 its service ID immediately to the current trial with Phase, component, and
@@ -133,9 +138,10 @@ service-level networks and task-level networks. The label claim therefore uses
 the selected context's verified local Unix socket to round-trip the complete
 v1.40 spec, and fails unless service ID, version, image, and every non-label
 field remain unchanged.
-If startup fails before this initial capture completes, cleanup claims the
-newly appeared service only when the preflight absence and reviewed Orborus
-image both match, then applies the same ID and ownership checks before removal.
+If startup fails before the initial ownership claim completes, cleanup records
+the newly appeared exact service ID and specification only when preflight
+absence, reviewed image, and Orborus contract match. It stops Orborus, proves
+the same ID and specification remain, and only then removes that candidate.
 After dispatch, the same owned service and worker image identity must remain in
 place and the running task container's logs must contain the current Shuffle
 execution ID. Receipt success is timestamped only after its authenticated
@@ -214,13 +220,12 @@ restart. The snapshot inventory includes observed runtime image IDs for both
 the digest-pinned Shuffle worker task and the Shuffle action service. After
 operator approval, the runner revalidates the live workflow and both runtime
 image identities, then checks the complete repository snapshot immediately
-before dispatch. For publication, report and raw artifacts are moved only
-after every destination is checked, and the passing manifest is moved last.
-The final manifest path is validated once more after that move. The final report
-and exact artifact file set are then rehashed from their published paths against
-the manifest before it is made read-only and success is declared. Failure before
-that validation restores the unpublished packet where possible and never leaves
-a discoverable passing manifest with missing references.
+before dispatch. For publication, the manifest is first staged at a hidden
+candidate path. After every destination is checked, the report and raw artifacts
+are moved and rehashed from their published paths against that candidate. Only
+after the candidate is made read-only does an atomic no-clobber link expose it
+at the canonical manifest path as the final commit point. Failure before that
+commit never leaves a discoverable passing manifest with missing references.
 The prepare, approved execution, and restart-verification commands all enter
 the bind-mounted journey runner through one helper that checks the captured
 repository revision and complete worktree immediately before container

--- a/control-plane/deployment/phase-67-integration-lab/e2e/update_swarm_service_labels.py
+++ b/control-plane/deployment/phase-67-integration-lab/e2e/update_swarm_service_labels.py
@@ -161,15 +161,15 @@ def _service_state(
     expected_image: str,
 ) -> tuple[int, dict[str, Any], dict[str, str]]:
     if service.get("ID") != expected_id:
-        raise SwarmLabelUpdateError("Shuffle worker service ID changed")
+        raise SwarmLabelUpdateError("Shuffle service ID changed")
     version = _require_mapping(service.get("Version"), "service Version").get(
         "Index"
     )
     if isinstance(version, bool) or not isinstance(version, int) or version < 1:
-        raise SwarmLabelUpdateError("Shuffle worker service version is invalid")
+        raise SwarmLabelUpdateError("Shuffle service version is invalid")
     spec = deepcopy(dict(_require_mapping(service.get("Spec"), "service Spec")))
     if spec.get("Name") != expected_name:
-        raise SwarmLabelUpdateError("Shuffle worker service name changed")
+        raise SwarmLabelUpdateError("Shuffle service name changed")
     task_template = _require_mapping(
         spec.get("TaskTemplate"),
         "service TaskTemplate",
@@ -180,14 +180,14 @@ def _service_state(
     )
     if container_spec.get("Image") != expected_image:
         raise SwarmLabelUpdateError(
-            "Shuffle worker service is not pinned to the reviewed digest"
+            "Shuffle service image does not match the expected reference"
         )
     raw_labels = spec.get("Labels", {})
     if not isinstance(raw_labels, dict) or not all(
         isinstance(key, str) and isinstance(value, str)
         for key, value in raw_labels.items()
     ):
-        raise SwarmLabelUpdateError("Shuffle worker service labels are invalid")
+        raise SwarmLabelUpdateError("Shuffle service labels are invalid")
     return version, spec, dict(raw_labels)
 
 
@@ -218,12 +218,12 @@ def claim_service_labels(
     )
     if version != expected_version:
         raise SwarmLabelUpdateError(
-            "Shuffle worker service changed before ownership could be claimed"
+            "Shuffle service changed before ownership could be claimed"
         )
     conflicting_keys = sorted(set(before_labels).intersection(labels))
     if conflicting_keys:
         raise SwarmLabelUpdateError(
-            "Shuffle worker service already carries ownership labels: "
+            "Shuffle service already carries ownership labels: "
             + ", ".join(conflicting_keys)
         )
 
@@ -249,17 +249,17 @@ def claim_service_labels(
     )
     if after_version <= version:
         raise SwarmLabelUpdateError(
-            "Shuffle worker service version did not advance after ownership update"
+            "Shuffle service version did not advance after ownership update"
         )
     if after_labels != expected_labels:
         raise SwarmLabelUpdateError(
-            "Shuffle worker service did not retain the exact ownership labels"
+            "Shuffle service did not retain the exact ownership labels"
         )
     after_nonlabel_spec = deepcopy(after_spec)
     after_nonlabel_spec.pop("Labels", None)
     if after_nonlabel_spec != before_nonlabel_spec:
         raise SwarmLabelUpdateError(
-            "Shuffle worker service changed outside ownership labels"
+            "Shuffle service changed outside ownership labels"
         )
     return {
         "service_id": service_id,
@@ -340,8 +340,10 @@ def _positive_timeout(raw: str) -> float:
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Claim a Shuffle worker service without migrating its legacy "
-            "Swarm network specification."
+            "Claim a Shuffle-created service without migrating its legacy "
+            "Swarm network specification. Callers that admit an observed "
+            "tag-only image reference must independently verify the running "
+            "task's runtime image ID before and after this helper runs."
         )
     )
     parser.add_argument("--docker-context", required=True)
@@ -349,6 +351,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--expected-version", required=True, type=int)
     parser.add_argument("--expected-name", required=True)
     parser.add_argument("--expected-image", required=True)
+    parser.add_argument(
+        "--allow-observed-image-reference-after-runtime-id-verification",
+        action="store_true",
+        help=(
+            "admit the exact observed service image string when the caller "
+            "has already verified the running task image ID against a "
+            "reviewed digest and will verify it again after the update"
+        ),
+    )
     parser.add_argument(
         "--label",
         action="append",
@@ -362,8 +373,20 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         parser.error("--service-id is not a Swarm service ID")
     if args.expected_version < 1:
         parser.error("--expected-version must be positive")
-    if not IMMUTABLE_IMAGE_PATTERN.fullmatch(args.expected_image):
+    if (
+        not args.allow_observed_image_reference_after_runtime_id_verification
+        and not IMMUTABLE_IMAGE_PATTERN.fullmatch(args.expected_image)
+    ):
         parser.error("--expected-image must be a digest-pinned image reference")
+    if (
+        args.allow_observed_image_reference_after_runtime_id_verification
+        and (
+            not isinstance(args.expected_image, str)
+            or not args.expected_image
+            or any(character.isspace() for character in args.expected_image)
+        )
+    ):
+        parser.error("--expected-image must be an observed image reference")
     label_keys = [key for key, _ in args.label]
     if len(label_keys) != len(set(label_keys)):
         parser.error("--label keys must be unique")

--- a/control-plane/deployment/phase-67-integration-lab/run-e2e-trial.sh
+++ b/control-plane/deployment/phase-67-integration-lab/run-e2e-trial.sh
@@ -14,6 +14,7 @@ require_command jq
 require_command openssl
 require_command python3
 require_command curl
+require_command ln
 require_runtime_environment
 [[ "${AEGISOPS_LAB_SHUFFLE_TRANSPORT_MODE:-}" == "real_http" ]] \
   || fail "real Shuffle transport is not enabled; run ${LAB_DIR}/bootstrap-shuffle.sh"
@@ -26,22 +27,23 @@ shuffle_action_service="shuffle-tools_1-2-0"
 shuffle_action_preflight_absent=false
 shuffle_action_owned=false
 shuffle_action_service_id=""
+shuffle_action_service_image=""
+shuffle_action_service_port=""
+shuffle_action_network_id=""
+shuffle_action_cleanup_candidate_id=""
+shuffle_action_cleanup_candidate_spec=""
 shuffle_worker_service="shuffle-workers"
+shuffle_worker_network="shuffle_swarm_executions"
 shuffle_worker_immutable_ref=""
 shuffle_worker_preflight_absent=false
 shuffle_worker_owned=false
 shuffle_worker_service_id=""
+shuffle_worker_cleanup_candidate_id=""
+shuffle_worker_cleanup_candidate_spec=""
 captured_shuffle_worker_image_json=""
-shuffle_action_service_port=33334
-shuffle_action_network="shuffle-executions"
 shuffle_backend_url="$(
   printf 'http://%s-shuffle-backend-1:5001' \
     "${AEGISOPS_LAB_COMPOSE_PROJECT_NAME:-aegisops-phase67-lab}"
-)"
-shuffle_action_publish_spec="$(
-  printf 'name=app-port,published=%s,target=%s,protocol=tcp,mode=ingress' \
-    "${shuffle_action_service_port}" \
-    "${shuffle_action_service_port}"
 )"
 schema="${LAB_DIR}/e2e/evidence-manifest.schema.json"
 validator="${LAB_DIR}/e2e/validate_evidence_manifest.py"
@@ -96,85 +98,255 @@ run_reviewed_lab_startup() {
   "$@"
 }
 
-assert_reviewed_shuffle_action_service() {
-  local service_metadata
-  local service_image
+shuffle_action_runtime_matches_reviewed_image() {
+  local service_id="$1"
+  local service_metadata="$2"
+  local replicas
   local task_ids
   local task_metadata
   local task_container_ids
   local container_metadata
   local pinned_image_id
 
-  [[ "${shuffle_action_owned}" == true ]] \
-    && [[ -n "${shuffle_action_service_id}" ]] \
-    || fail "Shuffle action service is not owned by the current trial"
-  service_metadata="$(
-    docker_lab service inspect "${shuffle_action_service_id}"
-  )"
-  service_image="$(
-    jq -er '.[0].Spec.TaskTemplate.ContainerSpec.Image' \
-      <<<"${service_metadata}"
-  )"
-  [[ "${service_image}" == "${shuffle_tools_immutable_ref}" ]] \
-    || fail "Shuffle action service is not pinned to the reviewed digest"
-  jq -e \
-    --arg phase "67.4" \
-    --arg component "shuffle-action-image" \
-    --arg trial_run_id "${trial_run_id}" \
-    --arg service_id "${shuffle_action_service_id}" \
-    --argjson port "${shuffle_action_service_port}" '
-      .[0] as $service
-      | $service.ID == $service_id
-      and $service.Spec.Labels["com.aegisops.lab.phase"] == $phase
-      and $service.Spec.Labels["com.aegisops.lab.component"] == $component
-      and $service.Spec.Labels["com.aegisops.lab.trial-run-id"]
-        == $trial_run_id
-      and $service.Spec.Mode.Replicated.Replicas == 1
-      and (
-        [
-          $service.Endpoint.Spec.Ports[]
-          | select(
-              .Name == "app-port"
-              and .PublishedPort == $port
-              and .TargetPort == $port
-            )
-        ]
-        | length == 1
-      )
-    ' <<<"${service_metadata}" >/dev/null \
-    || fail "Shuffle action service does not match the reviewed lab contract"
-
+  replicas="$(
+    jq -er '
+      .[0].Spec.Mode.Replicated.Replicas
+      | select(type == "number" and . >= 1 and floor == .)
+    ' <<<"${service_metadata}"
+  )" || return 1
   task_ids="$(
     docker_lab service ps \
       --filter desired-state=running \
       --quiet \
-      "${shuffle_action_service_id}"
-  )"
-  [[ "$(wc -w <<<"${task_ids}")" -eq 1 ]] \
-    || fail "Shuffle action service does not have exactly one running task"
-  task_metadata="$(docker_lab inspect "${task_ids}")"
-  jq -e '
-    length == 1 and all(.[]; .Status.State == "running")
-  ' <<<"${task_metadata}" >/dev/null \
-    || fail "Shuffle action task is not running"
+      "${service_id}" 2>/dev/null
+  )" || return 1
+  [[ "$(wc -w <<<"${task_ids}")" -eq "${replicas}" ]] || return 1
+  # shellcheck disable=SC2086
+  task_metadata="$(docker_lab inspect ${task_ids} 2>/dev/null)" || return 1
+  jq -e \
+    --arg service_id "${service_id}" \
+    --argjson replicas "${replicas}" '
+      length == $replicas
+      and all(.[];
+        .ServiceID == $service_id
+        and .DesiredState == "running"
+        and .Status.State == "running"
+        and (
+          (.Status.ContainerStatus.ContainerID // "")
+          | type == "string" and length > 0
+        )
+      )
+    ' <<<"${task_metadata}" >/dev/null || return 1
   task_container_ids="$(
-    jq -er '
-      [.[].Status.ContainerStatus.ContainerID | select(length > 0)]
-      | if length == 1 then .[]
-        else error("expected one Shuffle action task container")
-        end
-    ' <<<"${task_metadata}"
-  )"
-  container_metadata="$(docker_lab inspect "${task_container_ids}")"
+    jq -er '.[].Status.ContainerStatus.ContainerID' <<<"${task_metadata}"
+  )" || return 1
+  # shellcheck disable=SC2086
+  container_metadata="$(
+    docker_lab inspect ${task_container_ids} 2>/dev/null
+  )" || return 1
   pinned_image_id="$(
     docker_lab image inspect \
       "${shuffle_tools_immutable_ref}" \
-      --format '{{.Id}}'
-  )"
-  jq -e --arg image_id "${pinned_image_id}" '
-    length == 1 and all(.[]; .Image == $image_id)
-  ' <<<"${container_metadata}" >/dev/null \
-    || fail "Shuffle action task did not use the reviewed image ID"
+      --format '{{.Id}}' 2>/dev/null
+  )" || return 1
+  jq -e \
+    --arg image_id "${pinned_image_id}" \
+    --argjson replicas "${replicas}" '
+      length == $replicas and all(.[]; .Image == $image_id)
+    ' <<<"${container_metadata}" >/dev/null
+}
+
+derive_reviewed_shuffle_action_network_id() {
+  local worker_metadata
+  local network_ids
+  local network_id
+  local network_metadata
+
+  [[ -n "${shuffle_worker_service_id}" ]] || return 1
+  worker_metadata="$(
+    docker_lab service inspect "${shuffle_worker_service_id}" 2>/dev/null
+  )" || return 1
+  network_ids="$(
+    jq -er '
+      [.[0].Spec.Networks[]?.Target
+        | select(type == "string" and length > 0)]
+      | unique
+      | if length > 0 then .[]
+        else error("worker service has no execution-network candidates")
+        end
+    ' <<<"${worker_metadata}"
+  )" || return 1
+  # shellcheck disable=SC2086
+  network_metadata="$(docker_lab network inspect ${network_ids} 2>/dev/null)" \
+    || return 1
+  network_id="$(
+    jq -er '
+      [
+        .[]
+        | select(
+            .Name == "shuffle_swarm_executions"
+            and .Scope == "swarm"
+            and .Driver == "overlay"
+            and .Ingress == false
+            and (.Id | type == "string" and length > 0)
+          )
+        | .Id
+      ]
+      | unique
+      | if length == 1 then .[0]
+        else error("expected one reviewed worker execution network")
+        end
+    ' <<<"${network_metadata}"
+  )" || return 1
+  printf '%s\n' "${network_id}"
+}
+
+shuffle_action_unowned_service_matches_contract() {
+  local service_metadata="$1"
+  local network_id="$2"
+
+  jq -e \
+    --arg service_name "${shuffle_action_service}" \
+    --arg callback_url "${shuffle_backend_url}" \
+    --arg network_id "${network_id}" '
+      length == 1
+      and (.[0].ID | type == "string" and length > 0)
+      and .[0].Spec.Name == $service_name
+      and ((.[0].Spec.Labels // {}) | type == "object")
+      and ((.[0].Spec.Labels // {})
+        | has("com.aegisops.lab.phase") | not)
+      and ((.[0].Spec.Labels // {})
+        | has("com.aegisops.lab.component") | not)
+      and ((.[0].Spec.Labels // {})
+        | has("com.aegisops.lab.trial-run-id") | not)
+      and (
+        .[0].Spec.TaskTemplate.ContainerSpec.Image
+        | type == "string" and length > 0 and (test("\\s") | not)
+      )
+      and (
+        [.[0].Spec.TaskTemplate.ContainerSpec.Env[]?
+          | select(startswith("CALLBACK_URL="))] as $callbacks
+        | ($callbacks | length) == 1
+          and $callbacks[0] == ("CALLBACK_URL=" + $callback_url)
+      )
+      and (
+        [.[0].Spec.Networks[]?.Target] | unique
+      ) == [$network_id]
+      and ((.[0].Spec.EndpointSpec.Ports // []) as $ports
+        | ($ports | length) == 1
+        and $ports[0].Name == "app-port"
+        and $ports[0].Protocol == "tcp"
+        and $ports[0].PublishMode == "ingress"
+        and ($ports[0].PublishedPort
+          | type == "number" and . > 0 and floor == .)
+        and ($ports[0].TargetPort
+          | type == "number" and . > 0 and floor == .))
+    ' <<<"${service_metadata}" >/dev/null
+}
+
+shuffle_action_service_observation_is_stable() {
+  local before_metadata="$1"
+  local after_metadata="$2"
+
+  jq -e -s '
+    .[0][0] as $before
+    | .[1][0] as $after
+    | $before.ID == $after.ID
+      and $before.Version.Index == $after.Version.Index
+      and (($before.Spec | del(.Labels)) == ($after.Spec | del(.Labels)))
+  ' \
+    <(printf '%s\n' "${before_metadata}") \
+    <(printf '%s\n' "${after_metadata}") \
+    >/dev/null
+}
+
+shuffle_action_service_matches_attempted_claim() {
+  local before_metadata="$1"
+  local after_metadata="$2"
+
+  jq -e -s \
+    --arg service_id "${shuffle_action_service_id}" \
+    --arg trial_run_id "${trial_run_id}" '
+      .[0][0] as $before
+      | .[1][0] as $after
+      | $before.ID == $service_id
+        and $after.ID == $service_id
+        and $after.Version.Index > $before.Version.Index
+        and (
+          ($after.Spec.Labels // {})
+          == (
+            ($before.Spec.Labels // {})
+            + {
+                "com.aegisops.lab.phase": "67.4",
+                "com.aegisops.lab.component": "shuffle-action-image",
+                "com.aegisops.lab.trial-run-id": $trial_run_id
+              }
+          )
+        )
+        and (($after.Spec | del(.Labels)) == ($before.Spec | del(.Labels)))
+    ' \
+    <(printf '%s\n' "${before_metadata}") \
+    <(printf '%s\n' "${after_metadata}") \
+    >/dev/null
+}
+
+assert_reviewed_shuffle_action_service() {
+  local service_metadata
+  local named_metadata
+
+  [[ "${shuffle_action_owned}" == true ]] \
+    && [[ -n "${shuffle_action_service_id}" ]] \
+    && [[ -n "${shuffle_action_service_image}" ]] \
+    && [[ -n "${shuffle_action_service_port}" ]] \
+    && [[ -n "${shuffle_action_network_id}" ]] \
+    || fail "Shuffle action service is not owned by the current trial"
+  service_metadata="$(
+    docker_lab service inspect "${shuffle_action_service_id}" 2>/dev/null
+  )" || fail "owned Shuffle action service disappeared"
+  named_metadata="$(
+    docker_lab service inspect "${shuffle_action_service}" 2>/dev/null
+  )" || fail "Shuffle action service name no longer resolves to the owned service"
+  jq -e \
+    --arg service_id "${shuffle_action_service_id}" \
+    --arg service_name "${shuffle_action_service}" \
+    --arg service_image "${shuffle_action_service_image}" \
+    --arg trial_run_id "${trial_run_id}" \
+    --arg callback_url "${shuffle_backend_url}" \
+    --arg network_id "${shuffle_action_network_id}" \
+    --argjson port "${shuffle_action_service_port}" '
+      length == 1
+      and .[0].ID == $service_id
+      and .[0].Spec.Name == $service_name
+      and .[0].Spec.TaskTemplate.ContainerSpec.Image == $service_image
+      and .[0].Spec.Labels["com.aegisops.lab.phase"] == "67.4"
+      and .[0].Spec.Labels["com.aegisops.lab.component"]
+        == "shuffle-action-image"
+      and .[0].Spec.Labels["com.aegisops.lab.trial-run-id"] == $trial_run_id
+      and (
+        [.[0].Spec.TaskTemplate.ContainerSpec.Env[]?
+          | select(startswith("CALLBACK_URL="))] as $callbacks
+        | ($callbacks | length) == 1
+          and $callbacks[0] == ("CALLBACK_URL=" + $callback_url)
+      )
+      and ([.[0].Spec.Networks[]?.Target] | unique) == [$network_id]
+      and ((.[0].Spec.EndpointSpec.Ports // []) as $ports
+        | ($ports | length) == 1
+        and $ports[0].Name == "app-port"
+        and $ports[0].Protocol == "tcp"
+        and $ports[0].PublishMode == "ingress"
+        and $ports[0].PublishedPort == $port
+        and ($ports[0].TargetPort
+          | type == "number" and . > 0 and floor == .))
+    ' <<<"${service_metadata}" >/dev/null \
+    || fail "Shuffle action service does not match the reviewed lab contract"
+  jq -e \
+    --arg service_id "${shuffle_action_service_id}" '
+      length == 1 and .[0].ID == $service_id
+    ' <<<"${named_metadata}" >/dev/null \
+    || fail "Shuffle action service name now resolves to a replacement service"
+  shuffle_action_runtime_matches_reviewed_image \
+    "${shuffle_action_service_id}" "${service_metadata}" \
+    || fail "Shuffle action tasks did not retain the reviewed image ID"
 }
 
 assert_shuffle_action_service_absent() {
@@ -191,107 +363,245 @@ assert_shuffle_action_service_absent() {
 
 ensure_reviewed_shuffle_action_service() {
   local attempt
+  local candidate_id=""
+  local current_metadata=""
+  local previous_metadata=""
+  local owned_metadata
+  local service_version
+  local stable=false
 
   assert_repository_snapshot
   [[ "${shuffle_action_preflight_absent}" == true ]] \
     || fail "Shuffle action service absence was not established before startup"
-  for attempt in {1..60}; do
-    if docker_lab network inspect "${shuffle_action_network}" >/dev/null 2>&1; then
-      break
-    fi
-    sleep 1
-  done
-  docker_lab network inspect "${shuffle_action_network}" >/dev/null 2>&1 \
-    || fail "Shuffle execution network was not initialized"
-
-  ! docker_lab service inspect "${shuffle_action_service}" >/dev/null 2>&1 \
-    || fail "Shuffle action service appeared after the preflight absence check"
-
-  shuffle_action_service_id="$(docker_lab service create \
-    --detach=true \
-    --quiet \
-    --name "${shuffle_action_service}" \
-    --label com.aegisops.lab.phase=67.4 \
-    --label com.aegisops.lab.component=shuffle-action-image \
-    --label "com.aegisops.lab.trial-run-id=${trial_run_id}" \
-    --network "${shuffle_action_network}" \
-    --publish "${shuffle_action_publish_spec}" \
-    --replicas 1 \
-    --restart-condition any \
-    --log-driver json-file \
-    --log-opt max-size=10m \
-    --env "SHUFFLE_APP_EXPOSED_PORT=${shuffle_action_service_port}" \
-    --env SHUFFLE_SWARM_CONFIG=run \
-    --env SHUFFLE_LOGS_DISABLED=true \
-    --env "CALLBACK_URL=${shuffle_backend_url}" \
-    --env "BASE_URL=${shuffle_backend_url}" \
-    --env DOCKER_API_VERSION=1.40 \
-    --env SHUFFLE_APP_SDK_TIMEOUT=300 \
-    --env TZ=Europe/Amsterdam \
-    "${shuffle_tools_immutable_ref}")"
-  [[ -n "${shuffle_action_service_id}" ]] \
-    || fail "Shuffle action service creation did not return a service ID"
-  shuffle_action_owned=true
-
   for attempt in {1..120}; do
-    if [[ "$(
-      docker_lab service ps \
-        --filter desired-state=running \
-        --format '{{.CurrentState}}' \
-        "${shuffle_action_service_id}" 2>/dev/null \
-        | sed -n '/^Running /p' \
-        | wc -l \
-        | tr -d ' '
-    )" -eq 1 ]]; then
+    if shuffle_action_network_id="$(
+      derive_reviewed_shuffle_action_network_id
+    )"; then
       break
     fi
     sleep 1
   done
+  [[ -n "${shuffle_action_network_id}" ]] \
+    || fail "Shuffle worker execution network did not stabilize"
+  for attempt in {1..120}; do
+    if ! current_metadata="$(
+      docker_lab service inspect "${shuffle_action_service}" 2>/dev/null
+    )"; then
+      if [[ -n "${candidate_id}" ]]; then
+        fail "Shuffle action service disappeared before ownership was claimed"
+      fi
+      sleep 1
+      continue
+    fi
+    if ! shuffle_action_unowned_service_matches_contract \
+      "${current_metadata}" "${shuffle_action_network_id}"; then
+      fail "new Shuffle action service does not match the Orborus contract"
+    fi
+    shuffle_action_service_id="$(jq -er '.[0].ID' <<<"${current_metadata}")"
+    if [[ -z "${candidate_id}" ]]; then
+      candidate_id="${shuffle_action_service_id}"
+    elif [[ "${shuffle_action_service_id}" != "${candidate_id}" ]]; then
+      fail "Shuffle action service was replaced before ownership was claimed"
+    fi
+    if ! shuffle_action_runtime_matches_reviewed_image \
+      "${shuffle_action_service_id}" "${current_metadata}"; then
+      sleep 1
+      continue
+    fi
+    if [[ -n "${previous_metadata}" ]] \
+      && shuffle_action_service_observation_is_stable \
+        "${previous_metadata}" "${current_metadata}"; then
+      stable=true
+      break
+    fi
+    previous_metadata="${current_metadata}"
+    sleep 1
+  done
+  [[ "${stable}" == true ]] \
+    || fail "Shuffle action service did not reach a stable unowned state"
+  shuffle_action_service_image="$(
+    jq -er '.[0].Spec.TaskTemplate.ContainerSpec.Image' \
+      <<<"${current_metadata}"
+  )"
+  shuffle_action_service_port="$(
+    jq -er '
+      [.[0].Spec.EndpointSpec.Ports[]? | select(.Name == "app-port")]
+      | if length == 1 then .[0].PublishedPort
+        else error("expected one app-port")
+        end
+    ' <<<"${current_metadata}"
+  )"
+  service_version="$(jq -er '.[0].Version.Index' <<<"${current_metadata}")"
+  if ! python3 "${swarm_service_labeler}" \
+    --docker-context "${AEGISOPS_LAB_DOCKER_CONTEXT}" \
+    --service-id "${shuffle_action_service_id}" \
+    --expected-version "${service_version}" \
+    --expected-name "${shuffle_action_service}" \
+    --expected-image "${shuffle_action_service_image}" \
+    --allow-observed-image-reference-after-runtime-id-verification \
+    --label "com.aegisops.lab.phase=67.4" \
+    --label "com.aegisops.lab.component=shuffle-action-image" \
+    --label "com.aegisops.lab.trial-run-id=${trial_run_id}" \
+    >/dev/null; then
+    if owned_metadata="$(
+      docker_lab service inspect "${shuffle_action_service_id}" 2>/dev/null
+    )" && shuffle_action_service_matches_attempted_claim \
+      "${current_metadata}" "${owned_metadata}" \
+      && shuffle_action_runtime_matches_reviewed_image \
+        "${shuffle_action_service_id}" "${owned_metadata}"; then
+      shuffle_action_owned=true
+      assert_reviewed_shuffle_action_service
+      return
+    fi
+    fail "failed to claim the Orborus-created Shuffle action service"
+  fi
+  shuffle_action_owned=true
   assert_reviewed_shuffle_action_service
 }
 
-remove_reviewed_shuffle_action_service() {
+wait_for_exact_swarm_service_removal() {
+  local service_id="$1"
   local attempt
-  local owned_service_id
-  local service_metadata
+  local task_container_ids
 
-  [[ "${shuffle_action_owned}" == true ]] \
-    && [[ -n "${shuffle_action_service_id}" ]] \
-    || return
-  owned_service_id="${shuffle_action_service_id}"
-  if ! service_metadata="$(
-    docker_lab service inspect "${owned_service_id}" 2>/dev/null
-  )"; then
-    return
-  fi
-  jq -e \
-    --arg service_id "${owned_service_id}" \
-    --arg trial_run_id "${trial_run_id}" \
-    --arg image "${shuffle_tools_immutable_ref}" '
-    .[0].ID == $service_id
-    and .[0].Spec.Labels["com.aegisops.lab.phase"] == "67.4"
-    and .[0].Spec.Labels["com.aegisops.lab.component"]
-      == "shuffle-action-image"
-    and .[0].Spec.Labels["com.aegisops.lab.trial-run-id"] == $trial_run_id
-    and .[0].Spec.TaskTemplate.ContainerSpec.Image == $image
-  ' <<<"${service_metadata}" >/dev/null \
-    || fail "refusing to remove an unowned Shuffle action service"
-  docker_lab service rm "${owned_service_id}" >/dev/null
   for attempt in {1..60}; do
-    if [[ -z "$(
+    if docker_lab service inspect "${service_id}" >/dev/null 2>&1; then
+      sleep 1
+      continue
+    fi
+    if ! task_container_ids="$(
       docker_lab ps \
         --all \
         --quiet \
-        --filter \
-          "label=com.docker.swarm.service.id=${owned_service_id}"
-    )" ]]; then
-      shuffle_action_owned=false
-      shuffle_action_service_id=""
-      return
+        --filter "label=com.docker.swarm.service.id=${service_id}"
+    )"; then
+      sleep 1
+      continue
     fi
+    [[ -z "${task_container_ids}" ]] && return
     sleep 1
   done
-  fail "Shuffle action service tasks did not stop during cleanup"
+  echo "BLOCKED: Swarm service ${service_id} tasks did not stop during cleanup" >&2
+  return 1
+}
+
+capture_reviewed_shuffle_action_cleanup_candidate() {
+  local candidate_id
+  local current_spec
+  local network_id="${shuffle_action_network_id}"
+  local service_image
+  local service_metadata
+
+  [[ "${shuffle_action_preflight_absent}" == true ]] || return
+  if [[ -n "${shuffle_action_service_id}" ]]; then
+    candidate_id="${shuffle_action_service_id}"
+    service_metadata="$(
+      docker_lab service inspect "${candidate_id}" 2>/dev/null
+    )" || return
+  else
+    service_metadata="$(
+      docker_lab service inspect "${shuffle_action_service}" 2>/dev/null
+    )" || return
+    candidate_id="$(jq -er '.[0].ID' <<<"${service_metadata}")" || return 1
+  fi
+  [[ "${candidate_id}" =~ ^[a-z0-9]{12,64}$ ]] || return 1
+  jq -e \
+    --arg service_id "${candidate_id}" \
+    --arg service_name "${shuffle_action_service}" '
+      length == 1
+      and .[0].ID == $service_id
+      and .[0].Spec.Name == $service_name
+    ' <<<"${service_metadata}" >/dev/null || return 1
+  if [[ -z "${network_id}" ]]; then
+    network_id="$(derive_reviewed_shuffle_action_network_id)" || return 1
+  fi
+  if [[ "${shuffle_action_owned}" == true ]]; then
+    jq -e \
+      --arg service_id "${candidate_id}" \
+      --arg service_image "${shuffle_action_service_image}" \
+      --arg trial_run_id "${trial_run_id}" '
+        .[0].ID == $service_id
+        and .[0].Spec.TaskTemplate.ContainerSpec.Image == $service_image
+        and .[0].Spec.Labels["com.aegisops.lab.phase"] == "67.4"
+        and .[0].Spec.Labels["com.aegisops.lab.component"]
+          == "shuffle-action-image"
+        and .[0].Spec.Labels["com.aegisops.lab.trial-run-id"]
+          == $trial_run_id
+      ' <<<"${service_metadata}" >/dev/null || return 1
+    shuffle_action_runtime_matches_reviewed_image \
+      "${candidate_id}" "${service_metadata}" || return 1
+  else
+    shuffle_action_unowned_service_matches_contract \
+      "${service_metadata}" "${network_id}" || return 1
+    service_image="$(
+      jq -er '.[0].Spec.TaskTemplate.ContainerSpec.Image' \
+        <<<"${service_metadata}"
+    )" || return 1
+    [[ "${service_image}" == "${shuffle_tools_image}" ]] || return 1
+  fi
+  current_spec="$(jq -cS '.[0].Spec' <<<"${service_metadata}")" || return 1
+  shuffle_action_service_id="${candidate_id}"
+  shuffle_action_network_id="${network_id}"
+  shuffle_action_cleanup_candidate_id="${candidate_id}"
+  shuffle_action_cleanup_candidate_spec="${current_spec}"
+}
+
+remove_reviewed_shuffle_action_service() {
+  local current_spec
+  local named_metadata
+  local service_metadata
+
+  [[ -n "${shuffle_action_cleanup_candidate_id}" ]] || return
+  service_metadata="$(
+    docker_lab service inspect \
+      "${shuffle_action_cleanup_candidate_id}" 2>/dev/null
+  )" || {
+    if ! wait_for_exact_swarm_service_removal \
+      "${shuffle_action_cleanup_candidate_id}"; then
+      return 1
+    fi
+    if named_metadata="$(
+      docker_lab service inspect "${shuffle_action_service}" 2>/dev/null
+    )"; then
+      echo "BLOCKED: a replacement Shuffle action service appeared during cleanup" >&2
+      return 1
+    fi
+    shuffle_action_cleanup_candidate_id=""
+    shuffle_action_cleanup_candidate_spec=""
+    return
+  }
+  current_spec="$(jq -cS '.[0].Spec' <<<"${service_metadata}")" || return 1
+  [[ "${current_spec}" == "${shuffle_action_cleanup_candidate_spec}" ]] \
+    || {
+      echo "BLOCKED: refusing to remove a changed Shuffle action service" >&2
+      return 1
+    }
+  jq -e \
+    --arg service_id "${shuffle_action_cleanup_candidate_id}" \
+    --arg service_name "${shuffle_action_service}" '
+      length == 1
+      and .[0].ID == $service_id
+      and .[0].Spec.Name == $service_name
+    ' <<<"${service_metadata}" >/dev/null || {
+      echo "BLOCKED: refusing to remove a replaced Shuffle action service" >&2
+      return 1
+    }
+  docker_lab service rm "${shuffle_action_cleanup_candidate_id}" >/dev/null
+  wait_for_exact_swarm_service_removal \
+    "${shuffle_action_cleanup_candidate_id}"
+  if named_metadata="$(
+    docker_lab service inspect "${shuffle_action_service}" 2>/dev/null
+  )"; then
+    echo "BLOCKED: a replacement Shuffle action service appeared during cleanup" >&2
+    return 1
+  fi
+  shuffle_action_owned=false
+  shuffle_action_service_id=""
+  shuffle_action_service_image=""
+  shuffle_action_service_port=""
+  shuffle_action_network_id=""
+  shuffle_action_cleanup_candidate_id=""
+  shuffle_action_cleanup_candidate_spec=""
 }
 
 configured_shuffle_worker_immutable_ref() {
@@ -397,11 +707,194 @@ shuffle_worker_service_matches_attempted_claim() {
     >/dev/null
 }
 
+resolve_reviewed_shuffle_worker_network_id() {
+  local service_id="$1"
+  local attempt
+  local network_id
+  local network_metadata
+  local service_metadata
+
+  for attempt in {1..120}; do
+    if ! service_metadata="$(
+      docker_lab service inspect "${service_id}" 2>/dev/null
+    )"; then
+      echo "BLOCKED: Shuffle worker service ID disappeared before network stabilization" >&2
+      return 1
+    fi
+    if ! shuffle_worker_service_is_unowned_candidate \
+      "${service_metadata}" "${service_id}"; then
+      echo "BLOCKED: Shuffle worker service identity or ownership changed before network stabilization" >&2
+      return 1
+    fi
+    if ! network_id="$(
+      jq -er '
+        (.[0].Spec.TaskTemplate.Networks // []) as $networks
+        | if (($networks | type) != "array") then
+            error("worker task networks are not an array")
+          elif ($networks | length) == 0 then "pending"
+          elif (
+            ($networks | length) == 1
+            and (($networks[0] | type) == "object")
+            and (
+              $networks[0].Target
+              | type == "string" and test("^[a-z0-9]{12,64}$")
+            )
+          ) then $networks[0].Target
+          else error("expected one worker task network target")
+        end
+      ' <<<"${service_metadata}" 2>/dev/null
+    )"; then
+      echo "BLOCKED: Shuffle worker task network specification is invalid" >&2
+      return 1
+    fi
+    if [[ "${network_id}" == "pending" ]]; then
+      sleep 1
+      continue
+    fi
+    if ! network_metadata="$(
+      docker_lab network inspect "${network_id}" 2>/dev/null
+    )" || ! jq -e \
+      --arg network_id "${network_id}" \
+      --arg network_name "${shuffle_worker_network}" '
+        length == 1
+        and .[0].Id == $network_id
+        and .[0].Name == $network_name
+        and .[0].Scope == "swarm"
+        and .[0].Driver == "overlay"
+      ' <<<"${network_metadata}" >/dev/null; then
+      echo "BLOCKED: Shuffle worker task network is not the expected Swarm overlay" >&2
+      return 1
+    fi
+    printf '%s\n' "${network_id}"
+    return
+  done
+  echo "BLOCKED: Shuffle worker overlay network was not created" >&2
+  return 1
+}
+
+shuffle_worker_service_is_unowned_candidate() {
+  local service_metadata="$1"
+  local service_id="$2"
+
+  jq -e \
+    --arg service_id "${service_id}" \
+    --arg service_name "${shuffle_worker_service}" \
+    --arg service_image "${shuffle_worker_immutable_ref}" '
+      length == 1
+      and .[0].ID == $service_id
+      and ($service_id | test("^[a-z0-9]{12,64}$"))
+      and (
+        .[0].Version.Index
+        | type == "number" and . >= 1 and floor == .
+      )
+      and .[0].Spec.Name == $service_name
+      and .[0].Spec.TaskTemplate.ContainerSpec.Image == $service_image
+      and (
+        (.[0].Spec.Labels // {}) as $labels
+        | ($labels | type == "object") and ($labels | length) == 0
+      )
+    ' <<<"${service_metadata}" >/dev/null
+}
+
+wait_for_stable_reviewed_shuffle_worker_service() {
+  local service_id="$1"
+  local expected_network_id="$2"
+  local required_nonlabel_spec="${3:-}"
+  local attempt
+  local current_nonlabel_spec
+  local current_version
+  local network_metadata
+  local network_state
+  local previous_nonlabel_spec=""
+  local previous_version=""
+  local service_metadata
+
+  for attempt in {1..120}; do
+    if ! network_metadata="$(
+      docker_lab network inspect "${expected_network_id}" 2>/dev/null
+    )" || ! jq -e \
+      --arg network_id "${expected_network_id}" \
+      --arg network_name "${shuffle_worker_network}" '
+        length == 1
+        and .[0].Id == $network_id
+        and .[0].Name == $network_name
+        and .[0].Scope == "swarm"
+        and .[0].Driver == "overlay"
+      ' <<<"${network_metadata}" >/dev/null; then
+      echo "BLOCKED: Shuffle worker overlay network identity changed before ownership" >&2
+      return 1
+    fi
+    if ! service_metadata="$(
+      docker_lab service inspect "${service_id}" 2>/dev/null
+    )"; then
+      echo "BLOCKED: Shuffle worker service ID disappeared before ownership" >&2
+      return 1
+    fi
+    if ! shuffle_worker_service_is_unowned_candidate \
+      "${service_metadata}" "${service_id}"; then
+      echo "BLOCKED: Shuffle worker service identity or ownership changed before claim" >&2
+      return 1
+    fi
+    if ! network_state="$(
+      jq -er --arg network_id "${expected_network_id}" '
+        (.[0].Spec.TaskTemplate.Networks // []) as $networks
+        | if (($networks | type) != "array") then "invalid"
+          elif ($networks | length) == 0 then "pending"
+          elif (
+            ($networks | length) == 1
+            and (($networks[0] | type) == "object")
+            and $networks[0].Target == $network_id
+          ) then "ready"
+          else "invalid"
+          end
+      ' <<<"${service_metadata}" 2>/dev/null
+    )"; then
+      echo "BLOCKED: cannot inspect Shuffle worker task networks" >&2
+      return 1
+    fi
+    if [[ "${network_state}" == "pending" ]]; then
+      previous_version=""
+      previous_nonlabel_spec=""
+      sleep 1
+      continue
+    fi
+    if [[ "${network_state}" != "ready" ]]; then
+      echo "BLOCKED: Shuffle worker task networks do not match the expected overlay" >&2
+      return 1
+    fi
+    current_version="$(jq -er '.[0].Version.Index' <<<"${service_metadata}")"
+    current_nonlabel_spec="$(
+      jq -cS '.[0].Spec | del(.Labels)' <<<"${service_metadata}"
+    )"
+    if [[ -n "${required_nonlabel_spec}" ]] \
+      && [[ "${current_nonlabel_spec}" != "${required_nonlabel_spec}" ]]; then
+      echo "BLOCKED: Shuffle worker non-label specification changed before retry" >&2
+      return 1
+    fi
+    if [[ "${current_version}" == "${previous_version}" ]] \
+      && [[ "${current_nonlabel_spec}" == "${previous_nonlabel_spec}" ]]; then
+      printf '%s\n' "${service_metadata}"
+      return
+    fi
+    previous_version="${current_version}"
+    previous_nonlabel_spec="${current_nonlabel_spec}"
+    sleep 1
+  done
+  echo "BLOCKED: Shuffle worker service did not reach a stable network specification" >&2
+  return 1
+}
+
 claim_reviewed_shuffle_worker_service() {
   local service_metadata="$1"
+  local claim_attempt
+  local claim_rc
+  local expected_network_id
+  local owned_nonlabel_spec
+  local retry_version
   local service_id
   local service_image
   local service_version
+  local stable_nonlabel_spec
   local owned_metadata
 
   if [[ "${shuffle_worker_owned}" == true ]]; then
@@ -427,6 +920,12 @@ claim_reviewed_shuffle_worker_service() {
     echo "BLOCKED: new Shuffle worker service has no stable service ID" >&2
     return 1
   fi
+  if [[ -n "${shuffle_worker_service_id}" ]] \
+    && [[ "${shuffle_worker_service_id}" != "${service_id}" ]]; then
+    echo "BLOCKED: Shuffle worker service ID was replaced before ownership" >&2
+    return 1
+  fi
+  shuffle_worker_service_id="${service_id}"
   if ! service_image="$(
     jq -er '.[0].Spec.TaskTemplate.ContainerSpec.Image' \
       <<<"${service_metadata}"
@@ -447,26 +946,65 @@ claim_reviewed_shuffle_worker_service() {
     echo "BLOCKED: new Shuffle worker service has no stable service version" >&2
     return 1
   fi
-  shuffle_worker_service_id="${service_id}"
-  if ! python3 "${swarm_service_labeler}" \
-    --docker-context "${AEGISOPS_LAB_DOCKER_CONTEXT}" \
-    --service-id "${service_id}" \
-    --expected-version "${service_version}" \
-    --expected-name "${shuffle_worker_service}" \
-    --expected-image "${shuffle_worker_immutable_ref}" \
-    --label "com.aegisops.lab.phase=67.4" \
-    --label "com.aegisops.lab.component=shuffle-worker-image" \
-    --label "com.aegisops.lab.trial-run-id=${trial_run_id}" \
-    >/dev/null; then
+  if ! expected_network_id="$(
+    resolve_reviewed_shuffle_worker_network_id "${service_id}"
+  )"; then
+    return 1
+  fi
+  if ! service_metadata="$(
+    wait_for_stable_reviewed_shuffle_worker_service \
+      "${service_id}" "${expected_network_id}"
+  )"; then
+    return 1
+  fi
+  stable_nonlabel_spec="$(
+    jq -cS '.[0].Spec | del(.Labels)' <<<"${service_metadata}"
+  )"
+
+  for claim_attempt in 1 2; do
+    service_version="$(jq -er '.[0].Version.Index' <<<"${service_metadata}")"
+    if python3 "${swarm_service_labeler}" \
+      --docker-context "${AEGISOPS_LAB_DOCKER_CONTEXT}" \
+      --service-id "${service_id}" \
+      --expected-version "${service_version}" \
+      --expected-name "${shuffle_worker_service}" \
+      --expected-image "${shuffle_worker_immutable_ref}" \
+      --label "com.aegisops.lab.phase=67.4" \
+      --label "com.aegisops.lab.component=shuffle-worker-image" \
+      --label "com.aegisops.lab.trial-run-id=${trial_run_id}" \
+      >/dev/null 2>&1; then
+      claim_rc=0
+      break
+    else
+      claim_rc=$?
+    fi
     if owned_metadata="$(
       docker_lab service inspect "${shuffle_worker_service_id}" 2>/dev/null
     )" && shuffle_worker_service_matches_attempted_claim \
       "${service_metadata}" "${owned_metadata}"; then
       shuffle_worker_owned=true
+      echo "BLOCKED: Shuffle worker ownership helper failed after applying labels" >&2
+      return 1
     fi
-    echo "BLOCKED: failed to label the new Shuffle worker service" >&2
-    return 1
-  fi
+    if [[ "${claim_attempt}" -ge 2 ]]; then
+      echo "BLOCKED: failed to label the new Shuffle worker service (exit ${claim_rc})" >&2
+      return 1
+    fi
+    if ! service_metadata="$(
+      wait_for_stable_reviewed_shuffle_worker_service \
+        "${service_id}" \
+        "${expected_network_id}" \
+        "${stable_nonlabel_spec}"
+    )"; then
+      echo "BLOCKED: refusing to retry an unstable Shuffle worker ownership claim" >&2
+      return 1
+    fi
+    retry_version="$(jq -er '.[0].Version.Index' <<<"${service_metadata}")"
+    if [[ "${retry_version}" -le "${service_version}" ]]; then
+      echo "BLOCKED: refusing to retry a Shuffle worker claim without a newer stable version" >&2
+      return 1
+    fi
+  done
   shuffle_worker_owned=true
   if ! owned_metadata="$(
     docker_lab service inspect "${shuffle_worker_service_id}"
@@ -478,78 +1016,113 @@ claim_reviewed_shuffle_worker_service() {
     echo "BLOCKED: Shuffle worker service did not retain trial ownership labels" >&2
     return 1
   fi
+  owned_nonlabel_spec="$(
+    jq -cS '.[0].Spec | del(.Labels)' <<<"${owned_metadata}"
+  )"
+  if [[ "${owned_nonlabel_spec}" != "${stable_nonlabel_spec}" ]]; then
+    echo "BLOCKED: Shuffle worker service changed outside ownership labels" >&2
+    return 1
+  fi
+}
+
+capture_reviewed_shuffle_worker_cleanup_candidate() {
+  local candidate_id
+  local current_spec
+  local service_metadata
+
+  [[ "${shuffle_worker_preflight_absent}" == true ]] || return
+  if [[ -z "${shuffle_worker_immutable_ref}" ]]; then
+    shuffle_worker_immutable_ref="$(
+      configured_shuffle_worker_immutable_ref
+    )" || return 1
+  fi
+  if [[ -n "${shuffle_worker_service_id}" ]]; then
+    candidate_id="${shuffle_worker_service_id}"
+    service_metadata="$(
+      docker_lab service inspect "${candidate_id}" 2>/dev/null
+    )" || return
+  else
+    service_metadata="$(
+      docker_lab service inspect "${shuffle_worker_service}" 2>/dev/null
+    )" || return
+    candidate_id="$(jq -er '.[0].ID' <<<"${service_metadata}")" || return 1
+  fi
+  [[ "${candidate_id}" =~ ^[a-z0-9]{12,64}$ ]] || return 1
+  if [[ "${shuffle_worker_owned}" == true ]]; then
+    shuffle_worker_service_is_trial_owned "${service_metadata}" || return 1
+  else
+    shuffle_worker_service_is_unowned_candidate \
+      "${service_metadata}" "${candidate_id}" || return 1
+  fi
+  current_spec="$(jq -cS '.[0].Spec' <<<"${service_metadata}")" || return 1
+  shuffle_worker_service_id="${candidate_id}"
+  shuffle_worker_cleanup_candidate_id="${candidate_id}"
+  shuffle_worker_cleanup_candidate_spec="${current_spec}"
+}
+
+capture_reviewed_shuffle_cleanup_candidates() {
+  local rc=0
+
+  capture_reviewed_shuffle_worker_cleanup_candidate || rc=1
+  capture_reviewed_shuffle_action_cleanup_candidate || rc=1
+  return "${rc}"
 }
 
 remove_reviewed_shuffle_worker_service() {
-  local attempt
-  local expected_image
+  local current_spec
+  local named_metadata
   local service_metadata
-  local service_image
-  local service_removed
-  local task_container_ids
 
-  if ! service_metadata="$(
+  [[ -n "${shuffle_worker_cleanup_candidate_id}" ]] || return
+  service_metadata="$(
+    docker_lab service inspect \
+      "${shuffle_worker_cleanup_candidate_id}" 2>/dev/null
+  )" || {
+    if ! wait_for_exact_swarm_service_removal \
+      "${shuffle_worker_cleanup_candidate_id}"; then
+      return 1
+    fi
+    if named_metadata="$(
+      docker_lab service inspect "${shuffle_worker_service}" 2>/dev/null
+    )"; then
+      echo "BLOCKED: a replacement Shuffle worker service appeared during cleanup" >&2
+      return 1
+    fi
+    shuffle_worker_cleanup_candidate_id=""
+    shuffle_worker_cleanup_candidate_spec=""
+    return
+  }
+  current_spec="$(jq -cS '.[0].Spec' <<<"${service_metadata}")" || return 1
+  [[ "${current_spec}" == "${shuffle_worker_cleanup_candidate_spec}" ]] \
+    || {
+      echo "BLOCKED: refusing to remove a changed Shuffle worker service" >&2
+      return 1
+    }
+  if [[ "${shuffle_worker_owned}" == true ]]; then
+    shuffle_worker_service_is_trial_owned "${service_metadata}" || {
+      echo "BLOCKED: refusing to remove a worker without trial ownership" >&2
+      return 1
+    }
+  else
+    shuffle_worker_service_is_unowned_candidate \
+      "${service_metadata}" "${shuffle_worker_cleanup_candidate_id}" || {
+        echo "BLOCKED: refusing to remove an unverified worker candidate" >&2
+        return 1
+      }
+  fi
+  docker_lab service rm "${shuffle_worker_cleanup_candidate_id}" >/dev/null
+  wait_for_exact_swarm_service_removal \
+    "${shuffle_worker_cleanup_candidate_id}"
+  if named_metadata="$(
     docker_lab service inspect "${shuffle_worker_service}" 2>/dev/null
   )"; then
-    return
-  fi
-  if ! expected_image="$(configured_shuffle_worker_immutable_ref)"; then
-    echo "BLOCKED: refusing to remove a Shuffle worker service without owned Orborus image evidence" >&2
+    echo "BLOCKED: a replacement Shuffle worker service appeared during cleanup" >&2
     return 1
   fi
-  if ! shuffle_worker_service_is_trial_owned "${service_metadata}"; then
-    if [[ "${shuffle_worker_owned}" == true ]] \
-      || [[ "${shuffle_worker_preflight_absent}" != true ]]; then
-      echo "BLOCKED: refusing to remove a Shuffle worker service without current-trial ownership" >&2
-      return 1
-    fi
-    shuffle_worker_immutable_ref="${expected_image}"
-    if ! claim_reviewed_shuffle_worker_service "${service_metadata}"; then
-      echo "BLOCKED: initial Shuffle worker cleanup claim did not complete" >&2
-    fi
-    if [[ -z "${shuffle_worker_service_id}" ]] \
-      || ! service_metadata="$(
-        docker_lab service inspect "${shuffle_worker_service_id}" 2>/dev/null
-      )" \
-      || ! shuffle_worker_service_is_trial_owned "${service_metadata}"; then
-      echo "BLOCKED: refusing to claim an unverified Shuffle worker service during cleanup" >&2
-      return 1
-    fi
-    shuffle_worker_owned=true
-  fi
-  service_image="$(
-    jq -er '.[0].Spec.TaskTemplate.ContainerSpec.Image' \
-      <<<"${service_metadata}"
-  )"
-  if [[ "${service_image}" != "${expected_image}" ]]; then
-    echo "BLOCKED: refusing to remove a Shuffle worker service with an unreviewed image" >&2
-    return 1
-  fi
-
-  docker_lab service rm "${shuffle_worker_service_id}" >/dev/null
-  for attempt in {1..60}; do
-    service_removed=false
-    if ! docker_lab service inspect \
-      "${shuffle_worker_service_id}" >/dev/null 2>&1; then
-      service_removed=true
-    fi
-    if ! task_container_ids="$(
-      docker_lab ps \
-        --all \
-        --quiet \
-        --filter \
-          "label=com.docker.swarm.service.name=${shuffle_worker_service}"
-    )"; then
-      sleep 1
-      continue
-    fi
-    if [[ "${service_removed}" == true && -z "${task_container_ids}" ]]; then
-      return
-    fi
-    sleep 1
-  done
-  echo "BLOCKED: Shuffle worker service tasks did not stop during cleanup" >&2
-  return 1
+  shuffle_worker_owned=false
+  shuffle_worker_service_id=""
+  shuffle_worker_cleanup_candidate_id=""
+  shuffle_worker_cleanup_candidate_spec=""
 }
 
 [[ -f "${evaluation}" ]] \
@@ -582,10 +1155,11 @@ evidence_output="${staging_dir}/evidence.json"
 final_evidence="${AEGISOPS_LAB_EVIDENCE_DIR}/${trial_run_id}.json"
 final_report="${AEGISOPS_LAB_EVIDENCE_DIR}/${trial_run_id}-report.json"
 final_artifacts="${AEGISOPS_LAB_EVIDENCE_DIR}/${trial_run_id}-artifacts"
+publication_manifest_candidate="${AEGISOPS_LAB_EVIDENCE_DIR}/.${trial_run_id}.manifest-candidate"
 cleaned=false
 publication_report_published=false
 publication_artifacts_published=false
-publication_manifest_moved=false
+publication_manifest_staged=false
 publication_manifest_published=false
 
 observed_now() {
@@ -736,24 +1310,52 @@ capture_reviewed_shuffle_worker_image() {
   )"
   shuffle_worker_service_is_trial_owned "${service_metadata}" \
     || fail "Shuffle worker service is not owned by the current trial"
-  task_ids="$(
-    docker_lab service ps \
-      --filter desired-state=running \
-      --quiet \
-      "${shuffle_worker_service}"
-  )"
-  [[ "$(wc -w <<<"${task_ids}")" -eq 1 ]] \
-    || fail "Shuffle worker service does not have exactly one running task"
-  # shellcheck disable=SC2086
-  task_metadata="$(docker_lab inspect ${task_ids})"
-  task_container_id="$(
-    jq -er '
-      [.[].Status.ContainerStatus.ContainerID | select(length > 0)]
-      | if length == 1 then .[]
-        else error("expected one Shuffle worker task container")
-        end
-    ' <<<"${task_metadata}"
-  )"
+  task_ids=""
+  task_metadata=""
+  task_container_id=""
+  for attempt in {1..120}; do
+    if ! task_ids="$(
+      docker_lab service ps \
+        --filter desired-state=running \
+        --quiet \
+        "${shuffle_worker_service_id}" 2>/dev/null
+    )"; then
+      sleep 1
+      continue
+    fi
+    if [[ "$(wc -w <<<"${task_ids}")" -ne 1 ]]; then
+      sleep 1
+      continue
+    fi
+    if ! task_metadata="$(docker_lab inspect "${task_ids}" 2>/dev/null)"; then
+      sleep 1
+      continue
+    fi
+    if task_container_id="$(
+      jq -er \
+        --arg task_id "${task_ids}" \
+        --arg service_id "${shuffle_worker_service_id}" '
+          if (
+            length == 1
+            and .[0].ID == $task_id
+            and .[0].ServiceID == $service_id
+            and .[0].DesiredState == "running"
+            and .[0].Status.State == "running"
+            and (
+              (.[0].Status.ContainerStatus.ContainerID // "")
+              | type == "string" and length > 0
+            )
+          ) then .[0].Status.ContainerStatus.ContainerID
+          else error("Shuffle worker task is not ready")
+          end
+        ' <<<"${task_metadata}" 2>/dev/null
+    )"; then
+      break
+    fi
+    sleep 1
+  done
+  [[ -n "${task_container_id}" ]] \
+    || fail "Shuffle worker service did not reach exactly one running task with a container ID"
   container_metadata="$(docker_lab inspect "${task_container_id}")"
   reviewed_image_id="$(
     docker_lab image inspect \
@@ -795,21 +1397,22 @@ capture_reviewed_shuffle_worker_image() {
 
 cleanup_on_exit() {
   local rc=$?
+  local cleanup_failed=false
   rm -f "${compose_render_output}" >/dev/null 2>&1 || true
-  remove_reviewed_shuffle_worker_service >/dev/null 2>&1 || true
-  remove_reviewed_shuffle_action_service >/dev/null 2>&1 || true
   if [[ "${cleaned}" != true ]]; then
-    "${LAB_DIR}/cleanup.sh" >/dev/null 2>&1 || true
+    capture_reviewed_shuffle_cleanup_candidates >/dev/null 2>&1 \
+      || cleanup_failed=true
+    "${LAB_DIR}/cleanup.sh" >/dev/null 2>&1 || cleanup_failed=true
+    remove_reviewed_shuffle_action_service >/dev/null 2>&1 \
+      || cleanup_failed=true
+    remove_reviewed_shuffle_worker_service >/dev/null 2>&1 \
+      || cleanup_failed=true
+  fi
+  if [[ "${cleanup_failed}" == true && "${rc}" -eq 0 ]]; then
+    rc=1
   fi
   if [[ "${rc}" -ne 0 ]]; then
     if [[ "${publication_manifest_published}" != true ]]; then
-      if [[ "${publication_manifest_moved}" == true ]] \
-        && [[ -f "${final_evidence}" ]] \
-        && [[ -d "${final_artifacts}" ]] \
-        && [[ ! -e "${final_artifacts}/evidence.json" ]]; then
-        mv "${final_evidence}" \
-          "${final_artifacts}/evidence.json" >/dev/null 2>&1 || true
-      fi
       if [[ "${publication_artifacts_published}" == true ]] \
         && [[ -d "${final_artifacts}" ]] \
         && [[ ! -e "${staging_dir}" ]]; then
@@ -819,6 +1422,18 @@ cleanup_on_exit() {
         && [[ -f "${final_report}" ]] \
         && [[ -d "${staging_dir}" ]]; then
         mv "${final_report}" "${report_output}" >/dev/null 2>&1 || true
+      fi
+      if [[ "${publication_manifest_staged}" == true ]] \
+        && [[ -f "${publication_manifest_candidate}" ]]; then
+        if [[ -d "${staging_dir}" ]] && [[ ! -e "${evidence_output}" ]]; then
+          mv "${publication_manifest_candidate}" \
+            "${evidence_output}" >/dev/null 2>&1 \
+            || rm -f "${publication_manifest_candidate}" \
+              >/dev/null 2>&1 \
+            || true
+        else
+          rm -f "${publication_manifest_candidate}" >/dev/null 2>&1 || true
+        fi
       fi
     fi
     echo "BLOCKED: Phase 67.4 real-service E2E trial failed; no passing manifest was published" >&2
@@ -1095,11 +1710,20 @@ Path(sys.argv[2]).write_text(
 )
 PY
 
-run_reviewed_lab_command remove_reviewed_shuffle_action_service
+run_reviewed_lab_command capture_reviewed_shuffle_cleanup_candidates
 run_reviewed_lab_command "${LAB_DIR}/down.sh"
+run_reviewed_lab_command remove_reviewed_shuffle_action_service
+run_reviewed_lab_command remove_reviewed_shuffle_worker_service
+run_reviewed_lab_command assert_shuffle_action_service_absent
+run_reviewed_lab_command assert_shuffle_worker_service_absent
 restart_up_output="$(run_reviewed_lab_startup "${LAB_DIR}/up.sh" full)"
 printf '%s\n' "${restart_up_output}"
 retain_status_evidence "${restart_up_output}" "${restart_status_output}"
+capture_reviewed_shuffle_worker_image >/dev/null
+restart_shuffle_worker_image="${captured_shuffle_worker_image_json}"
+[[ "${restart_shuffle_worker_image}" == "${shuffle_worker_image}" ]] \
+  || fail "Shuffle worker service changed during restart verification"
+run_reviewed_lab_command ensure_reviewed_shuffle_action_service
 jq -cn \
   --slurpfile journey "${journey_output}" \
   --slurpfile report "${report_output}" '
@@ -1141,8 +1765,10 @@ jq -n \
   ' >"${evaluation_record_output}"
 record_step 15 "record_prerequisite_evaluation" "${evaluated_at}"
 
-run_reviewed_lab_command remove_reviewed_shuffle_worker_service
+run_reviewed_lab_command capture_reviewed_shuffle_cleanup_candidates
 run_reviewed_lab_command "${LAB_DIR}/cleanup.sh"
+run_reviewed_lab_command remove_reviewed_shuffle_action_service
+run_reviewed_lab_command remove_reviewed_shuffle_worker_service
 cleaned=true
 assert_repository_snapshot
 assert_compose_snapshot
@@ -1176,27 +1802,37 @@ assert_repository_snapshot
 python3 "${validator}" "${schema}" "${evidence_output}"
 assert_repository_snapshot
 
-for destination in "${final_evidence}" "${final_report}" "${final_artifacts}"; do
+for destination in \
+  "${final_evidence}" \
+  "${final_report}" \
+  "${final_artifacts}" \
+  "${publication_manifest_candidate}"; do
   [[ ! -e "${destination}" && ! -L "${destination}" ]] \
     || fail "publication destination already exists: ${destination}"
 done
 chmod 700 "${staging_dir}"
 find "${staging_dir}" -type f -exec chmod 600 {} +
+mv "${evidence_output}" "${publication_manifest_candidate}"
+publication_manifest_staged=true
 mv "${report_output}" "${final_report}"
 publication_report_published=true
 mv "${staging_dir}" "${final_artifacts}"
 publication_artifacts_published=true
-mv "${final_artifacts}/evidence.json" "${final_evidence}"
-publication_manifest_moved=true
 assert_repository_snapshot
 python3 "${validator}" \
   --published \
   "${schema}" \
-  "${final_evidence}" \
+  "${publication_manifest_candidate}" \
   "${final_report}" \
   "${final_artifacts}"
-chmod 400 "${final_evidence}"
+chmod 400 "${publication_manifest_candidate}"
+assert_repository_snapshot
+[[ ! -e "${final_evidence}" && ! -L "${final_evidence}" ]] \
+  || fail "publication destination appeared during validation: ${final_evidence}"
+ln "${publication_manifest_candidate}" "${final_evidence}"
 publication_manifest_published=true
+rm -f "${publication_manifest_candidate}" >/dev/null 2>&1 || true
+publication_manifest_staged=false
 trap - EXIT
 
 echo "PASS: Phase 67.4 real-service E2E trial completed"

--- a/control-plane/tests/test_phase67_4_real_service_e2e.py
+++ b/control-plane/tests/test_phase67_4_real_service_e2e.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stderr
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 import hashlib
 import importlib.util
+from io import StringIO
 import json
+import os
 from pathlib import Path
 import re
+import subprocess
 import sys
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
@@ -3564,6 +3567,129 @@ class Phase674RealServiceE2ETests(unittest.TestCase):
         self.assertEqual(result["version_before"], 2342226)
         self.assertEqual(result["version_after"], 2342227)
 
+    @staticmethod
+    def _swarm_labeler_arguments(
+        expected_image: str,
+        *,
+        allow_observed_image: bool = False,
+    ) -> list[str]:
+        arguments = [
+            "--docker-context",
+            "colima",
+            "--service-id",
+            "wo7au34eetl5tc0id1jzxxu9e",
+            "--expected-version",
+            "2342226",
+            "--expected-name",
+            "shuffle-tools_1-2-0",
+            "--expected-image",
+            expected_image,
+            "--label",
+            "com.aegisops.lab.phase=67.4",
+        ]
+        if allow_observed_image:
+            arguments.append(
+                "--allow-observed-image-reference-after-runtime-id-verification"
+            )
+        return arguments
+
+    def test_swarm_labeler_rejects_tag_only_image_without_runtime_id_flag(
+        self,
+    ) -> None:
+        stderr = StringIO()
+        with redirect_stderr(stderr), self.assertRaises(SystemExit) as raised:
+            swarm_labeler.parse_args(
+                self._swarm_labeler_arguments("frikky/shuffle:app_sdk")
+            )
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("digest-pinned image reference", stderr.getvalue())
+
+    def test_swarm_labeler_accepts_exact_tag_only_image_with_runtime_id_flag(
+        self,
+    ) -> None:
+        observed_image = "frikky/shuffle:app_sdk"
+        args = swarm_labeler.parse_args(
+            self._swarm_labeler_arguments(
+                observed_image,
+                allow_observed_image=True,
+            )
+        )
+        service = _hybrid_network_worker_service()
+        service["Spec"]["Name"] = args.expected_name
+        service["Spec"]["TaskTemplate"]["ContainerSpec"][
+            "Image"
+        ] = observed_image
+        api = _FakeDockerEngine(service)
+
+        swarm_labeler.claim_service_labels(
+            api,
+            service_id=args.service_id,
+            expected_version=args.expected_version,
+            expected_name=args.expected_name,
+            expected_image=args.expected_image,
+            labels=dict(args.label),
+        )
+
+        self.assertTrue(
+            args.allow_observed_image_reference_after_runtime_id_verification
+        )
+        self.assertIsNotNone(api.updated_spec)
+        assert api.updated_spec is not None
+        self.assertEqual(
+            api.updated_spec["TaskTemplate"]["ContainerSpec"]["Image"],
+            observed_image,
+        )
+
+    def test_swarm_labeler_rejects_empty_or_whitespace_observed_image(
+        self,
+    ) -> None:
+        for invalid_image in ("", " ", "frikky/shuffle:app sdk"):
+            with self.subTest(expected_image=invalid_image):
+                stderr = StringIO()
+                with redirect_stderr(stderr), self.assertRaises(
+                    SystemExit
+                ) as raised:
+                    swarm_labeler.parse_args(
+                        self._swarm_labeler_arguments(
+                            invalid_image,
+                            allow_observed_image=True,
+                        )
+                    )
+
+                self.assertEqual(raised.exception.code, 2)
+                self.assertIn(
+                    "observed image reference",
+                    stderr.getvalue(),
+                )
+
+    def test_swarm_labeler_still_enforces_exact_observed_image(self) -> None:
+        observed_image = "frikky/shuffle:app_sdk"
+        args = swarm_labeler.parse_args(
+            self._swarm_labeler_arguments(
+                observed_image,
+                allow_observed_image=True,
+            )
+        )
+        service = _hybrid_network_worker_service()
+        service["Spec"]["Name"] = args.expected_name
+        service["Spec"]["TaskTemplate"]["ContainerSpec"][
+            "Image"
+        ] = "frikky/shuffle:app_sdk-replaced"
+        api = _FakeDockerEngine(service)
+
+        with self.assertRaises(swarm_labeler.SwarmLabelUpdateError):
+            swarm_labeler.claim_service_labels(
+                api,
+                service_id=args.service_id,
+                expected_version=args.expected_version,
+                expected_name=args.expected_name,
+                expected_image=args.expected_image,
+                labels=dict(args.label),
+            )
+
+        self.assertIsNone(api.updated_spec)
+
     def test_swarm_label_claim_rejects_stale_or_preowned_service(self) -> None:
         service = _hybrid_network_worker_service()
         arguments = {
@@ -3809,24 +3935,35 @@ class Phase674RealServiceE2ETests(unittest.TestCase):
         self.assertIn("capture_reviewed_shuffle_worker_image()", runner)
         self.assertIn("ensure_reviewed_shuffle_action_service()", runner)
         self.assertIn("assert_reviewed_shuffle_action_service()", runner)
-        self.assertIn('--name "${shuffle_action_service}"', runner)
         self.assertIn('"${shuffle_tools_immutable_ref}"', runner)
-        service_create = runner.index("docker_lab service create")
-        service_create_end = runner.index(
-            '"${shuffle_tools_immutable_ref}"',
-            service_create,
+        self.assertNotIn("docker_lab service create", runner)
+        action_ensure_start = runner.index(
+            "ensure_reviewed_shuffle_action_service()"
         )
-        service_create_block = runner[service_create:service_create_end + 40]
-        self.assertIn('"${shuffle_tools_immutable_ref}"', service_create_block)
-        self.assertNotIn('"${shuffle_tools_image}"', service_create_block)
-        self.assertIn("--quiet", service_create_block)
+        action_ensure_end = runner.index(
+            "remove_reviewed_shuffle_action_service()",
+            action_ensure_start,
+        )
+        action_ensure = runner[action_ensure_start:action_ensure_end]
+        self.assertIn(
+            'docker_lab service inspect "${shuffle_action_service}"',
+            action_ensure,
+        )
+        self.assertIn(
+            "shuffle_action_service_observation_is_stable",
+            action_ensure,
+        )
+        self.assertIn(
+            "shuffle_action_runtime_matches_reviewed_image",
+            action_ensure,
+        )
+        self.assertIn(
+            "--allow-observed-image-reference-after-runtime-id-verification",
+            action_ensure,
+        )
         self.assertIn(
             'com.aegisops.lab.trial-run-id=${trial_run_id}',
-            service_create_block,
-        )
-        self.assertIn(
-            'shuffle_action_service_id="$(docker_lab service create',
-            runner,
+            action_ensure,
         )
         self.assertIn(".Image == $image_id", runner)
         self.assertIn(
@@ -3905,7 +4042,86 @@ class Phase674RealServiceE2ETests(unittest.TestCase):
             worker_capture.index("claim_reviewed_shuffle_worker_service"),
             worker_capture.index('service_image="$('),
         )
+        worker_readiness_start = worker_capture.index('task_ids=""')
+        worker_readiness_end = worker_capture.index(
+            'container_metadata="$(',
+            worker_readiness_start,
+        )
+        worker_readiness = worker_capture[
+            worker_readiness_start:worker_readiness_end
+        ]
+        self.assertIn("for attempt in {1..120}; do", worker_readiness)
+        self.assertIn(
+            '"${shuffle_worker_service_id}" 2>/dev/null',
+            worker_readiness,
+        )
+        self.assertNotIn(
+            '"${shuffle_worker_service}"',
+            worker_readiness,
+        )
+        self.assertIn('.[0].ServiceID == $service_id', worker_readiness)
+        self.assertIn('.[0].DesiredState == "running"', worker_readiness)
+        self.assertIn('.[0].Status.State == "running"', worker_readiness)
+        self.assertIn(
+            '(.[0].Status.ContainerStatus.ContainerID // "")',
+            worker_readiness,
+        )
+        self.assertIn(
+            "Shuffle worker service did not reach exactly one running task "
+            "with a container ID",
+            worker_readiness,
+        )
+        self.assertLess(
+            worker_readiness.index('docker_lab service ps \\'),
+            worker_readiness.index('docker_lab inspect "${task_ids}"'),
+        )
+        self.assertLess(
+            worker_readiness.index('.Status.State == "running"'),
+            worker_readiness.index(
+                "Shuffle worker service did not reach exactly one running task"
+            ),
+        )
         claim_start = runner.index("claim_reviewed_shuffle_worker_service()")
+        stabilization_start = runner.index(
+            "resolve_reviewed_shuffle_worker_network_id()"
+        )
+        worker_stabilization = runner[stabilization_start:claim_start]
+        self.assertIn(
+            'shuffle_worker_network="shuffle_swarm_executions"',
+            runner,
+        )
+        self.assertIn(
+            '.[0].Spec.TaskTemplate.Networks',
+            worker_stabilization,
+        )
+        self.assertIn(
+            'docker_lab network inspect "${network_id}"',
+            worker_stabilization,
+        )
+        self.assertIn(
+            '--arg network_name "${shuffle_worker_network}"',
+            worker_stabilization,
+        )
+        self.assertIn(
+            'shuffle_worker_service_is_unowned_candidate',
+            worker_stabilization,
+        )
+        self.assertIn(
+            '"${current_version}" == "${previous_version}"',
+            worker_stabilization,
+        )
+        self.assertIn(
+            '"${current_nonlabel_spec}" == "${previous_nonlabel_spec}"',
+            worker_stabilization,
+        )
+        self.assertIn(
+            '[[ "${network_state}" == "pending" ]]',
+            worker_stabilization,
+        )
+        self.assertIn(
+            "Shuffle worker service did not reach a stable network specification",
+            worker_stabilization,
+        )
         claim_end = runner.index(
             "remove_reviewed_shuffle_worker_service()",
             claim_start,
@@ -3930,11 +4146,27 @@ class Phase674RealServiceE2ETests(unittest.TestCase):
             "shuffle_worker_service_matches_attempted_claim",
             worker_claim,
         )
+        self.assertIn("for claim_attempt in 1 2; do", worker_claim)
+        self.assertIn(
+            '"${stable_nonlabel_spec}"',
+            worker_claim,
+        )
+        self.assertIn(
+            '[[ "${retry_version}" -le "${service_version}" ]]',
+            worker_claim,
+        )
+        self.assertIn(
+            "refusing to retry a Shuffle worker claim without a newer stable version",
+            worker_claim,
+        )
         self.assertLess(
             worker_claim.index('shuffle_worker_service_id="${service_id}"'),
             worker_claim.index('owned_metadata="$('),
         )
         self.assertIn("remove_reviewed_shuffle_worker_service()", runner)
+        capture_action_start = runner.index(
+            "capture_reviewed_shuffle_action_cleanup_candidate()"
+        )
         remove_action_start = runner.index(
             "remove_reviewed_shuffle_action_service()"
         )
@@ -3942,90 +4174,151 @@ class Phase674RealServiceE2ETests(unittest.TestCase):
             "configured_shuffle_worker_immutable_ref()",
             remove_action_start,
         )
+        capture_action = runner[capture_action_start:remove_action_start]
         remove_action = runner[remove_action_start:remove_action_end]
-        self.assertLess(
-            remove_action.index('[[ "${shuffle_action_owned}" == true ]]'),
-            remove_action.index(
-                'docker_lab service inspect "${owned_service_id}"'
-            ),
-        )
-        self.assertLess(
-            remove_action.index(
-                'com.aegisops.lab.trial-run-id"] == $trial_run_id'
-            ),
-            remove_action.index('docker_lab service rm "${owned_service_id}"'),
-        )
-        self.assertLess(
-            remove_action.index(
-                ".Spec.TaskTemplate.ContainerSpec.Image == $image"
-            ),
-            remove_action.index('docker_lab service rm "${owned_service_id}"'),
+        self.assertIn(
+            'shuffle_action_cleanup_candidate_id="${candidate_id}"',
+            capture_action,
         )
         self.assertIn(
-            'label=com.docker.swarm.service.id=${owned_service_id}',
+            'shuffle_action_cleanup_candidate_spec="${current_spec}"',
+            capture_action,
+        )
+        self.assertIn(
+            '[[ "${service_image}" == "${shuffle_tools_image}" ]]',
+            capture_action,
+        )
+        self.assertLess(
+            remove_action.index(
+                '[[ "${current_spec}" == '
+                '"${shuffle_action_cleanup_candidate_spec}" ]]'
+            ),
+            remove_action.index(
+                'docker_lab service rm '
+                '"${shuffle_action_cleanup_candidate_id}"'
+            ),
+        )
+        self.assertIn(
+            '--arg service_image "${shuffle_action_service_image}"',
+            runner,
+        )
+        self.assertIn(
+            "Shuffle action service name now resolves to a replacement service",
+            runner,
+        )
+        self.assertIn(
+            'wait_for_exact_swarm_service_removal',
             remove_action,
         )
-        remove_start = runner.index("remove_reviewed_shuffle_worker_service()")
+        capture_worker_start = runner.index(
+            "capture_reviewed_shuffle_worker_cleanup_candidate()"
+        )
+        remove_start = runner.index(
+            "remove_reviewed_shuffle_worker_service()",
+            capture_worker_start,
+        )
         remove_end = runner.index(
             '[[ -f "${evaluation}" ]]',
             remove_start,
         )
+        capture_worker = runner[capture_worker_start:remove_start]
         remove_worker = runner[remove_start:remove_end]
-        self.assertLess(
-            remove_worker.index("shuffle_worker_service_is_trial_owned"),
-            remove_worker.index('docker_lab service rm "${shuffle_worker_service_id}"'),
+        self.assertIn(
+            'shuffle_worker_cleanup_candidate_id="${candidate_id}"',
+            capture_worker,
+        )
+        self.assertIn(
+            'shuffle_worker_cleanup_candidate_spec="${current_spec}"',
+            capture_worker,
         )
         self.assertLess(
             remove_worker.index(
-                '[[ "${shuffle_worker_preflight_absent}" != true ]]'
+                '[[ "${current_spec}" == '
+                '"${shuffle_worker_cleanup_candidate_spec}" ]]'
             ),
-            remove_worker.index("claim_reviewed_shuffle_worker_service"),
-        )
-        self.assertLess(
-            remove_worker.index('shuffle_worker_immutable_ref="${expected_image}"'),
-            remove_worker.index("claim_reviewed_shuffle_worker_service"),
+            remove_worker.index(
+                'docker_lab service rm '
+                '"${shuffle_worker_cleanup_candidate_id}"'
+            ),
         )
         self.assertIn(
-            "refusing to claim an unverified Shuffle worker service during cleanup",
+            'shuffle_worker_service_is_unowned_candidate',
+            remove_worker,
+        )
+        self.assertNotIn(
+            "claim_reviewed_shuffle_worker_service",
             remove_worker,
         )
         self.assertIn(
-            '[[ "${service_image}" != "${expected_image}" ]]',
-            runner,
+            "refusing to remove an unverified worker candidate",
+            remove_worker,
         )
         self.assertIn(
-            'docker_lab service rm "${shuffle_worker_service_id}"',
+            'label=com.docker.swarm.service.id=${service_id}',
             runner,
         )
-        self.assertIn(
+        self.assertNotIn(
             'label=com.docker.swarm.service.name=${shuffle_worker_service}',
-            runner,
+            remove_worker,
         )
         exit_cleanup_start = runner.index("cleanup_on_exit()")
         exit_cleanup_end = runner.index("trap cleanup_on_exit EXIT")
         exit_cleanup = runner[exit_cleanup_start:exit_cleanup_end]
         self.assertLess(
-            exit_cleanup.index("remove_reviewed_shuffle_worker_service"),
+            exit_cleanup.index("capture_reviewed_shuffle_cleanup_candidates"),
             exit_cleanup.index('"${LAB_DIR}/cleanup.sh"'),
         )
+        self.assertLess(
+            exit_cleanup.index('"${LAB_DIR}/cleanup.sh"'),
+            exit_cleanup.index("remove_reviewed_shuffle_action_service"),
+        )
+        self.assertLess(
+            exit_cleanup.index("remove_reviewed_shuffle_action_service"),
+            exit_cleanup.index("remove_reviewed_shuffle_worker_service"),
+        )
+        restart_down = runner.index(
+            'run_reviewed_lab_command "${LAB_DIR}/down.sh"'
+        )
+        restart_remove_action = runner.index(
+            "run_reviewed_lab_command remove_reviewed_shuffle_action_service",
+            restart_down,
+        )
+        restart_remove_worker = runner.index(
+            "run_reviewed_lab_command remove_reviewed_shuffle_worker_service",
+            restart_remove_action,
+        )
+        restart_up = runner.index(
+            'restart_up_output="$(run_reviewed_lab_startup',
+            restart_remove_worker,
+        )
+        restart_reclaim_worker = runner.index(
+            "capture_reviewed_shuffle_worker_image >/dev/null",
+            restart_up,
+        )
+        restart_reclaim_action = runner.index(
+            "run_reviewed_lab_command ensure_reviewed_shuffle_action_service",
+            restart_reclaim_worker,
+        )
+        self.assertLess(restart_down, restart_remove_action)
+        self.assertLess(restart_remove_action, restart_remove_worker)
+        self.assertLess(restart_remove_worker, restart_up)
+        self.assertLess(restart_up, restart_reclaim_worker)
+        self.assertLess(restart_reclaim_worker, restart_reclaim_action)
         normal_worker_cleanup = runner.rindex(
             "run_reviewed_lab_command remove_reviewed_shuffle_worker_service"
         )
         normal_compose_cleanup = runner.rindex(
             'run_reviewed_lab_command "${LAB_DIR}/cleanup.sh"'
         )
-        self.assertLess(normal_worker_cleanup, normal_compose_cleanup)
+        normal_action_cleanup = runner.rindex(
+            "run_reviewed_lab_command remove_reviewed_shuffle_action_service"
+        )
+        self.assertLess(normal_compose_cleanup, normal_action_cleanup)
+        self.assertLess(normal_action_cleanup, normal_worker_cleanup)
         self.assertIn('final_artifacts=', runner)
-        self.assertLess(
-            runner.index('mv "${report_output}" "${final_report}"'),
-            runner.index('mv "${final_artifacts}/evidence.json" "${final_evidence}"'),
-        )
-        self.assertLess(
-            runner.index('mv "${staging_dir}" "${final_artifacts}"'),
-            runner.index('mv "${final_artifacts}/evidence.json" "${final_evidence}"'),
-        )
         self.assertIn('publication_manifest_published=false', runner)
-        self.assertIn('publication_manifest_moved=false', runner)
+        self.assertIn('publication_manifest_staged=false', runner)
+        self.assertIn('publication_manifest_candidate=', runner)
         self.assertIn('no passing manifest was published', runner)
         self.assertIn('startup_status_output=', runner)
         self.assertIn('initial_status_output=', runner)
@@ -4163,25 +4456,39 @@ class Phase674RealServiceE2ETests(unittest.TestCase):
         self.assertLess(evidence_build, post_build_snapshot_check)
         self.assertLess(post_build_snapshot_check, evidence_validation)
         self.assertLess(evidence_validation, post_validation_snapshot_check)
-        final_manifest_move = runner.index(
-            'mv "${final_artifacts}/evidence.json" "${final_evidence}"'
+        manifest_candidate_move = runner.index(
+            'mv "${evidence_output}" "${publication_manifest_candidate}"'
         )
         final_manifest_validation = runner.index(
             "--published",
-            final_manifest_move,
+            manifest_candidate_move,
         )
-        self.assertLess(final_manifest_move, final_manifest_validation)
-        publication_complete = runner.index(
-            "publication_manifest_published=true",
+        final_manifest_commit = runner.index(
+            'ln "${publication_manifest_candidate}" "${final_evidence}"',
             final_manifest_validation,
         )
+        self.assertLess(
+            runner.index('mv "${report_output}" "${final_report}"'),
+            final_manifest_validation,
+        )
+        self.assertLess(
+            runner.index('mv "${staging_dir}" "${final_artifacts}"'),
+            final_manifest_validation,
+        )
+        self.assertLess(manifest_candidate_move, final_manifest_validation)
+        self.assertLess(final_manifest_validation, final_manifest_commit)
+        publication_complete = runner.index(
+            "publication_manifest_published=true",
+            final_manifest_commit,
+        )
         validation_block = runner[
-            final_manifest_validation:publication_complete
+            final_manifest_validation:final_manifest_commit
         ]
+        self.assertIn('"${publication_manifest_candidate}"', validation_block)
         self.assertIn('"${final_report}"', validation_block)
         self.assertIn('"${final_artifacts}"', validation_block)
         self.assertLess(
-            final_manifest_validation,
+            final_manifest_commit,
             publication_complete,
         )
         self.assertIn("status --porcelain=v1 --untracked-files=all", runner)
@@ -4238,6 +4545,192 @@ class Phase674RealServiceE2ETests(unittest.TestCase):
         self.assertLess(revalidation, dispatch)
         compose = (LAB_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
         self.assertIn("./e2e:/opt/aegisops/phase67-e2e:ro", compose)
+
+
+    def test_worker_claim_retries_only_a_newer_stable_unowned_version(
+        self,
+    ) -> None:
+        runner = (LAB_ROOT / "run-e2e-trial.sh").read_text(encoding="utf-8")
+        functions_start = runner.index(
+            "shuffle_worker_service_is_trial_owned()"
+        )
+        functions_end = runner.index(
+            "remove_reviewed_shuffle_worker_service()",
+            functions_start,
+        )
+        worker_functions = runner[functions_start:functions_end]
+        service_id = "worker12345678"
+        network_id = "network12345678"
+        image = "ghcr.io/shuffle/shuffle-worker:2.2.1@sha256:" + "9" * 64
+        trial_run_id = "phase67-e2e-test-0123456789ab"
+
+        def service_metadata(
+            version: int,
+            *,
+            owned: bool = False,
+            replicas: int = 1,
+        ) -> str:
+            labels = (
+                {
+                    "com.aegisops.lab.phase": "67.4",
+                    "com.aegisops.lab.component": "shuffle-worker-image",
+                    "com.aegisops.lab.trial-run-id": trial_run_id,
+                }
+                if owned
+                else {}
+            )
+            return json.dumps(
+                [
+                    {
+                        "ID": service_id,
+                        "Version": {"Index": version},
+                        "Spec": {
+                            "Name": "shuffle-workers",
+                            "Labels": labels,
+                            "Mode": {"Replicated": {"Replicas": replicas}},
+                            "Networks": [
+                                {"Target": "shuffle_swarm_executions"}
+                            ],
+                            "TaskTemplate": {
+                                "ContainerSpec": {"Image": image},
+                                "Networks": [{"Target": network_id}],
+                            },
+                        },
+                    }
+                ],
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+
+        network_metadata = json.dumps(
+            [
+                {
+                    "Id": network_id,
+                    "Name": "shuffle_swarm_executions",
+                    "Scope": "swarm",
+                    "Driver": "overlay",
+                }
+            ],
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        harness = f"""
+set -uo pipefail
+{worker_functions}
+shuffle_worker_service=shuffle-workers
+shuffle_worker_network=shuffle_swarm_executions
+shuffle_worker_immutable_ref="${{REVIEWED_IMAGE}}"
+shuffle_worker_preflight_absent=true
+shuffle_worker_owned=false
+shuffle_worker_service_id=""
+trial_run_id="${{TRIAL_RUN_ID}}"
+AEGISOPS_LAB_DOCKER_CONTEXT=test-context
+swarm_service_labeler=/unused/update_swarm_service_labels.py
+sleep() {{ :; }}
+docker_lab() {{
+  if [[ "$1" == network && "$2" == inspect ]]; then
+    printf '%s\n' "${{NETWORK_METADATA}}"
+    return
+  fi
+  if [[ "$1" == service && "$2" == inspect ]]; then
+    case "$(<"${{MODE_FILE}}")" in
+      initial) printf '%s\n' "${{STABLE_SERVICE}}" ;;
+      conflict) printf '%s\n' "${{CONFLICT_SERVICE}}" ;;
+      owned) printf '%s\n' "${{OWNED_SERVICE}}" ;;
+      *) return 1 ;;
+    esac
+    return
+  fi
+  return 1
+}}
+python3() {{
+  local calls
+  calls="$(<"${{CALLS_FILE}}")"
+  calls=$((calls + 1))
+  printf '%s\n' "${{calls}}" >"${{CALLS_FILE}}"
+  if [[ "${{calls}}" -eq 1 ]]; then
+    printf '%s\n' conflict >"${{MODE_FILE}}"
+    return 1
+  fi
+  printf '%s\n' owned >"${{MODE_FILE}}"
+  return 0
+}}
+claim_reviewed_shuffle_worker_service "${{INITIAL_SERVICE}}"
+rc=$?
+printf 'rc=%s owned=%s helper_calls=%s\n' \
+  "${{rc}}" "${{shuffle_worker_owned}}" "$(<"${{CALLS_FILE}}")"
+exit "${{rc}}"
+"""
+
+        def run_claim(
+            conflict_version: int,
+            *,
+            conflict_replicas: int = 1,
+            conflict_owned: bool = False,
+        ) -> subprocess.CompletedProcess[str]:
+            with TemporaryDirectory() as directory:
+                mode_file = Path(directory) / "mode"
+                calls_file = Path(directory) / "calls"
+                mode_file.write_text("initial\n", encoding="utf-8")
+                calls_file.write_text("0\n", encoding="utf-8")
+                return subprocess.run(
+                    ["bash", "-c", harness],
+                    cwd=REPO_ROOT,
+                    env={
+                        **os.environ,
+                        "MODE_FILE": str(mode_file),
+                        "CALLS_FILE": str(calls_file),
+                        "REVIEWED_IMAGE": image,
+                        "TRIAL_RUN_ID": trial_run_id,
+                        "NETWORK_METADATA": network_metadata,
+                        "INITIAL_SERVICE": service_metadata(41),
+                        "STABLE_SERVICE": service_metadata(42),
+                        "CONFLICT_SERVICE": service_metadata(
+                            conflict_version,
+                            owned=conflict_owned,
+                            replicas=conflict_replicas,
+                        ),
+                        "OWNED_SERVICE": service_metadata(
+                            max(conflict_version, 42) + 1,
+                            owned=True,
+                        ),
+                    },
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+
+        successful_retry = run_claim(43)
+        self.assertEqual(successful_retry.returncode, 0, successful_retry.stderr)
+        self.assertIn(
+            "rc=0 owned=true helper_calls=2",
+            successful_retry.stdout,
+        )
+
+        unchanged_version = run_claim(42)
+        self.assertNotEqual(unchanged_version.returncode, 0)
+        self.assertIn(
+            "without a newer stable version",
+            unchanged_version.stderr,
+        )
+        self.assertIn("helper_calls=1", unchanged_version.stdout)
+
+        changed_spec = run_claim(43, conflict_replicas=2)
+        self.assertNotEqual(changed_spec.returncode, 0)
+        self.assertIn(
+            "non-label specification changed before retry",
+            changed_spec.stderr,
+        )
+        self.assertIn("helper_calls=1", changed_spec.stdout)
+
+        preowned = run_claim(43, conflict_owned=True)
+        self.assertNotEqual(preowned.returncode, 0)
+        self.assertIn(
+            "ownership helper failed after applying labels",
+            preowned.stderr,
+        )
+        self.assertIn("helper_calls=1", preowned.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/test-verify-phase-67-4-real-service-e2e.sh
+++ b/scripts/test-verify-phase-67-4-real-service-e2e.sh
@@ -6,6 +6,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 schema="${repo_root}/control-plane/deployment/phase-67-integration-lab/e2e/evidence-manifest.schema.json"
 sample="${repo_root}/control-plane/deployment/phase-67-integration-lab/e2e/sample-evidence.json"
 validator="${repo_root}/control-plane/deployment/phase-67-integration-lab/e2e/validate_evidence_manifest.py"
+source_verifier="${repo_root}/scripts/verify-phase-67-4-real-service-e2e.sh"
 workdir="$(mktemp -d)"
 trap 'rm -rf "${workdir}"' EXIT
 
@@ -71,6 +72,90 @@ assert_schema_fails_with() {
     }
 }
 
+source_fixture="${workdir}/source-verifier-fixture"
+source_fixture_lab="${source_fixture}/control-plane/deployment/phase-67-integration-lab"
+source_fixture_runner="${source_fixture_lab}/run-e2e-trial.sh"
+
+prepare_source_fixture() {
+  mkdir -p \
+    "${source_fixture}/control-plane/deployment" \
+    "${source_fixture_lab}"
+  ln -s "${repo_root}/README.md" "${source_fixture}/README.md"
+  ln -s "${repo_root}/docs" "${source_fixture}/docs"
+  ln -s \
+    "${repo_root}/control-plane/aegisops" \
+    "${source_fixture}/control-plane/aegisops"
+  ln -s \
+    "${repo_root}/control-plane/tests" \
+    "${source_fixture}/control-plane/tests"
+  for entry in e2e shuffle README.md RUNBOOK.md test-wazuh-intake.sh; do
+    ln -s \
+      "${repo_root}/control-plane/deployment/phase-67-integration-lab/${entry}" \
+      "${source_fixture_lab}/${entry}"
+  done
+}
+
+reset_source_fixture_runner() {
+  cp \
+    "${repo_root}/control-plane/deployment/phase-67-integration-lab/run-e2e-trial.sh" \
+    "${source_fixture_runner}"
+  chmod +x "${source_fixture_runner}"
+}
+
+replace_source_once() {
+  local old="$1"
+  local new="$2"
+  local path="$3"
+  python3 - "${old}" "${new}" "${path}" <<'PY'
+from pathlib import Path
+import sys
+
+old, new, raw_path = sys.argv[1:]
+path = Path(raw_path)
+source = path.read_text(encoding="utf-8")
+if source.count(old) != 1:
+    raise SystemExit(f"expected exactly one source match, found {source.count(old)}")
+path.write_text(source.replace(old, new, 1), encoding="utf-8")
+PY
+}
+
+replace_source_all() {
+  local old="$1"
+  local new="$2"
+  local path="$3"
+  python3 - "${old}" "${new}" "${path}" <<'PY'
+from pathlib import Path
+import sys
+
+old, new, raw_path = sys.argv[1:]
+path = Path(raw_path)
+source = path.read_text(encoding="utf-8")
+if old not in source:
+    raise SystemExit("source mutation target is missing")
+path.write_text(source.replace(old, new), encoding="utf-8")
+PY
+}
+
+assert_source_verifier_fails() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  reset_source_fixture_runner
+  "$@" "${source_fixture_runner}"
+  if AEGISOPS_REPO_ROOT_OVERRIDE="${source_fixture}" \
+    bash "${source_verifier}" \
+    >"${workdir}/${name}.out" 2>"${workdir}/${name}.err"; then
+    echo "self-test expected source verifier rejection for ${name}" >&2
+    exit 1
+  fi
+  grep -Fq -- "${expected}" "${workdir}/${name}.err" \
+    || {
+      cat "${workdir}/${name}.err" >&2
+      echo "self-test ${name} missed expected diagnostic: ${expected}" >&2
+      exit 1
+    }
+}
+
 python3 "${validator}" "${schema}" "${sample}"
 assert_schema_fails_with \
   reordered-current-journey \
@@ -96,6 +181,72 @@ assert_schema_fails_with \
   passed-ga-accepted \
   'schema profile, journey, and passed-verdict selection drifted' \
   '(.allOf[] | select(.if.properties.verdict.const == "integration_trial_passed_with_owned_limitations") | .then.properties.evaluation.properties.ga_accepted.const) = true'
+
+prepare_source_fixture
+
+assert_source_verifier_fails \
+  reintroduced-manual-action-service \
+  'contains forbidden text: docker_lab service create' \
+  replace_source_once \
+  'shuffle_action_service="shuffle-tools_1-2-0"' \
+  $'shuffle_action_service="shuffle-tools_1-2-0"\n# forbidden historical lifecycle: docker_lab service create'
+
+assert_source_verifier_fails \
+  reintroduced-fixed-action-port \
+  'contains forbidden text: shuffle_action_service_port=33334' \
+  replace_source_all \
+  'shuffle_action_service_port=""' \
+  'shuffle_action_service_port=33334'
+
+assert_source_verifier_fails \
+  removed-action-runtime-id-guard \
+  'missing required text: shuffle_action_runtime_matches_reviewed_image' \
+  replace_source_all \
+  'shuffle_action_runtime_matches_reviewed_image' \
+  'shuffle_action_runtime_check_removed'
+
+assert_source_verifier_fails \
+  removed-action-stability-guard \
+  'missing required text: shuffle_action_service_observation_is_stable' \
+  replace_source_all \
+  'shuffle_action_service_observation_is_stable' \
+  'shuffle_action_service_stability_check_removed'
+
+assert_source_verifier_fails \
+  removed-stop-before-remove-guard \
+  'exit cleanup must stop Orborus before exact-ID removal' \
+  replace_source_once \
+  $'    "${LAB_DIR}/cleanup.sh" >/dev/null 2>&1 || cleanup_failed=true\n    remove_reviewed_shuffle_action_service >/dev/null 2>&1 \\\n      || cleanup_failed=true' \
+  $'    remove_reviewed_shuffle_action_service >/dev/null 2>&1 \\\n      || cleanup_failed=true\n    "${LAB_DIR}/cleanup.sh" >/dev/null 2>&1 || cleanup_failed=true'
+
+assert_source_verifier_fails \
+  removed-restart-worker-cleanup \
+  'restart must stop, remove exact IDs, start, and re-claim in order' \
+  replace_source_once \
+  $'run_reviewed_lab_command remove_reviewed_shuffle_action_service\nrun_reviewed_lab_command remove_reviewed_shuffle_worker_service\nrun_reviewed_lab_command assert_shuffle_action_service_absent' \
+  $'run_reviewed_lab_command remove_reviewed_shuffle_action_service\n# worker cleanup guard removed\nrun_reviewed_lab_command assert_shuffle_action_service_absent'
+
+assert_source_verifier_fails \
+  published-manifest-before-validation \
+  'manifest must be validated before its atomic publication' \
+  replace_source_once \
+  'mv "${evidence_output}" "${publication_manifest_candidate}"' \
+  $'mv "${evidence_output}" "${publication_manifest_candidate}"\nln "${publication_manifest_candidate}" "${final_evidence}" # forbidden early commit'
+
+assert_source_verifier_fails \
+  duplicate-callback-accepted \
+  'missing required text: select(startswith("CALLBACK_URL="))' \
+  replace_source_all \
+  'select(startswith("CALLBACK_URL="))' \
+  'select(. == ("CALLBACK_URL=" + $callback_url))'
+
+assert_source_verifier_fails \
+  wrong-callback-accepted \
+  'missing required text: $callbacks[0] == ("CALLBACK_URL=" + $callback_url)' \
+  replace_source_all \
+  '$callbacks[0] == ("CALLBACK_URL=" + $callback_url)' \
+  '($callbacks[0] | startswith("CALLBACK_URL="))'
+
 runtime_images="${workdir}/runtime-images.json"
 jq '
   .snapshot.images

--- a/scripts/verify-phase-67-4-real-service-e2e.sh
+++ b/scripts/verify-phase-67-4-real-service-e2e.sh
@@ -299,10 +299,22 @@ require_fixed "${lab_root}/run-e2e-trial.sh" 'assert_reviewed_shuffle_action_ser
 require_fixed "${lab_root}/run-e2e-trial.sh" 'assert_shuffle_action_service_absent'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'shuffle_action_preflight_absent=true'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'shuffle_action_owned=true'
-require_fixed "${lab_root}/run-e2e-trial.sh" 'shuffle_action_service_id="$(docker_lab service create'
-require_fixed "${lab_root}/run-e2e-trial.sh" 'docker_lab service rm "${owned_service_id}"'
-require_fixed "${lab_root}/run-e2e-trial.sh" 'label=com.docker.swarm.service.id=${owned_service_id}'
-require_fixed "${lab_root}/run-e2e-trial.sh" 'docker_lab service create'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'derive_reviewed_shuffle_action_network_id'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'shuffle_swarm_executions'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'shuffle_action_service_observation_is_stable'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'shuffle_action_runtime_matches_reviewed_image'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'select(startswith("CALLBACK_URL="))'
+require_fixed "${lab_root}/run-e2e-trial.sh" '$callbacks[0] == ("CALLBACK_URL=" + $callback_url)'
+require_fixed "${lab_root}/run-e2e-trial.sh" '--allow-observed-image-reference-after-runtime-id-verification'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'Shuffle action service disappeared before ownership was claimed'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'Shuffle action service was replaced before ownership was claimed'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'Shuffle action service name now resolves to a replacement service'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'capture_reviewed_shuffle_action_cleanup_candidate'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'shuffle_action_cleanup_candidate_spec'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'docker_lab service rm "${shuffle_action_cleanup_candidate_id}"'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'label=com.docker.swarm.service.id=${service_id}'
+reject_fixed "${lab_root}/run-e2e-trial.sh" 'docker_lab service create'
+reject_fixed "${lab_root}/run-e2e-trial.sh" 'shuffle_action_service_port=33334'
 require_fixed "${lab_root}/run-e2e-trial.sh" '.Image == $image_id'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'postdispatch_shuffle_action_image'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'capture_reviewed_shuffle_worker_image'
@@ -322,12 +334,13 @@ require_fixed "${lab_root}/run-e2e-trial.sh" 'python3 "${swarm_service_labeler}"
 require_fixed "${lab_root}/run-e2e-trial.sh" '--expected-version "${service_version}"'
 reject_fixed "${lab_root}/run-e2e-trial.sh" 'docker_lab service update'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'com.aegisops.lab.trial-run-id=${trial_run_id}'
-require_fixed "${lab_root}/run-e2e-trial.sh" 'without current-trial ownership'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'remove_reviewed_shuffle_worker_service'
-require_fixed "${lab_root}/run-e2e-trial.sh" 'docker_lab service rm "${shuffle_worker_service_id}"'
-require_fixed "${lab_root}/run-e2e-trial.sh" 'initial Shuffle worker cleanup claim did not complete'
-require_fixed "${lab_root}/run-e2e-trial.sh" 'refusing to claim an unverified Shuffle worker service during cleanup'
-require_fixed "${lab_root}/run-e2e-trial.sh" 'label=com.docker.swarm.service.name=${shuffle_worker_service}'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'capture_reviewed_shuffle_worker_cleanup_candidate'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'shuffle_worker_cleanup_candidate_spec'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'docker_lab service rm "${shuffle_worker_cleanup_candidate_id}"'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'refusing to remove an unverified worker candidate'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'wait_for_exact_swarm_service_removal'
+reject_fixed "${lab_root}/run-e2e-trial.sh" 'label=com.docker.swarm.service.name=${shuffle_worker_service}'
 require_fixed "${swarm_service_labeler}" 'API_VERSION = "1.40"'
 require_fixed "${swarm_service_labeler}" 'docker", "context", "inspect", context'
 require_fixed "${swarm_service_labeler}" 'host.startswith("unix:///")'
@@ -355,8 +368,10 @@ require_fixed "${lab_root}/run-e2e-trial.sh" 'docker_context="${AEGISOPS_LAB_DOC
 require_fixed "${lab_root}/run-e2e-trial.sh" 'colima_profile="${AEGISOPS_LAB_COLIMA_PROFILE}"'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'final_artifacts=' 
 require_fixed "${lab_root}/run-e2e-trial.sh" 'publication_manifest_published=false'
-require_fixed "${lab_root}/run-e2e-trial.sh" 'publication_manifest_moved=false'
-require_fixed "${lab_root}/run-e2e-trial.sh" 'mv "${final_artifacts}/evidence.json" "${final_evidence}"'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'publication_manifest_staged=false'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'publication_manifest_candidate='
+require_fixed "${lab_root}/run-e2e-trial.sh" 'mv "${evidence_output}" "${publication_manifest_candidate}"'
+require_fixed "${lab_root}/run-e2e-trial.sh" 'ln "${publication_manifest_candidate}" "${final_evidence}"'
 require_fixed \
   "${lab_root}/run-e2e-trial.sh" \
   '--published'
@@ -364,6 +379,94 @@ require_fixed "${lab_root}/run-e2e-trial.sh" '"${final_report}"'
 require_fixed "${lab_root}/run-e2e-trial.sh" '"${final_artifacts}"'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'no passing manifest was published'
 require_fixed "${lab_root}/run-e2e-trial.sh" '"${LAB_DIR}/cleanup.sh"'
+python3 - "${lab_root}/run-e2e-trial.sh" <<'PY'
+from pathlib import Path
+import sys
+
+runner = Path(sys.argv[1]).read_text(encoding="utf-8")
+
+exit_start = runner.index("cleanup_on_exit()")
+exit_end = runner.index("trap cleanup_on_exit EXIT", exit_start)
+exit_cleanup = runner[exit_start:exit_end]
+exit_order = (
+    exit_cleanup.index("capture_reviewed_shuffle_cleanup_candidates"),
+    exit_cleanup.index('"${LAB_DIR}/cleanup.sh"'),
+    exit_cleanup.index("remove_reviewed_shuffle_action_service"),
+    exit_cleanup.index("remove_reviewed_shuffle_worker_service"),
+)
+if tuple(sorted(exit_order)) != exit_order:
+    raise SystemExit("exit cleanup must stop Orborus before exact-ID removal")
+
+restart_down = runner.index(
+    'run_reviewed_lab_command "${LAB_DIR}/down.sh"'
+)
+restart_up = runner.index(
+    'restart_up_output="$(run_reviewed_lab_startup', restart_down
+)
+restart_block = runner[restart_down:restart_up]
+try:
+    restart_remove_action = restart_down + restart_block.index(
+        "run_reviewed_lab_command remove_reviewed_shuffle_action_service"
+    )
+    restart_remove_worker = restart_down + restart_block.index(
+        "run_reviewed_lab_command remove_reviewed_shuffle_worker_service"
+    )
+    restart_reclaim_worker = runner.index(
+        "capture_reviewed_shuffle_worker_image >/dev/null",
+        restart_up,
+    )
+    restart_reclaim_action = runner.index(
+        "run_reviewed_lab_command ensure_reviewed_shuffle_action_service",
+        restart_reclaim_worker,
+    )
+except ValueError as exc:
+    raise SystemExit(
+        "restart must stop, remove exact IDs, start, and re-claim in order"
+    ) from exc
+restart_order = (
+    restart_down,
+    restart_remove_action,
+    restart_remove_worker,
+    restart_up,
+    restart_reclaim_worker,
+    restart_reclaim_action,
+)
+if tuple(sorted(restart_order)) != restart_order:
+    raise SystemExit(
+        "restart must stop, remove exact IDs, start, and re-claim in order"
+    )
+
+final_compose_cleanup = runner.rindex(
+    'run_reviewed_lab_command "${LAB_DIR}/cleanup.sh"'
+)
+final_action_cleanup = runner.rindex(
+    "run_reviewed_lab_command remove_reviewed_shuffle_action_service"
+)
+final_worker_cleanup = runner.rindex(
+    "run_reviewed_lab_command remove_reviewed_shuffle_worker_service"
+)
+if not final_compose_cleanup < final_action_cleanup < final_worker_cleanup:
+    raise SystemExit("final cleanup must stop Orborus before exact-ID removal")
+
+manifest_candidate_move = runner.index(
+    'mv "${evidence_output}" "${publication_manifest_candidate}"'
+)
+published_validation = runner.index("--published", manifest_candidate_move)
+manifest_commit = runner.index(
+    'ln "${publication_manifest_candidate}" "${final_evidence}"',
+    manifest_candidate_move,
+)
+manifest_published = runner.index(
+    "publication_manifest_published=true", manifest_commit
+)
+if not (
+    manifest_candidate_move
+    < published_validation
+    < manifest_commit
+    < manifest_published
+):
+    raise SystemExit("manifest must be validated before its atomic publication")
+PY
 require_fixed "${lab_root}/run-e2e-trial.sh" 'assert_repository_snapshot'
 require_fixed "${lab_root}/run-e2e-trial.sh" 'status --porcelain=v1 --untracked-files=all'
 require_fixed "${lab_root}/RUNBOOK.md" 'all worker task'


### PR DESCRIPTION
## Summary

- wait for stable Orborus-created worker and action services instead of racing creation or manually creating the action service
- verify exact service IDs, non-label specs, callback/network/port contracts, and running task image IDs before and after ownership claims
- stop Compose/Orborus before removing only captured exact service IDs, and repeat worker/action claims across restart verification
- validate a hidden evidence-manifest candidate against the published report and artifacts before exposing the canonical manifest as the final atomic commit point
- add focused lifecycle tests, verifier guards, adversarial mutations, and matching runbook documentation

## Root cause

The merged Phase 67.4 runner assumed the worker task was immediately ready, raced Orborus's later network-spec update, and manually created `shuffle-tools_1-2-0` with a fixed port even though Shuffle 2.2.1 auto-deploys that service. Cleanup also removed Swarm services while Orborus was still running, allowing them to be recreated and orphaned.

## Validation

- `python3 -m unittest discover -s control-plane/tests` — 1601 tests passed
- `python3 -m unittest control-plane/tests/test_phase67_4_real_service_e2e.py` — 66 tests passed
- `bash scripts/verify-phase-67-4-real-service-e2e.sh`
- `bash scripts/test-verify-phase-67-4-real-service-e2e.sh`
- Bash syntax, Python compile, and `git diff --check`

## Trial status and boundary

This is a blocker repair found while executing #1418; it does not complete or close #1418 or #1414. After review and merge, the full real-service trial must be rerun from the then-current `main`, with a distinct human approving the macOS dialog. Any passing prerequisite evidence must retain `ga_accepted=false`.